### PR TITLE
Added umount service

### DIFF
--- a/package/suse_migration_services_spec_template
+++ b/package/suse_migration_services_spec_template
@@ -59,6 +59,9 @@ install -D -m 644 systemd/suse-migration-prepare.service \
 install -D -m 644 systemd/suse-migration.service \
     %{buildroot}%{_unitdir}/suse-migration.service
 
+install -D -m 644 systemd/suse-migration-umount-system.service \
+    %{buildroot}%{_unitdir}/suse-migration-umount-system.service
+
 %files
 %defattr(-,root,root,-)
 %{python3_sitelib}/*
@@ -74,5 +77,8 @@ install -D -m 644 systemd/suse-migration.service \
 
 %{_bindir}/suse-migration
 %{_unitdir}/suse-migration.service
+
+%{_bindir}/suse-migration-umount-system
+%{_unitdir}/suse-migration-umount-system.service
 
 %changelog

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ config = {
     'entry_points': {
         'console_scripts': [
             'suse-migration-mount-system=suse_migration_services.units.mount_system:main',
+            'suse-migration-umount-system=suse_migration_services.units.umount_system:main',
             'suse-migration-setup-host-network=suse_migration_services.units.setup_host_network:main',
             'suse-migration-prepare=suse_migration_services.units.prepare:main',
             'suse-migration=suse_migration_services.units.migrate:main'

--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -30,3 +30,7 @@ class Defaults(object):
     @classmethod
     def get_migration_config_file(self):
         return '/etc/migration-config.yml'
+
+    @classmethod
+    def get_system_mount_info_file(self):
+        return '/etc/system-root.fstab'

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -20,6 +20,7 @@ import shutil
 
 # project
 from suse_migration_services.command import Command
+from suse_migration_services.fstab import Fstab
 from suse_migration_services.defaults import Defaults
 
 from suse_migration_services.exceptions import (
@@ -53,8 +54,18 @@ def main():
         [root_path, 'etc', 'zypp']
     )
     try:
+        system_mount = Fstab()
+        system_mount.read(
+            Defaults.get_system_mount_info_file()
+        )
         Command.run(
             ['mount', '--bind', zypp_metadata, '/etc/zypp']
+        )
+        system_mount.add_entry(
+            zypp_metadata, '/etc/zypp'
+        )
+        system_mount.export(
+            Defaults.get_system_mount_info_file()
         )
     except Exception as issue:
         raise DistMigrationZypperMetaDataException(

--- a/suse_migration_services/units/setup_host_network.py
+++ b/suse_migration_services/units/setup_host_network.py
@@ -20,6 +20,7 @@ import shutil
 
 # project
 from suse_migration_services.command import Command
+from suse_migration_services.fstab import Fstab
 from suse_migration_services.defaults import Defaults
 
 from suse_migration_services.exceptions import (
@@ -54,14 +55,24 @@ def main():
         [root_path, 'etc', 'sysconfig', 'network']
     )
     try:
+        system_mount = Fstab()
+        system_mount.read(
+            Defaults.get_system_mount_info_file()
+        )
         Command.run(
             ['mount', '--bind', sysconfig_network, '/etc/sysconfig/network']
+        )
+        system_mount.add_entry(
+            sysconfig_network, '/etc/sysconfig/network'
         )
         Command.run(
             ['systemctl', 'daemon-reload']
         )
         Command.run(
             ['systemctl', 'restart', 'network']
+        )
+        system_mount.export(
+            Defaults.get_system_mount_info_file()
         )
     except Exception as issue:
         raise DistMigrationHostNetworkException(

--- a/suse_migration_services/units/umount_system.py
+++ b/suse_migration_services/units/umount_system.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2018 SUSE Linux LLC.  All rights reserved.
+#
+# This file is part of suse-migration-services.
+#
+# suse-migration-services is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# suse-migration-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
+#
+import os
+
+# project
+from suse_migration_services.command import Command
+from suse_migration_services.defaults import Defaults
+from suse_migration_services.fstab import Fstab
+
+
+def main():
+    """
+    DistMigration umount upgraded system
+
+    Reverse umount the filesystems mounted by the mount_system
+    service and thus release the upgraded system from the
+    migration host. If for whatever reason a filesystem is busy
+    and can't be umounted, this condition is not handled as an
+    error. The reason is that the cleanup should not prevent us
+    from continuing with the migration process. The risk on
+    reboot of the migration host with a potential active mount
+    is something we take into account intentionally
+    """
+    root_path = Defaults.get_system_root_path()
+
+    for shared_location in ['/etc/sysconfig/network', '/etc/zypp']:
+        Command.run(
+            ['umount', shared_location], raise_on_error=False
+        )
+
+    fstab_file = os.sep.join(
+        [root_path, 'etc', 'fstab']
+    )
+    if os.path.exists(fstab_file):
+        fstab = Fstab(fstab_file)
+        for fstab_entry in reversed(fstab.get_devices()):
+            if fstab_entry.mountpoint != 'swap':
+                mountpoint = ''.join(
+                    [root_path, fstab_entry.mountpoint]
+                )
+                Command.run(
+                    ['umount', mountpoint], raise_on_error=False
+                )

--- a/suse_migration_services/units/umount_system.py
+++ b/suse_migration_services/units/umount_system.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
-import os
-
 # project
 from suse_migration_services.command import Command
 from suse_migration_services.defaults import Defaults
@@ -36,23 +34,11 @@ def main():
     reboot of the migration host with a potential active mount
     is something we take into account intentionally
     """
-    root_path = Defaults.get_system_root_path()
-
-    for shared_location in ['/etc/sysconfig/network', '/etc/zypp']:
-        Command.run(
-            ['umount', shared_location], raise_on_error=False
-        )
-
-    fstab_file = os.sep.join(
-        [root_path, 'etc', 'fstab']
+    system_mount = Fstab()
+    system_mount.read(
+        Defaults.get_system_mount_info_file()
     )
-    if os.path.exists(fstab_file):
-        fstab = Fstab(fstab_file)
-        for fstab_entry in reversed(fstab.get_devices()):
-            if fstab_entry.mountpoint != 'swap':
-                mountpoint = ''.join(
-                    [root_path, fstab_entry.mountpoint]
-                )
-                Command.run(
-                    ['umount', mountpoint], raise_on_error=False
-                )
+    for mount in reversed(system_mount.get_devices()):
+        Command.run(
+            ['umount', mount.mountpoint], raise_on_error=False
+        )

--- a/systemd/suse-migration-umount-system.service
+++ b/systemd/suse-migration-umount-system.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Umount Upgraded System
-After=suse-migration.service
-Requires=suse-migration.service
+After=suse-migration-grub-setup.service
+Requires=suse-migration-grub-setup.service
 
 [Service]
 Type=oneshot

--- a/systemd/suse-migration-umount-system.service
+++ b/systemd/suse-migration-umount-system.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Umount Upgraded System
+After=suse-migration.service
+Requires=suse-migration.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/suse-migration-umount-system
+
+[Install]
+WantedBy=multi-user.target

--- a/test/data/system-root.fstab
+++ b/test/data/system-root.fstab
@@ -1,0 +1,6 @@
+/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2 /system-root/ ext4 defaults 0 0
+/dev/disk/by-uuid/FCF7-B051 /system-root/boot/efi vfat defaults 0 0
+/dev/disk/by-label/foo /system-root/home          ext4 defaults 0 0
+/dev/mynode /system-root/foo                      ext4 defaults 0 0
+/system-root/etc/zypp /etc/zypp none defaults 0 0
+/system-root/etc/sysconfig/network /etc/sysconfig/network none defaults 0 0

--- a/test/unit/fstab_test.py
+++ b/test/unit/fstab_test.py
@@ -1,40 +1,65 @@
-from collections import namedtuple
-
+import io
+from unittest.mock import (
+    MagicMock, patch, call
+)
 from suse_migration_services.fstab import Fstab
 
 
 class TestFstab(object):
     def setup(self):
-        self.fstab = Fstab('../data/fstab')
+        self.fstab = Fstab()
+        self.fstab.read('../data/fstab')
 
     def test_get_devices(self):
-        fstab_entry_type = namedtuple(
-            'fstab_entry_type', ['mountpoint', 'device', 'options']
-        )
         assert self.fstab.get_devices() == [
-            fstab_entry_type(
+            self.fstab.fstab_entry_type(
+                fstype='ext4',
                 mountpoint='/',
                 device='/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2',
                 options='acl,user_xattr'
             ),
-            fstab_entry_type(
-                mountpoint='swap',
-                device='/dev/disk/by-uuid/daa5a8c3-5c72-4343-a1d4-bb74ec4e586e',
-                options='defaults'
-            ),
-            fstab_entry_type(
+            self.fstab.fstab_entry_type(
+                fstype='vfat',
                 mountpoint='/boot/efi',
                 device='/dev/disk/by-uuid/FCF7-B051',
                 options='defaults'
             ),
-            fstab_entry_type(
+            self.fstab.fstab_entry_type(
+                fstype='ext4',
                 mountpoint='/home',
                 device='/dev/disk/by-label/foo',
                 options='defaults'
             ),
-            fstab_entry_type(
+            self.fstab.fstab_entry_type(
+                fstype='ext4',
                 mountpoint='/foo',
                 device='/dev/mynode',
                 options='defaults'
             )
         ]
+
+    def test_add_entry(self):
+        fstab = Fstab()
+        fstab.add_entry('/dev/sda', '/foo')
+        assert fstab.get_devices() == [
+            fstab.fstab_entry_type(
+                fstype='none',
+                mountpoint='/foo',
+                device='/dev/sda',
+                options='defaults'
+            )
+        ]
+
+    def test_export(self):
+        fstab = Fstab()
+        fstab.add_entry('/dev/sda', '/foo')
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            fstab.export('filename')
+            file_handle = mock_open.return_value.__enter__.return_value
+            mock_open.assert_called_once_with(
+                'filename', 'w'
+            )
+            assert file_handle.write.call_args_list == [
+                call('/dev/sda /foo none defaults 0 0')
+            ]

--- a/test/unit/units/umount_system_test.py
+++ b/test/unit/units/umount_system_test.py
@@ -1,5 +1,5 @@
 from unittest.mock import (
-    patch, call
+    patch, call, Mock
 )
 
 from suse_migration_services.units.umount_system import main
@@ -13,8 +13,12 @@ class TestUMountSystem(object):
     def test_main(
         self, mock_os_path_exists, mock_Fstab, mock_Command_run
     ):
+        fstab = Fstab()
+        fstab_mock = Mock()
+        fstab_mock.read.return_value = fstab.read('../data/system-root.fstab')
+        fstab_mock.get_devices.return_value = fstab.get_devices()
+        mock_Fstab.return_value = fstab_mock
         mock_os_path_exists.return_value = True
-        mock_Fstab.return_value = Fstab('../data/fstab')
         main()
         assert mock_Command_run.call_args_list == [
             call(['umount', '/etc/sysconfig/network'], raise_on_error=False),

--- a/test/unit/units/umount_system_test.py
+++ b/test/unit/units/umount_system_test.py
@@ -1,0 +1,26 @@
+from unittest.mock import (
+    patch, call
+)
+
+from suse_migration_services.units.umount_system import main
+from suse_migration_services.fstab import Fstab
+
+
+class TestUMountSystem(object):
+    @patch('suse_migration_services.command.Command.run')
+    @patch('suse_migration_services.units.umount_system.Fstab')
+    @patch('os.path.exists')
+    def test_main(
+        self, mock_os_path_exists, mock_Fstab, mock_Command_run
+    ):
+        mock_os_path_exists.return_value = True
+        mock_Fstab.return_value = Fstab('../data/fstab')
+        main()
+        assert mock_Command_run.call_args_list == [
+            call(['umount', '/etc/sysconfig/network'], raise_on_error=False),
+            call(['umount', '/etc/zypp'], raise_on_error=False),
+            call(['umount', '/system-root/foo'], raise_on_error=False),
+            call(['umount', '/system-root/home'], raise_on_error=False),
+            call(['umount', '/system-root/boot/efi'], raise_on_error=False),
+            call(['umount', '/system-root/'], raise_on_error=False)
+        ]


### PR DESCRIPTION
The umount service cleans up the migration host such that
no active mount reference into the migrated systems exists
anymore and we are safe to reboot