### PR TITLE
Boot space too small

### DIFF
--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -13,7 +13,7 @@ else
     ) ${CLASS}"
 fi
 
-migration_iso=$(echo /boot/*-Migration.*.iso)
+migration_iso=$(echo /usr/share/migration-image/*-Migration.*.iso)
 
 if grub_file_is_not_garbage "${migration_iso}"; then
     kernel="(loop)/boot/x86_64/loader/linux"

--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -14,6 +14,9 @@ else
 fi
 
 migration_iso=$(echo /usr/share/migration-image/*-Migration.*.iso)
+root_device=$(lsblk -p -n -r -o NAME,MOUNTPOINT | grep -E "/$" | cut -f1 -d" ")
+root_uuid=$(blkid -s UUID -o value "${root_device}")
+root_type=$(blkid -s TYPE -o value "${root_device}")
 
 if grub_file_is_not_garbage "${migration_iso}"; then
     kernel="(loop)/boot/x86_64/loader/linux"
@@ -22,6 +25,8 @@ if grub_file_is_not_garbage "${migration_iso}"; then
     boot_options="rd.live.image root=live:CDLABEL=CDROM"
     printf "menuentry '%s' %s \${menuentry_id_option} '%s' {\n" \
         "${OS}" "${CLASS}" "Migration-${boot_device_id}"
+    printf "    insmod %s\n" "${root_type}"
+    printf "    search --no-floppy --fs-uuid --set=root %s\n" "${root_uuid}"
     printf "    set isofile='%s'\n" \
         "${migration_iso}"
     printf "    loopback loop (\$root)\$isofile\n"


### PR DESCRIPTION
This patch is two fold:

__Add rootpart detection to grub activation script__
    
The live migration image gets installed to the system again because of the space limitation on /boot. This affects the menuentry created on grub side in a way that we can't use the pre-allocated pointer to the boot device but have to search the root partition like in a real grub root entry. This patch adds the needed code changes to locate the root part, insert the needed filesystem module and initializes the root variable to allow the loopback loading of the image.

__Revert location change from /usr/share to /boot__
    
This reverts commit #66dd8d4943d38f121f4b16b70bf0ab8d0b2ec82d.  If there is an extra boot partition and it's too small we are not able to install the migration system and the customer will not be able to use the migration concept. The image is  usually around ~300MB of size and that can often be too much  for an extra boot partition which is often designed to be small

This Fixes #54 