### PR TITLE
Path for log file

### DIFF
--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -59,10 +59,13 @@ def main():
         etc_issue_path = os.sep.join(
             [root_path, 'etc/issue']
         )
+        log_path_migrated_system = os.sep + os.path.relpath(
+            Defaults.get_migration_log_file(), root_path
+        )
         with open(etc_issue_path, 'w') as issue_file:
             issue_file.write(
-                '\nMigration has failed, for further details see {0}'
-                .format(Defaults.get_migration_log_file())
+                'Migration has failed, for further details see {0}'
+                .format(log_path_migrated_system)
             )
         debug_file = Defaults.get_system_migration_debug_file()
         migration_debug_path = os.sep.join(

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -28,8 +28,8 @@ class TestMigration(object):
         issue_path = '../data/etc/issue'
         with open(issue_path) as issue_file:
             message = (
-                '\nMigration has failed, for further details see {0}'
-                .format(Defaults.get_migration_log_file())
+                'Migration has failed, for further details see {0}'
+                .format('/var/log/distro_migration.log')
             )
             assert message in issue_file.read()
         os.remove(issue_path)


### PR DESCRIPTION
After reboot, if the migration has failed, the file
/etc/issue has a message pointing to the log file.
The path of that log file must exist inside the rebooted system.