### PR TITLE
Fix log file initialization

### DIFF
--- a/suse_migration_services/units/mount_system.py
+++ b/suse_migration_services/units/mount_system.py
@@ -42,7 +42,6 @@ def main():
     """
     root_path = Defaults.get_system_root_path()
     Path.create(root_path)
-    log.set_logfile(Defaults.get_migration_log_file())
     log.info('Running mount system service')
 
     if is_mounted(root_path):

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -85,6 +85,7 @@ def main():
     try:
         with open(Defaults.get_migration_log_file(), 'w'):
             pass
+        log.set_logfile(Defaults.get_migration_log_file())
     except Exception as issue:
         raise DistMigrationLoggingException(
             'Migration log file init failed with {0}'.format(

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -53,10 +53,11 @@ class TestSetupPrepare(object):
     @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.prepare.Fstab')
+    @patch('suse_migration_services.units.prepare.log.set_logfile')
     @patch('os.path.exists')
     @patch('shutil.copy')
     def test_main(
-        self, mock_shutil_copy, mock_os_path_exists,
+        self, mock_shutil_copy, mock_os_path_exists, mock_set_logfile,
         mock_Fstab, mock_Command_run,
         mock_info
     ):
@@ -88,5 +89,8 @@ class TestSetupPrepare(object):
             )
             mock_open.assert_called_once_with(
                 '/system-root/var/log/zypper_migrate.log', 'w'
+            )
+            mock_set_logfile.assert_called_once_with(
+                '/system-root/var/log/zypper_migrate.log'
             )
             assert mock_info.called


### PR DESCRIPTION
We agreed on writing the log file into the root filesystem
of the system to migrate. This implies that the first time
to initialize this log file is in the prepare service
after the mount system service has succeeded. Calling
set_logfile in the mount system service before the system
got mounted is the wrong place. This patch fixes this
and also improves the unit test for this condition.