### PR TITLE
Fixed kexec reboot kernel and grub lookup

### DIFF
--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -37,12 +37,12 @@ class Defaults(object):
 
     @classmethod
     def get_grub_config_file(self):
-        return '/boot/grub2/grub.cfg'
+        return 'boot/grub2/grub.cfg'
 
     @classmethod
     def get_target_kernel(self):
-        return '/boot/vmlinuz'
+        return 'boot/vmlinuz'
 
     @classmethod
     def get_target_initrd(self):
-        return '/boot/initrd'
+        return 'boot/initrd'

--- a/suse_migration_services/units/grub_setup.py
+++ b/suse_migration_services/units/grub_setup.py
@@ -76,8 +76,8 @@ def main():
         )
         Command.run(
             [
-                'chroot', root_path,
-                'grub2-mkconfig', '-o', grub_config_file
+                'chroot', root_path, 'grub2-mkconfig', '-o',
+                '{0}{1}'.format(os.sep, grub_config_file)
             ]
         )
         system_mount.export(

--- a/suse_migration_services/units/kernel_reboot.py
+++ b/suse_migration_services/units/kernel_reboot.py
@@ -34,6 +34,8 @@ def main():
     Reads the info of the new kernel and loads the latest (new migrated kernel)
     version for rebooting.
     """
+    root_path = Defaults.get_system_root_path()
+
     target_kernel = Defaults.get_target_kernel()
     target_initrd = Defaults.get_target_initrd()
     try:
@@ -43,8 +45,8 @@ def main():
         Command.run(
             [
                 'kexec',
-                '--load', target_kernel,
-                '--initrd', target_initrd,
+                '--load', os.sep.join([root_path, target_kernel]),
+                '--initrd', os.sep.join([root_path, target_initrd]),
                 '--command-line', _get_cmdline(target_kernel)
             ]
         )
@@ -63,14 +65,16 @@ def main():
 
 
 def _get_cmdline(kernel_name):
-    grub_config_file_path = Defaults.get_grub_config_file()
+    grub_config_file_path = os.sep.join(
+        [Defaults.get_system_root_path(), Defaults.get_grub_config_file()]
+    )
     if not os.path.exists(grub_config_file_path):
         raise DistMigrationKernelRebootException(
             'Could not find {0} to load the kernel options'.format(
                 grub_config_file_path
             )
         )
-    pattern = r'(?<=linux)[ \t]+{}.*'.format(kernel_name)
+    pattern = r'(?<=linux)[ \t]+{0}{1}.*'.format(os.sep, kernel_name)
     with open(grub_config_file_path) as grub_config_file:
         grub_content = grub_config_file.read()
     cmd_line = re.findall(pattern, grub_content)[0]


### PR DESCRIPTION
In the reboot service the kernel files and the grub config
was not searched in the root of the migrated system but in
the root of the migration live system, which is the wrong
place.