### PR TITLE
Change location for live migration ISO image

### DIFF
--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -13,7 +13,7 @@ else
     ) ${CLASS}"
 fi
 
-migration_iso=$(echo /usr/share/migration-image/*-Migration.*.iso)
+migration_iso=$(echo /boot/*-Migration.*.iso)
 
 if grub_file_is_not_garbage "${migration_iso}"; then
     kernel="(loop)/boot/x86_64/loader/linux"


### PR DESCRIPTION
Instead of /usr/share expect the image in /boot. The reason
for this change is because we don't know if the system uses
an extra boot partition to load the kernel and initrd from.
However the way we add the extra loop boot entry to grub
is based on reading the value for ($root) as it was configured
on the system. The location ($root) points to in grub could
be anywhere but we can trust /boot to be in there.
This Fixes the run of the migration in Azure and also
stabilizes the concept.