### PR TITLE
Update prepare service on hosts file

### DIFF
--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -46,9 +46,16 @@ def main():
     suse_connect_setup = os.sep.join(
         [root_path, 'etc', 'SUSEConnect']
     )
+    hosts_setup = os.sep.join(
+        [root_path, 'etc', 'hosts']
+    )
     if os.path.exists(suse_connect_setup):
         shutil.copy(
             suse_connect_setup, '/etc/SUSEConnect'
+        )
+    if os.path.exists(hosts_setup):
+        shutil.copy(
+            hosts_setup, '/etc/hosts'
         )
 
     zypp_metadata = os.sep.join(

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -94,9 +94,10 @@ class TestSetupPrepare(object):
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)
             main()
-            mock_shutil_copy.assert_called_once_with(
-                '/system-root/etc/SUSEConnect', '/etc/SUSEConnect'
-            )
+            assert mock_shutil_copy.call_args_list == [
+                call('/system-root/etc/SUSEConnect', '/etc/SUSEConnect'),
+                call('/system-root/etc/hosts', '/etc/hosts')
+            ]
             assert mock_Command_run.call_args_list == [
                 call(
                     [


### PR DESCRIPTION
In the cloud the translation from a name into an IP might also
be configured via the static etc/hosts file. In case of SUSE's
public cloud infrastructure the connected smt server is
configured that way at registration time. For the migration
process this means that this information must be present otherwise
the host to upgrade cannot be resolved.