### PR TITLE
Reboot system after migration unless debug

### DIFF
--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -69,3 +69,9 @@ class Defaults(object):
         return os.sep.join(
             [self.get_system_root_path(), prefix_path, '.ssh/authorized_keys']
         )
+
+    @classmethod
+    def get_system_migration_debug_file(self):
+        return os.sep.join(
+            [self.get_system_root_path(), '/etc/sle-migration-service']
+        )

--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -55,7 +55,6 @@ def main():
             ['bash', '-c', bash_command]
         )
     except Exception as issue:
-        root_path = Defaults.get_system_root_path()
         etc_issue_path = os.sep.join(
             [root_path, 'etc/issue']
         )

--- a/systemd/suse-migration-grub-setup.service
+++ b/systemd/suse-migration-grub-setup.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Recreate grub configuration file from migrated version
 After=suse-migration.service
-Requires=suse-migration.service
 
 [Service]
 Type=oneshot

--- a/systemd/suse-migration-reboot.service
+++ b/systemd/suse-migration-reboot.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Reboot System
 After=suse-migration-umount-system.service
-Requires=suse-migration-umount-system.service
 
 [Service]
 Type=oneshot

--- a/test/unit/units/reboot_test.py
+++ b/test/unit/units/reboot_test.py
@@ -1,29 +1,116 @@
 from unittest.mock import (
     patch, call
 )
+from collections import namedtuple
 
-from suse_migration_services.units.reboot import main
+from suse_migration_services.units.reboot import (
+    main, _migration_has_failed
+)
 
 
 class TestKernelReboot(object):
+
+    @patch('suse_migration_services.command.Command.run')
+    def test_migration_has_failed(
+        self, mock_Command_run
+    ):
+        command_type = namedtuple(
+            'command', ['output', 'error', 'returncode']
+        )
+        result = command_type(
+            output='failed\n',
+            error='',
+            returncode=1
+        )
+        mock_Command_run.return_value = result
+        _migration_has_failed()
+        mock_Command_run.assert_called_once_with(
+            ['systemctl', 'is-failed', 'suse-migration']
+        )
+
+    @patch('suse_migration_services.units.reboot._migration_has_failed')
+    @patch('os.path.exists')
     @patch('suse_migration_services.logger.log.warning')
     @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.command.Command.run')
-    def test_main(
-        self, mock_Command_run,
-        mock_info, mock_warning
+    def test_main_not_reboot(
+        self, mock_Command_run, mock_info, mock_warning,
+        mock_path_exists, mock_migration_failed
     ):
+        mock_path_exists.return_value = True
+        mock_migration_failed.return_value = True
+        main()
+        assert mock_info.called
+        assert not mock_Command_run.called
+
+    @patch('suse_migration_services.units.reboot._migration_has_failed')
+    @patch('os.path.exists')
+    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.command.Command.run')
+    def test_main_failed_migration_reboot(
+        self, mock_Command_run, mock_info,
+        mock_path_exists, mock_migration_failed
+    ):
+        mock_migration_failed.return_value = True
+        mock_path_exists.return_value = False
         main()
         assert mock_info.called
         mock_Command_run.assert_called_once_with(
             ['kexec', '--exec']
         )
-        mock_Command_run.reset_mock()
+
+    @patch('suse_migration_services.units.reboot._migration_has_failed')
+    @patch('os.path.exists')
+    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.command.Command.run')
+    def test_main_not_remove_file_reboot(
+        self, mock_Command_run, mock_info,
+        mock_path_exists, mock_migration_failed
+    ):
+        mock_migration_failed.return_value = False
+        mock_path_exists.return_value = False
+        main()
+        assert mock_info.called
+        mock_Command_run.assert_called_once_with(
+            ['kexec', '--exec']
+        )
+
+    @patch('os.path.exists')
+    @patch('os.remove')
+    @patch('suse_migration_services.defaults.Defaults.get_system_migration_debug_file')
+    @patch('suse_migration_services.units.reboot._migration_has_failed')
+    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.command.Command.run')
+    def test_main_remove_file_reboot(
+        self, mock_Command_run, mock_info, mock_migration_failed,
+        mock_get_system_migration_debug_file, mock_os_remove, mock_path_exists
+    ):
+        mock_migration_failed.return_value = False
+        debug_file = 'debug_file'
+        mock_path_exists.return_value = True
+        mock_get_system_migration_debug_file.return_value = debug_file
+        main()
+        assert mock_info.called
+        mock_os_remove.assert_called_once_with(debug_file)
+        mock_Command_run.assert_called_once_with(
+            ['kexec', '--exec']
+        )
+
+    @patch('suse_migration_services.units.reboot._migration_has_failed')
+    @patch('suse_migration_services.logger.log.warning')
+    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.command.Command.run')
+    def test_main_reboot_exception(
+        self, mock_Command_run, mock_info,
+        mock_warning, mock_migration_failed
+    ):
+        mock_migration_failed.return_value = True
         mock_Command_run.side_effect = [
             Exception,
             None
         ]
         main()
+        assert mock_info.called
         assert mock_Command_run.call_args_list == [
             call(['kexec', '--exec']),
             call(['reboot', '-f'])


### PR DESCRIPTION
The migration process will reboot the system whether it has succeeded or not
unless there is a file indicating not to reboot.

Fixes #48