### PR TITLE
Import certificates

### DIFF
--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -32,6 +32,7 @@ Requires:         python3-PyYAML
 Requires:         python3-setuptools
 Requires:         util-linux
 Requires:         kexec-tools
+Requires:         ca-certificates
 Requires:         dialog
 Requires(preun):  systemd
 Requires(postun): systemd

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -49,6 +49,9 @@ def main():
     hosts_setup = os.sep.join(
         [root_path, 'etc', 'hosts']
     )
+    trust_anchors = os.sep.join(
+        [root_path, 'usr', 'share', 'pki', 'trust', 'anchors']
+    )
     if os.path.exists(suse_connect_setup):
         shutil.copy(
             suse_connect_setup, '/etc/SUSEConnect'
@@ -57,6 +60,18 @@ def main():
         shutil.copy(
             hosts_setup, '/etc/hosts'
         )
+    if os.path.exists(trust_anchors):
+        certificates = os.listdir(trust_anchors)
+        if certificates:
+            for cert in certificates:
+                log.info(
+                    'Importing certificate: {0}'.format(cert)
+                )
+                shutil.copy(cert, '/usr/share/pki/trust/anchors/')
+            log.info('Update certificate pool')
+            Command.run(
+                ['update-ca-certificates']
+            )
 
     zypp_metadata = os.sep.join(
         [root_path, 'etc', 'zypp']


### PR DESCRIPTION
Copy certificates from /usr/share/pki/trust/anchors of the
system to become migrated into the live migration system
and update the certificate pool. This Fixes #37