### PR TITLE
Added prepare service

### DIFF
--- a/package/suse_migration_services_spec_template
+++ b/package/suse_migration_services_spec_template
@@ -52,6 +52,9 @@ install -D -m 644 systemd/suse-migration-mount-system.service \
 install -D -m 644 systemd/suse-migration-setup-host-network.service \
     %{buildroot}%{_unitdir}/suse-migration-setup-host-network.service
 
+install -D -m 644 systemd/suse-migration-prepare.service \
+    %{buildroot}%{_unitdir}/suse-migration-prepare.service
+
 %files
 %defattr(-,root,root,-)
 %{python3_sitelib}/*
@@ -61,5 +64,8 @@ install -D -m 644 systemd/suse-migration-setup-host-network.service \
 
 %{_bindir}/suse-migration-setup-host-network
 %{_unitdir}//suse-migration-setup-host-network.service
+
+%{_bindir}/suse-migration-prepare
+%{_unitdir}//suse-migration-prepare.service
 
 %changelog

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,9 @@ config = {
     'packages': ['suse_migration_services'],
     'entry_points': {
         'console_scripts': [
-            'suse-migration-mount-system=suse_migration_services.units.mount_system:main'
-            'suse-migration-setup-host-network=suse_migration_services.units.setup_host_network:main'
+            'suse-migration-mount-system=suse_migration_services.units.mount_system:main',
+            'suse-migration-setup-host-network=suse_migration_services.units.setup_host_network:main',
+            'suse-migration-prepare=suse_migration_services.units.prepare:main'
         ]
     },
     'include_package_data': True,

--- a/suse_migration_services/exceptions.py
+++ b/suse_migration_services/exceptions.py
@@ -73,3 +73,17 @@ class DistMigrationHostNetworkException(DistMigrationException):
     Exception raised if the activation of the migration host network
     failed for the reason reported by either mount or systemctl
     """
+
+
+class DistMigrationSUSEConnectException(DistMigrationException):
+    """
+    Exception raised if the migration host system does not provide
+    an /etc/SUSEConnect file
+    """
+
+
+class DistMigrationZypperMetaDataException(DistMigrationException):
+    """
+    Exception raised if the bind mount import of the migration
+    host /etc/zypp location failed
+    """

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2018 SUSE Linux LLC.  All rights reserved.
+#
+# This file is part of suse-migration-services.
+#
+# suse-migration-services is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# suse-migration-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
+#
+import os
+import shutil
+
+# project
+from suse_migration_services.command import Command
+from suse_migration_services.defaults import Defaults
+
+from suse_migration_services.exceptions import (
+    DistMigrationSUSEConnectException,
+    DistMigrationZypperMetaDataException
+)
+
+
+def main():
+    """
+    DistMigration prepare for migration
+
+    Prepare the migration live system to allow zypper migration to
+    upgrade the system across major distribution versions. The zypper
+    migration process contacts the service that provides the configured
+    repositories on the system being migrated. The service must be one
+    of SUSE's repository services, SCC, RMT, or SMT. This requiers
+    information from the target system. This service makes the necessary
+    information available inside the live system that performs the migration.
+    """
+    root_path = Defaults.get_system_root_path()
+
+    suse_connect_setup = os.sep.join(
+        [root_path, 'etc', 'SUSEConnect']
+    )
+    if not os.path.exists(suse_connect_setup):
+        raise DistMigrationSUSEConnectException(
+            'Could not find {0} on migration host'.format(suse_connect_setup)
+        )
+
+    shutil.copy(
+        suse_connect_setup, '/etc/SUSEConnect'
+    )
+
+    zypp_metadata = os.sep.join(
+        [root_path, 'etc', 'zypp']
+    )
+    try:
+        Command.run(
+            ['mount', '--bind', zypp_metadata, '/etc/zypp']
+        )
+    except Exception as issue:
+        raise DistMigrationZypperMetaDataException(
+            'Preparation of zypper metadata failed with {0}'.format(
+                issue
+            )
+        )

--- a/systemd/suse-migration-prepare.service
+++ b/systemd/suse-migration-prepare.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Prepare For Migration
+After=suse-migration-setup-host-network.service network.target
+Requires=suse-migration-mount-system.service suse-migration-setup-host-network.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/suse-migration-prepare
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/suse-migration-setup-host-network.service
+++ b/systemd/suse-migration-setup-host-network.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Setup Migration Host Network
 After=suse-migration-mount-system.service
+Requires=suse-migration-mount-system.service
 Before=network.target
 
 [Service]

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -1,0 +1,49 @@
+from unittest.mock import (
+    patch, call
+)
+from pytest import raises
+
+from suse_migration_services.units.prepare import main
+from suse_migration_services.exceptions import (
+    DistMigrationSUSEConnectException,
+    DistMigrationZypperMetaDataException
+)
+
+
+class TestSetupPrepare(object):
+    @patch('os.path.exists')
+    def test_main_suseconnect_not_present(self, mock_os_path_exists):
+        mock_os_path_exists.return_value = False
+        with raises(DistMigrationSUSEConnectException):
+            main()
+
+    @patch('suse_migration_services.command.Command.run')
+    @patch('os.path.exists')
+    @patch('shutil.copy')
+    def test_main_raises_on_zypp_bind(
+        self, mock_shutil_copy, mock_os_path_exists, mock_Command_run
+    ):
+        mock_os_path_exists.return_value = True
+        mock_Command_run.side_effect = Exception
+        with raises(DistMigrationZypperMetaDataException):
+            main()
+
+    @patch('suse_migration_services.command.Command.run')
+    @patch('os.path.exists')
+    @patch('shutil.copy')
+    def test_main(
+        self, mock_shutil_copy, mock_os_path_exists, mock_Command_run
+    ):
+        mock_os_path_exists.return_value = True
+        main()
+        mock_shutil_copy.assert_called_once_with(
+            '/system-root/etc/SUSEConnect', '/etc/SUSEConnect'
+        )
+        assert mock_Command_run.call_args_list == [
+            call(
+                [
+                    'mount', '--bind', '/system-root/etc/zypp',
+                    '/etc/zypp'
+                ]
+            )
+        ]


### PR DESCRIPTION
The prepare service runs the preparation tasks for systemd
to perform the migration. This includes the import of the
SUSEConnect configuration from the host as well as the
bind mount of the zypp metadata