### PR TITLE
Added zypper migration console logging

### DIFF
--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -32,6 +32,7 @@ Requires:         python3-PyYAML
 Requires:         python3-setuptools
 Requires:         util-linux
 Requires:         kexec-tools
+Requires:         dialog
 Requires(preun):  systemd
 Requires(postun): systemd
 BuildArch:        noarch

--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -85,6 +85,9 @@ install -D -m 644 systemd/suse-migration-reboot.service \
 install -D -m 644 systemd/suse-migration-ssh-keys.service \
     %{buildroot}%{_unitdir}/suse-migration-ssh-keys.service
 
+install -D -m 644 systemd/suse-migration-console-log.service \
+    %{buildroot}%{_unitdir}/suse-migration-console-log.service
+
 install -D -m 755 grub.d/99_migration \
     %{buildroot}/etc/grub.d/99_migration
 
@@ -113,6 +116,7 @@ install -D -m 755 grub.d/99_migration \
 
 %{_bindir}/suse-migration
 %{_unitdir}/suse-migration.service
+%{_unitdir}/suse-migration-console-log.service
 
 %{_bindir}/suse-migration-umount-system
 %{_unitdir}/suse-migration-umount-system.service

--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -33,6 +33,12 @@ class Defaults(object):
         return '/etc/migration-config.yml'
 
     @classmethod
+    def get_migration_log_file(self):
+        return os.sep.join(
+            [self.get_system_root_path(), 'var/log/zypper_migrate.log']
+        )
+
+    @classmethod
     def get_system_mount_info_file(self):
         return '/etc/system-root.fstab'
 
@@ -60,4 +66,6 @@ class Defaults(object):
         return '/home/migration/.ssh/authorized_keys'
 
     def _get_ssh_keys_path(self, prefix_path):
-        return os.sep.join([self.get_system_root_path(), prefix_path, '.ssh/authorized_keys'])
+        return os.sep.join(
+            [self.get_system_root_path(), prefix_path, '.ssh/authorized_keys']
+        )

--- a/suse_migration_services/exceptions.py
+++ b/suse_migration_services/exceptions.py
@@ -98,3 +98,10 @@ class DistMigrationKernelRebootException(DistMigrationException):
     """
     Exception raised if the kernel reboot call has failed
     """
+
+
+class DistMigrationLoggingException(DistMigrationException):
+    """
+    Exception raised if the initial creation of the log file to
+    store the zypper migration plugin output has failed
+    """

--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -30,12 +30,13 @@ def main():
     """
     DistMigration run zypper based migration
 
-    Call zypper migration plugin and migrate the system
+    Call zypper migration plugin and migrate the system.
+    The output of the call is logged on the system to migrate
     """
     root_path = Defaults.get_system_root_path()
 
     try:
-        Command.run(
+        bash_command = ' '.join(
             [
                 'zypper', 'migration',
                 '--non-interactive',
@@ -43,8 +44,12 @@ def main():
                 '--no-selfupdate',
                 '--auto-agree-with-licenses',
                 '--product', get_migration_product(),
-                '--root', root_path
+                '--root', root_path,
+                '&>', Defaults.get_migration_log_file()
             ]
+        )
+        Command.run(
+            ['bash', '-c', bash_command]
         )
     except Exception as issue:
         raise DistMigrationZypperException(

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -24,7 +24,8 @@ from suse_migration_services.fstab import Fstab
 from suse_migration_services.defaults import Defaults
 
 from suse_migration_services.exceptions import (
-    DistMigrationZypperMetaDataException
+    DistMigrationZypperMetaDataException,
+    DistMigrationLoggingException
 )
 
 
@@ -70,6 +71,16 @@ def main():
     except Exception as issue:
         raise DistMigrationZypperMetaDataException(
             'Preparation of zypper metadata failed with {0}'.format(
+                issue
+            )
+        )
+
+    try:
+        with open(Defaults.get_migration_log_file(), 'w'):
+            pass
+    except Exception as issue:
+        raise DistMigrationLoggingException(
+            'Migration log file init failed with {0}'.format(
                 issue
             )
         )

--- a/systemd/suse-migration-console-log.service
+++ b/systemd/suse-migration-console-log.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Show Migration Progress
+ConditionPathExists=/system-root/var/log/zypper_migrate.log
+DefaultDependencies=no
+After=systemd-vconsole-setup.service suse-migration-prepare.service
+Requires=suse-migration-prepare.service
+Wants=systemd-vconsole-setup.service
+Conflicts=emergency.service emergency.target
+
+[Service]
+ExecStart=dialog --tailbox /system-root/var/log/zypper_migrate.log 60 75
+Type=oneshot
+StandardInput=tty-force
+StandardOutput=inherit
+StandardError=inherit
+KillMode=process
+IgnoreSIGPIPE=no
+KillSignal=SIGHUP

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -23,12 +23,14 @@ class TestMigration(object):
         main()
         mock_Command_run.assert_called_once_with(
             [
-                'zypper', 'migration',
-                '--non-interactive',
-                '--gpg-auto-import-keys',
-                '--no-selfupdate',
-                '--auto-agree-with-licenses',
-                '--product', 'foo',
-                '--root', '/system-root'
+                'bash', '-c',
+                'zypper migration '
+                '--non-interactive '
+                '--gpg-auto-import-keys '
+                '--no-selfupdate '
+                '--auto-agree-with-licenses '
+                '--product foo '
+                '--root /system-root '
+                '&> /system-root/var/log/zypper_migrate.log'
             ]
         )

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -1,11 +1,13 @@
+import io
 from unittest.mock import (
-    patch, call, Mock
+    patch, call, Mock, MagicMock
 )
 from pytest import raises
 
 from suse_migration_services.units.prepare import main
 from suse_migration_services.exceptions import (
-    DistMigrationZypperMetaDataException
+    DistMigrationZypperMetaDataException,
+    DistMigrationLoggingException
 )
 
 
@@ -27,6 +29,20 @@ class TestSetupPrepare(object):
     @patch('suse_migration_services.units.prepare.Fstab')
     @patch('os.path.exists')
     @patch('shutil.copy')
+    def test_main_raises_on_log_init(
+        self, mock_shutil_copy, mock_os_path_exists,
+        mock_Fstab, mock_Command_run
+    ):
+        mock_os_path_exists.return_value = True
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.side_effect = Exception
+            with raises(DistMigrationLoggingException):
+                main()
+
+    @patch('suse_migration_services.command.Command.run')
+    @patch('suse_migration_services.units.prepare.Fstab')
+    @patch('os.path.exists')
+    @patch('shutil.copy')
     def test_main(
         self, mock_shutil_copy, mock_os_path_exists,
         mock_Fstab, mock_Command_run
@@ -34,24 +50,29 @@ class TestSetupPrepare(object):
         fstab = Mock()
         mock_Fstab.return_value = fstab
         mock_os_path_exists.return_value = True
-        main()
-        mock_shutil_copy.assert_called_once_with(
-            '/system-root/etc/SUSEConnect', '/etc/SUSEConnect'
-        )
-        assert mock_Command_run.call_args_list == [
-            call(
-                [
-                    'mount', '--bind', '/system-root/etc/zypp',
-                    '/etc/zypp'
-                ]
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            main()
+            mock_shutil_copy.assert_called_once_with(
+                '/system-root/etc/SUSEConnect', '/etc/SUSEConnect'
             )
-        ]
-        fstab.read.assert_called_once_with(
-            '/etc/system-root.fstab'
-        )
-        fstab.add_entry.assert_called_once_with(
-            '/system-root/etc/zypp', '/etc/zypp'
-        )
-        fstab.export.assert_called_once_with(
-            '/etc/system-root.fstab'
-        )
+            assert mock_Command_run.call_args_list == [
+                call(
+                    [
+                        'mount', '--bind', '/system-root/etc/zypp',
+                        '/etc/zypp'
+                    ]
+                )
+            ]
+            fstab.read.assert_called_once_with(
+                '/etc/system-root.fstab'
+            )
+            fstab.add_entry.assert_called_once_with(
+                '/system-root/etc/zypp', '/etc/zypp'
+            )
+            fstab.export.assert_called_once_with(
+                '/etc/system-root.fstab'
+            )
+            mock_open.assert_called_once_with(
+                '/system-root/var/log/zypper_migrate.log', 'w'
+            )


### PR DESCRIPTION
If the migration process starts the console should show a
progress information. We use a dialog tailbox which shows
the output of the zypper migration plugin while it runs.
The output is processed using a systemd service connected
to the console. In addition the log file

    var/log/zypper_migrate.log

Is created inside of the system which gets migrated. This
allows for later inspection of what the migration plugin
did. This Fixes #27