### PR TITLE
Don't truncate migration log file

### DIFF
--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -47,7 +47,7 @@ def main():
                 '--auto-agree-with-licenses',
                 '--product', get_migration_product(),
                 '--root', root_path,
-                '&>', Defaults.get_migration_log_file()
+                '&>>', Defaults.get_migration_log_file()
             ]
         )
         Command.run(

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -41,7 +41,7 @@ class TestMigration(object):
                 '--auto-agree-with-licenses '
                 '--product foo '
                 '--root /system-root '
-                '&> /system-root/var/log/zypper_migrate.log'
+                '&>> /system-root/var/log/zypper_migrate.log'
             ]
         )
         assert mock_info.called


### PR DESCRIPTION
If the zypper based migration process runs it truncates the
so far written logfile information. We want to keep all logging
data, thus the zypper call has to append information to the
existing log file and not overwrite them.