### PR TITLE
Fixed executable path in console log service

### DIFF
--- a/systemd/suse-migration-console-log.service
+++ b/systemd/suse-migration-console-log.service
@@ -8,7 +8,7 @@ Wants=systemd-vconsole-setup.service
 Conflicts=emergency.service emergency.target
 
 [Service]
-ExecStart=dialog --tailbox /system-root/var/log/zypper_migrate.log 60 75
+ExecStart=/usr/bin/dialog --tailbox /system-root/var/log/zypper_migrate.log 60 75
 Type=oneshot
 StandardInput=tty-force
 StandardOutput=inherit


### PR DESCRIPTION
systemd requires an absolute path to the called program.
This patch fixes the path to the dialog program such
that systemd calls it