### PR TITLE
Uninstall suse-migration-activation

### DIFF
--- a/suse_migration_services/units/grub_setup.py
+++ b/suse_migration_services/units/grub_setup.py
@@ -50,6 +50,11 @@ def main():
         system_mount.read(
             Defaults.get_system_mount_info_file()
         )
+        # uninstall suse-migration-activation so new grub
+        # menu does not have the migration entry
+        Command.run(
+            ['rpm', '-e', 'suse-migration-activation']
+        )
         Command.run(
             ['mount', '--bind', '/dev', dev_mount_point]
         )

--- a/test/unit/units/grub_setup_test.py
+++ b/test/unit/units/grub_setup_test.py
@@ -44,6 +44,11 @@ class TestSetupHostNetwork(object):
         assert mock_Command_run.call_args_list == [
             call(
                 [
+                    'rpm', '-e', 'suse-migration-activation'
+                ]
+            ),
+            call(
+                [
                     'mount', '--bind', '/dev',
                     '/system-root/dev'
                 ]


### PR DESCRIPTION
This is done when the migration is completed. 
The new grub menu should not have this entry.
This solves issue #12