### PR TITLE
Loopback boot activation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@
 graft suse_migration_services/units
 graft package
 graft systemd
+graft grub.d
 
 include tox.ini
 include README.md

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,16 @@ build: check test
 	mv setup.pye setup.py
 	# provide rpm source tarball
 	mv dist/suse_migration_services-${version}.tar.gz \
-		dist/suse_migration_services.tar.gz
+		dist/suse-migration-services.tar.gz
 	# provide rpm changelog from git changelog
 	git log | helper/changelog_generator |\
-		helper/changelog_descending > dist/suse_migration_services.changes
+		helper/changelog_descending > dist/suse-migration-services.changes
 	# update package version in spec file
-	cat package/suse_migration_services_spec_template \
+	cat package/suse-migration-services-spec-template \
 		| sed -e s'@%%VERSION@${version}@' \
-		> dist/suse_migration_services.spec
+		> dist/suse-migration-services.spec
+	# provide rpm rpmlintrc
+	cp package/suse-migration-services-rpmlintrc dist
 
 .PHONY: test
 test:

--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -1,0 +1,33 @@
+# SUSE Migration activation menu entry
+
+. /usr/share/grub2/grub-mkconfig_lib
+
+CLASS="--class memtest86 --class gnu --class tools"
+
+if [ -z "${GRUB_DISTRIBUTOR}" ] ; then
+    OS=Migration
+else
+    OS="${GRUB_DISTRIBUTOR} Migration"
+    CLASS="--class $(
+        echo "${GRUB_DISTRIBUTOR}" | tr '[:upper:]' '[:lower:]' | cut -d' ' -f1
+    ) ${CLASS}"
+fi
+
+migration_iso=$(echo /usr/share/migration-image/*-Migration.*.iso)
+
+if grub_file_is_not_garbage "${migration_iso}"; then
+    kernel="(loop)/boot/x86_64/loader/linux"
+    initrd="(loop)/boot/x86_64/loader/initrd"
+    boot_device_id="$(grub_get_device_id "${GRUB_DEVICE_BOOT}")"
+    boot_options="rd.live.image root=live:CDLABEL=CDROM"
+    printf "menuentry '%s' %s \${menuentry_id_option} '%s' {\n" \
+        "${OS}" "${CLASS}" "Migration-${boot_device_id}"
+    printf "    set isofile='%s'\n" \
+        "${migration_iso}"
+    printf "    loopback loop (\$root)\$isofile\n"
+    printf "    linux %s iso-scan/filename=\$isofile %s\n" \
+        "${kernel}" "${boot_options}"
+    printf "    initrd %s\n" \
+        "${initrd}"
+    printf "}\n"
+fi

--- a/package/suse-migration-services-rpmlintrc
+++ b/package/suse-migration-services-rpmlintrc
@@ -1,0 +1,16 @@
+# While the package provides services all services are one-shot.
+# Additionally this services runs as part of a live ISO migration
+# system which is used and booted only once. It's contents are
+# packed into a readonly squashfs layer. Therefore there is no
+# need for use of the "standard" systemd service handling macros.
+addFilter("systemd-service-without-service_add_pre .*")
+addFilter("systemd-service-without-service_add_post .*")
+addFilter("systemd-service-without-service_del_postun .*")
+addFilter("systemd-service-without-service_del_preun .*")
+
+# Migration services runs once and never manually
+addFilter("suse-missing-rclink .*")
+
+# etc/grub.d plugins are called in the scope of grub2-mkconfig
+# None of them has a shebang because never called standalone
+addFilter("script-without-shebang .*")

--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -20,10 +20,10 @@ Name:             suse-migration-services
 Version:          %%VERSION
 Release:          0
 Url:              https://github.com/SUSE/suse-migration-services
-Summary:          suse-migration-services - SUSE Distribution Migration Services
+Summary:          SUSE Distribution Migration Services
 License:          GPL-3.0+
 Group:            System/Management
-Source:           suse_migration_services.tar.gz
+Source:           suse-migration-services.tar.gz
 BuildRoot:        %{_tmppath}/%{name}-%{version}-build
 BuildRequires:    python3-devel
 BuildRequires:    python3-setuptools
@@ -37,6 +37,16 @@ BuildArch:        noarch
 
 %description
 Systemd services to prepare and run a distribution migration process.
+
+%package -n suse-migration-activation
+Summary:        LoopBack Grub Activation
+License:        GPL-3.0+
+Group:          System/Management
+
+%description -n suse-migration-activation
+Script code to activate the migration image to be booted at next
+reboot of the machine. The script provided here is typically used
+as post script of the package provding the migration image
 
 %prep
 %setup -q -n suse_migration_services-%{version}
@@ -65,6 +75,16 @@ install -D -m 644 systemd/suse-migration-umount-system.service \
 install -D -m 644 systemd/suse-migration-grub-setup.service \
     %{buildroot}%{_unitdir}/suse-migration-grub-setup.service
 
+install -D -m 755 grub.d/99_migration \
+    %{buildroot}/etc/grub.d/99_migration
+
+# preun / postun
+# While the package provides services all services are one-shot.
+# Additionally this services runs as part of a live ISO migration
+# system which is used and booted only once. It's contents are
+# packed into a readonly squashfs layer. Therefore there is no
+# need for use of the "standard" systemd service handling macros.
+
 %files
 %defattr(-,root,root,-)
 %{python3_sitelib}/*
@@ -86,5 +106,10 @@ install -D -m 644 systemd/suse-migration-grub-setup.service \
 
 %{_bindir}/suse-migration-grub-setup
 %{_unitdir}/suse-migration-grub-setup.service
+
+%files -n suse-migration-activation
+%defattr(-,root,root,-)
+%dir /etc/grub.d
+/etc/grub.d/*
 
 %changelog

--- a/tox.ini
+++ b/tox.ini
@@ -48,3 +48,4 @@ usedevelop = True
 commands =
     flake8 --statistics -j auto --count {toxinidir}/suse_migration_services
     flake8 --statistics -j auto --count {toxinidir}/test/unit
+    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117 {toxinidir}/grub.d/* -s bash'


### PR DESCRIPTION
__Added grub config extension to activate migration__
    
Provide /etc/grub.d/99_migration plugin which causes the creation of a Migration grub menu entry. In addition the package build was cleaned up and extended by a new sub-package suse-migration-activation which provides  that grub config plugin.

During testing of the loopback mount I found a "busy lock" problem which only exists on that boot scenario. As consequence this pull request also contains a commit to fix this part

__Notes:__
On merge of this change follow up changes to the package build which contains the live ISO migration image are needed. Those changes will be:

* Requires: suse-migration-activation
* A %post script which calls ```grub2-mkconfig```

If this is done the package with the migration ISO image will activate itself in a grub menu on install of 
the package. In my testing I could not yet came across a solution to make this entry the default boot 
entry. So at the moment the customer would need to select it from the menu which if course is not 
acceptable if we do that in the cloud.

* Also found by testing is the fact that we need to uninstall suse-migration-activation and recall ```grub2- 
  mkconfig``` to rollback the grub menu changes done when the migration system was activated.
  I suggest to do this as part of the grub update service in the suse-migration-services project

Thus there will be follow up changes/discussion to complete the processing here

Please take that into consideration on review

Thanks