### PR TITLE
Add flag to handle zypper migration errors

### DIFF
--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -47,6 +47,7 @@ def main():
                 '--gpg-auto-import-keys',
                 '--no-selfupdate',
                 '--auto-agree-with-licenses',
+                '--strict-errors-dist-migration',
                 '--product', get_migration_product(),
                 '--root', root_path,
                 '&>>', Defaults.get_migration_log_file()

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -57,6 +57,7 @@ class TestMigration(object):
                 '--gpg-auto-import-keys '
                 '--no-selfupdate '
                 '--auto-agree-with-licenses '
+                '--strict-errors-dist-migration '
                 '--product foo '
                 '--root /system-root '
                 '&>> /system-root/var/log/distro_migration.log'


### PR DESCRIPTION
Zypper has extra error codes that does not necessarily have to
stop a distribution migration.

Fixes #52