### PR TITLE
Rename migration log file

### DIFF
--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -35,7 +35,7 @@ class Defaults(object):
     @classmethod
     def get_migration_log_file(self):
         return os.sep.join(
-            [self.get_system_root_path(), 'var/log/zypper_migrate.log']
+            [self.get_system_root_path(), 'var/log/distro_migration.log']
         )
 
     @classmethod

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -41,7 +41,7 @@ class TestMigration(object):
                 '--auto-agree-with-licenses '
                 '--product foo '
                 '--root /system-root '
-                '&>> /system-root/var/log/zypper_migrate.log'
+                '&>> /system-root/var/log/distro_migration.log'
             ]
         )
         assert mock_info.called

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -163,9 +163,9 @@ class TestSetupPrepare(object):
                 '/etc/system-root.fstab'
             )
             mock_open.assert_called_once_with(
-                '/system-root/var/log/zypper_migrate.log', 'w'
+                '/system-root/var/log/distro_migration.log', 'w'
             )
             mock_set_logfile.assert_called_once_with(
-                '/system-root/var/log/zypper_migrate.log'
+                '/system-root/var/log/distro_migration.log'
             )
             assert mock_info.called


### PR DESCRIPTION
As zypper is part of the process but not the only
component, 'zypper_migration.log' does not describe it properly.