### PR TITLE
Revert/Refactor distro_target handling

### DIFF
--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -76,9 +76,6 @@ def main():
                 ['update-ca-certificates']
             )
 
-    products_metadata = os.sep.join(
-        [root_path, 'etc', 'products.d']
-    )
     zypp_metadata = os.sep.join(
         [root_path, 'etc', 'zypp']
     )
@@ -96,28 +93,6 @@ def main():
         system_mount = Fstab()
         system_mount.read(
             Defaults.get_system_mount_info_file()
-        )
-        log.info('Bind mounting migration system /etc/products.d')
-        # Note:
-        # This bind mount overlays the live migration product
-        # definition with the one present on the system to migrate.
-        # The reason for this is because of zyppers' handling of
-        # the distro_target attribute from the upgrade repositories
-        # metadata. In SMT repositories contains this flag and if
-        # it is present, zypper compares the value with the
-        # baseproduct setup in /etc/products.d. If they mismatch
-        # zypper refuses to create the repo. In the process of
-        # a migration from distribution [A] to [B] this mismatch
-        # always applies by design and prevents the zypper migration
-        # plugin to work. In SCC or RMT the repositories doesn't
-        # contain the distro_target attribute which is the reason
-        # why we don't see this problem there. SMT is still a valid
-        # registration target and cannot be ignored.
-        Command.run(
-            ['mount', '--bind', '/etc/products.d', products_metadata]
-        )
-        system_mount.add_entry(
-            '/etc/products.d', products_metadata
         )
         log.info('Bind mounting /etc/zypp')
         Command.run(

--- a/systemd/suse-migration-product-setup.service
+++ b/systemd/suse-migration-product-setup.service
@@ -1,7 +1,7 @@
 [Unit]
-Description=Synchronize product information to migrated system
-After=suse-migration.service
-Requires=suse-migration.service
+Description=Prepare Product Setup for Migration
+After=suse-migration-prepare.service
+Requires=suse-migration-prepare.service
 
 [Service]
 Type=oneshot

--- a/systemd/suse-migration.service
+++ b/systemd/suse-migration.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Run Zypper Migration
-After=suse-migration-prepare.service
-Requires=suse-migration-prepare.service 
+After=suse-migration-product-setup.service
+Requires=suse-migration-product-setup.service
 
 [Service]
 Type=oneshot

--- a/test/data/etc/products.d/baseproduct
+++ b/test/data/etc/products.d/baseproduct
@@ -1,0 +1,78 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<product schemeversion="0">
+  <vendor>SUSE</vendor>
+  <name>SLES</name>
+  <version>12.3</version>
+  <baseversion>12</baseversion>
+  <patchlevel>3</patchlevel>
+  <release>0</release>
+  <endoflife />
+  <arch>x86_64</arch>
+  <cpeid>cpe:/o:suse:sles:12:sp3</cpeid>
+  <productline>sles</productline>
+  <codestream>
+    <name>SUSE Linux Enterprise Server 12</name>
+    <endoflife>2024-10-31</endoflife>
+  </codestream>
+  <register>
+    <target>sle-12-x86_64</target>
+    <updates>
+      <repository repoid="obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER:12-SP3:x86_64/update" />
+      <repository repoid="obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER:12-SP3:x86_64/update_debug" />
+      <repository repoid="obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER-INSTALLER:12-SP3:x86_64/update" />
+    </updates>
+  </register>
+  <upgrades />
+  <updaterepokey>A43242DKD</updaterepokey>
+  <summary>SUSE Linux Enterprise Server 12 SP3</summary>
+  <shortsummary>SLES12-SP3</shortsummary>
+  <description>SUSE Linux Enterprise offers a comprehensive
+        suite of products built on a single code base.
+        The platform addresses business needs from
+        the smallest thin-client devices to the world's
+        most powerful high-performance computing
+        and mainframe servers. SUSE Linux Enterprise
+        offers common management tools and technology
+        certifications across the platform, and
+        each product is enterprise-class.</description>
+  <linguas>
+    <language>cs</language>
+    <language>da</language>
+    <language>de</language>
+    <language>en</language>
+    <language>en_GB</language>
+    <language>en_US</language>
+    <language>es</language>
+    <language>fi</language>
+    <language>fr</language>
+    <language>hu</language>
+    <language>it</language>
+    <language>ja</language>
+    <language>nb</language>
+    <language>nl</language>
+    <language>pl</language>
+    <language>pt</language>
+    <language>pt_BR</language>
+    <language>ru</language>
+    <language>sv</language>
+    <language>zh</language>
+    <language>zh_CN</language>
+    <language>zh_TW</language>
+  </linguas>
+  <urls>
+    <url name="releasenotes">https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12-SP3/release-notes-sles.rpm</url>
+  </urls>
+  <buildconfig>
+    <producttheme>SLES</producttheme>
+  </buildconfig>
+  <installconfig>
+    <defaultlang>en_US</defaultlang>
+    <datadir>suse</datadir>
+    <descriptiondir>suse/setup/descr</descriptiondir>
+    <releasepackage flag="EQ" name="sles-release" release="4.3.1" version="12.3" />
+    <distribution>SUSE_SLE</distribution>
+  </installconfig>
+  <runtimeconfig />
+  <productdependency baseversion="12" flag="EQ" name="SUSE_SLE" patchlevel="3" relationship="provides" />
+  <productdependency baseversion="12" flag="EQ" name="SUSE_SLE-SP3" patchlevel="3" relationship="provides" />
+</product>

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -119,12 +119,6 @@ class TestSetupPrepare(object):
                 ),
                 call(
                     [
-                        'mount', '--bind', '/etc/products.d',
-                        '/system-root/etc/products.d'
-                    ]
-                ),
-                call(
-                    [
                         'mount', '--bind', '/system-root/etc/zypp',
                         '/etc/zypp'
                     ]
@@ -152,9 +146,6 @@ class TestSetupPrepare(object):
                 '/etc/system-root.fstab'
             )
             assert fstab.add_entry.call_args_list == [
-                call(
-                    '/etc/products.d', '/system-root/etc/products.d'
-                ),
                 call(
                     '/system-root/etc/zypp', '/etc/zypp'
                 ),


### PR DESCRIPTION
zypper implements a handling for the distro_target attribute.
If present in the repository metadata, zypper compares the
value with the baseproduct <target> setup in /etc/products.d.
If they mismatch zypper refuses to create the repo. In the
process of a migration from distribution [A] to [B] this mismatch
always applies by design and prevents the zypper migration plugin
to work. In SCC or RMT the repositories doesn't contain the
distro_target attribute which is the reason why we don't see
this problem there. SMT however creates repos including
distro_target.

The refactored workaround solution is now to delete the target
specification in the baseproduct registration if present, because
the overlay mounting of etc/products.d did not work as it would
lead to a wrong upgrade path on response from SCC.

In addition a backup of the original products.d data is created
and used in the zypper migration plugin in case of an error