### PR TITLE
Product setup

### DIFF
--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -34,6 +34,7 @@ Requires:         util-linux
 Requires:         kexec-tools
 Requires:         ca-certificates
 Requires:         dialog
+Requires:         rsync
 Requires(preun):  systemd
 Requires(postun): systemd
 BuildArch:        noarch
@@ -77,6 +78,9 @@ install -D -m 644 systemd/suse-migration-umount-system.service \
 
 install -D -m 644 systemd/suse-migration-grub-setup.service \
     %{buildroot}%{_unitdir}/suse-migration-grub-setup.service
+
+install -D -m 644 systemd/suse-migration-product-setup.service \
+    %{buildroot}%{_unitdir}/suse-migration-product-setup.service
 
 install -D -m 644 systemd/suse-migration-kernel-load.service \
     %{buildroot}%{_unitdir}/suse-migration-kernel-load.service
@@ -125,6 +129,9 @@ install -D -m 755 grub.d/99_migration \
 
 %{_bindir}/suse-migration-grub-setup
 %{_unitdir}/suse-migration-grub-setup.service
+
+%{_bindir}/suse-migration-product-setup
+%{_unitdir}/suse-migration-product-setup.service
 
 %{_bindir}/suse-migration-kernel-load
 %{_unitdir}/suse-migration-kernel-load.service

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ config = {
             'suse-migration=suse_migration_services.units.migrate:main',
             'suse-migration-grub-setup=suse_migration_services.units.grub_setup:main',
             'suse-migration-kernel-load=suse_migration_services.units.kernel_load:main',
-            'suse-migration-reboot=suse_migration_services.units.reboot:main'
+            'suse-migration-reboot=suse_migration_services.units.reboot:main',
+            'suse-migration-product-setup=suse_migration_services.units.product_setup:main'
         ]
     },
     'include_package_data': True,

--- a/suse_migration_services/exceptions.py
+++ b/suse_migration_services/exceptions.py
@@ -105,3 +105,11 @@ class DistMigrationLoggingException(DistMigrationException):
     Exception raised if the initial creation of the log file to
     store the zypper migration plugin output has failed
     """
+
+
+class DistMigrationProductSetupException(DistMigrationException):
+    """
+    Exception raised if the syncing of the product information
+    from the bind mounted etc/products.d location into the
+    migrated system has failed
+    """

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -98,6 +98,21 @@ def main():
             Defaults.get_system_mount_info_file()
         )
         log.info('Bind mounting migration system /etc/products.d')
+        # Note:
+        # This bind mount overlays the live migration product
+        # definition with the one present on the system to migrate.
+        # The reason for this is because of zyppers' handling of
+        # the distro_target attribute from the upgrade repositories
+        # metadata. In SMT repositories contains this flag and if
+        # it is present, zypper compares the value with the
+        # baseproduct setup in /etc/products.d. If they mismatch
+        # zypper refuses to create the repo. In the process of
+        # a migration from distribution [A] to [B] this mismatch
+        # always applies by design and prevents the zypper migration
+        # plugin to work. In SCC or RMT the repositories doesn't
+        # contain the distro_target attribute which is the reason
+        # why we don't see this problem there. SMT is still a valid
+        # registration target and cannot be ignored.
         Command.run(
             ['mount', '--bind', '/etc/products.d', products_metadata]
         )

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -76,6 +76,9 @@ def main():
                 ['update-ca-certificates']
             )
 
+    products_metadata = os.sep.join(
+        [root_path, 'etc', 'products.d']
+    )
     zypp_metadata = os.sep.join(
         [root_path, 'etc', 'zypp']
     )
@@ -93,6 +96,13 @@ def main():
         system_mount = Fstab()
         system_mount.read(
             Defaults.get_system_mount_info_file()
+        )
+        log.info('Bind mounting migration system /etc/products.d')
+        Command.run(
+            ['mount', '--bind', '/etc/products.d', products_metadata]
+        )
+        system_mount.add_entry(
+            '/etc/products.d', products_metadata
         )
         log.info('Bind mounting /etc/zypp')
         Command.run(

--- a/suse_migration_services/units/product_setup.py
+++ b/suse_migration_services/units/product_setup.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2018 SUSE Linux LLC.  All rights reserved.
+#
+# This file is part of suse-migration-services.
+#
+# suse-migration-services is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# suse-migration-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
+#
+import os
+
+# project
+from suse_migration_services.command import Command
+from suse_migration_services.defaults import Defaults
+from suse_migration_services.logger import log
+
+from suse_migration_services.exceptions import (
+    DistMigrationProductSetupException
+)
+
+
+def main():
+    """
+    DistMigration setup product
+
+    Synchronize bind mounted etc/products.d data into the migrated system
+    """
+    root_path = Defaults.get_system_root_path()
+
+    try:
+        products_metadata = os.sep.join(
+            [root_path, 'etc', 'products.d']
+        )
+        log.info('Umounting {0}'.format(products_metadata))
+        Command.run(
+            ['umount', products_metadata]
+        )
+        log.info('Syncing product data to migrated system')
+        Command.run(
+            [
+                'rsync', '-zav', '--delete', '/etc/products.d/',
+                products_metadata + os.sep
+            ]
+        )
+    except Exception as issue:
+        message = 'Product setup failed with {0}'.format(issue)
+        log.error(message)
+        raise DistMigrationProductSetupException(message)

--- a/suse_migration_services/units/product_setup.py
+++ b/suse_migration_services/units/product_setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE Linux LLC.  All rights reserved.
+# Copyright (c) 2019 SUSE Linux LLC.  All rights reserved.
 #
 # This file is part of suse-migration-services.
 #
@@ -31,11 +31,27 @@ def main():
     """
     DistMigration setup product
 
-    Synchronize bind mounted etc/products.d data into the migrated system
+    Synchronize bind mounted /etc/products.d data into the migrated system
     """
     root_path = Defaults.get_system_root_path()
 
     try:
+        # Note:
+        # At the time this code was written fate#320882 was not
+        # implemented which means only one registration server
+        # (smt/rmt/scc) is used to answer the request for the
+        # upgrade path from Distribution [A] to [B]. The approach
+        # to overlay the systems' /etc/products.d directory with the
+        # one from the migration live system will therefore not
+        # hide product registrations from other registration
+        # servers and is a functional fix to the distro_target
+        # problem explained in units/prepare.py
+        #
+        # However once fate#320882 is resolved this will have an
+        # impact on the zypper migration plugin code and depending
+        # on that implementation it will no longer be allowed
+        # to potentially hide product definitions as they are
+        # defined on the system to migrate.
         products_metadata = os.sep.join(
             [root_path, 'etc', 'products.d']
         )

--- a/systemd/suse-migration-product-setup.service
+++ b/systemd/suse-migration-product-setup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Synchronize product information to migrated system
+After=suse-migration.service
+Requires=suse-migration.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/suse-migration-product-setup
+
+[Install]
+WantedBy=multi-user.target

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -119,6 +119,12 @@ class TestSetupPrepare(object):
                 ),
                 call(
                     [
+                        'mount', '--bind', '/etc/products.d',
+                        '/system-root/etc/products.d'
+                    ]
+                ),
+                call(
+                    [
                         'mount', '--bind', '/system-root/etc/zypp',
                         '/etc/zypp'
                     ]
@@ -146,6 +152,9 @@ class TestSetupPrepare(object):
                 '/etc/system-root.fstab'
             )
             assert fstab.add_entry.call_args_list == [
+                call(
+                    '/etc/products.d', '/system-root/etc/products.d'
+                ),
                 call(
                     '/system-root/etc/zypp', '/etc/zypp'
                 ),

--- a/test/unit/units/product_setup_test.py
+++ b/test/unit/units/product_setup_test.py
@@ -1,0 +1,43 @@
+from unittest.mock import (
+    patch, call
+)
+from pytest import raises
+
+from suse_migration_services.units.product_setup import main
+from suse_migration_services.exceptions import (
+    DistMigrationProductSetupException
+)
+
+
+class TestProductSetup(object):
+    @patch('suse_migration_services.logger.log.error')
+    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.command.Command.run')
+    def test_main_raises_on_product_setup(
+        self, mock_Command_run, mock_info, mock_error
+    ):
+        mock_Command_run.side_effect = Exception
+        with raises(DistMigrationProductSetupException):
+            main()
+            assert mock_info.called
+            assert mock_error.called
+
+    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.command.Command.run')
+    def test_main(
+        self, mock_Command_run, mock_info
+    ):
+        main()
+        assert mock_Command_run.call_args_list == [
+            call(
+                ['umount', '/system-root/etc/products.d']
+            ),
+            call(
+                [
+                    'rsync', '-zav', '--delete',
+                    '/etc/products.d/',
+                    '/system-root/etc/products.d/'
+                ]
+            )
+        ]
+        assert mock_info.called


### PR DESCRIPTION
__Product Setup__

Long time ago zypper added a distro_target information into the repository file and matches those with the product information of the system. If the distro doesn't match  zypper refused to create the repository. In the migration process using SMT this caused the zypper migration plugin to fail because zypper never created repositories.

That's  because in a migration process the repository and the system to migrate never matches. Therefore we bind mount  the /etc/products.d information from the migration live system into the
/system-root of the system to become migrated.

At the end of a successful migration the new product information is copied to the migrated system.
This task is handled by the new product_setup service