### PR TITLE
Fixed removal of suse-migration-activation

### DIFF
--- a/suse_migration_services/units/grub_setup.py
+++ b/suse_migration_services/units/grub_setup.py
@@ -53,8 +53,11 @@ def main():
         # uninstall suse-migration-activation so new grub
         # menu does not have the migration entry
         Command.run(
-            ['chroot', root_path,
-             'rpm', '-e', 'suse-migration-activation']
+            [
+                'chroot', root_path,
+                'zypper', '--non-interactive', '--no-gpg-checks',
+                'remove', '-u', 'suse-migration-activation'
+            ], raise_on_error=False
         )
         Command.run(
             ['mount', '--bind', '/dev', dev_mount_point]

--- a/test/unit/units/grub_setup_test.py
+++ b/test/unit/units/grub_setup_test.py
@@ -45,8 +45,9 @@ class TestSetupHostNetwork(object):
             call(
                 [
                     'chroot', '/system-root',
-                    'rpm', '-e', 'suse-migration-activation'
-                ]
+                    'zypper', '--non-interactive', '--no-gpg-checks',
+                    'remove', '-u', 'suse-migration-activation'
+                ], raise_on_error=False
             ),
             call(
                 [


### PR DESCRIPTION
A simple rpm -e call leads to an error because the package
depends on the master package providing the image. Thus it's
better to instruct zypper to remove the package including its
dependencies