### PR TITLE
Initialize logging and debug as early as possible

### DIFF
--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -39,6 +39,12 @@ class Defaults(object):
         )
 
     @classmethod
+    def get_system_migration_debug_file(self):
+        return os.sep.join(
+            [self.get_system_root_path(), 'etc/sle-migration-service']
+        )
+
+    @classmethod
     def get_system_mount_info_file(self):
         return '/etc/system-root.fstab'
 
@@ -69,7 +75,3 @@ class Defaults(object):
         return os.sep.join(
             [self.get_system_root_path(), prefix_path, '.ssh/authorized_keys']
         )
-
-    @classmethod
-    def get_system_migration_debug_file(self):
-        return 'etc/sle-migration-service'

--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -17,7 +17,6 @@
 #
 import yaml
 import os
-import shutil
 
 # project
 from suse_migration_services.command import Command
@@ -68,16 +67,6 @@ def main():
                 'Migration has failed, for further details see {0}'
                 .format(log_path_migrated_system)
             )
-        debug_file = Defaults.get_system_migration_debug_file()
-        migration_debug_path = os.sep.join(
-            [root_path, debug_file]
-        )
-        if os.path.exists(migration_debug_path):
-            shutil.copy(
-                migration_debug_path,
-                os.sep + debug_file
-            )
-
         log.error('migrate service failed with {0}'.format(issue))
         raise DistMigrationZypperException(
             'Migration failed with {0}'.format(

--- a/suse_migration_services/units/mount_system.py
+++ b/suse_migration_services/units/mount_system.py
@@ -108,6 +108,27 @@ def main():
 
     mount_system(root_path, fstab)
 
+    initialize_logging()
+    initialize_debugging()
+
+
+def initialize_logging():
+    with open(Defaults.get_migration_log_file(), 'w'):
+        log.set_logfile(Defaults.get_migration_log_file())
+
+
+def initialize_debugging():
+    debug_file = Defaults.get_system_migration_debug_file()
+    # delete potentially existing debug flag file from migration live system
+    Path.wipe(
+        os.sep.join(['/etc', os.path.basename(debug_file)])
+    )
+    # copy debug flag file if set on target system to migration live system
+    if os.path.exists(debug_file):
+        Command.run(
+            ['cp', debug_file, '/etc']
+        )
+
 
 def mount_system(root_path, fstab):
     log.info('Mount system in {0}'.format(root_path))

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -25,8 +25,7 @@ from suse_migration_services.defaults import Defaults
 from suse_migration_services.logger import log
 
 from suse_migration_services.exceptions import (
-    DistMigrationZypperMetaDataException,
-    DistMigrationLoggingException
+    DistMigrationZypperMetaDataException
 )
 
 
@@ -136,17 +135,6 @@ def main():
             )
         raise DistMigrationZypperMetaDataException(
             'Preparation of zypper metadata failed with {0}'.format(
-                issue
-            )
-        )
-
-    try:
-        with open(Defaults.get_migration_log_file(), 'w'):
-            pass
-        log.set_logfile(Defaults.get_migration_log_file())
-    except Exception as issue:
-        raise DistMigrationLoggingException(
-            'Migration log file init failed with {0}'.format(
                 issue
             )
         )

--- a/suse_migration_services/units/reboot.py
+++ b/suse_migration_services/units/reboot.py
@@ -18,7 +18,6 @@
 import os
 
 # project
-from suse_migration_services.path import Path
 from suse_migration_services.command import Command
 from suse_migration_services.logger import log
 from suse_migration_services.defaults import Defaults
@@ -28,7 +27,9 @@ def main():
     """
     DistMigration reboot with new kernel
     """
-    debug_file = os.sep + Defaults.get_system_migration_debug_file()
+    debug_file = os.sep.join(
+        ['/etc', os.path.basename(Defaults.get_system_migration_debug_file())]
+    )
 
     try:
         # Note:
@@ -38,7 +39,6 @@ def main():
             log.info('Reboot skipped due to debug flag set')
         else:
             log.info('Reboot system: [kexec]')
-            Path.wipe(debug_file)
             Command.run(
                 ['kexec', '--exec']
             )

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -10,7 +10,6 @@ from suse_migration_services.exceptions import (
 
 
 class TestMigration(object):
-    @patch('shutil.copy')
     @patch('os.path.exists')
     @patch('suse_migration_services.defaults.Defaults.get_system_root_path')
     @patch('suse_migration_services.logger.log.info')
@@ -18,7 +17,7 @@ class TestMigration(object):
     @patch('suse_migration_services.command.Command.run')
     def test_main_raises_on_zypper_migration(
         self, mock_Command_run, mock_error, mock_info,
-        mock_get_system_root_path, mock_path_exists, mock_shutil_copy
+        mock_get_system_root_path, mock_path_exists
     ):
         mock_Command_run.side_effect = Exception
         mock_get_system_root_path.return_value = '../data'
@@ -33,10 +32,6 @@ class TestMigration(object):
             )
             assert message in issue_file.read()
         os.remove(issue_path)
-        mock_shutil_copy.assert_called_once_with(
-            '../data/etc/sle-migration-service',
-            '/etc/sle-migration-service'
-        )
         assert mock_error.called
 
     @patch('suse_migration_services.logger.log.info')

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -1,6 +1,5 @@
-import io
 from unittest.mock import (
-    patch, call, Mock, MagicMock
+    patch, call, Mock
 )
 
 from pytest import raises
@@ -8,8 +7,7 @@ from pytest import raises
 from suse_migration_services.units.prepare import main
 from suse_migration_services.fstab import Fstab
 from suse_migration_services.exceptions import (
-    DistMigrationZypperMetaDataException,
-    DistMigrationLoggingException
+    DistMigrationZypperMetaDataException
 )
 
 
@@ -41,26 +39,6 @@ class TestSetupPrepare(object):
     @patch('os.path.exists')
     @patch('shutil.copy')
     @patch('os.listdir')
-    def test_main_raises_on_log_init(
-        self, mock_os_listdir, mock_shutil_copy, mock_os_path_exists,
-        mock_Fstab, mock_Command_run, mock_log_info,
-        mock_log_error
-    ):
-        mock_os_path_exists.return_value = True
-        with patch('builtins.open', create=True) as mock_open:
-            mock_open.side_effect = Exception
-            with raises(DistMigrationLoggingException):
-                main()
-                assert mock_log_info.called
-                assert mock_log_error.called
-
-    @patch('suse_migration_services.logger.log.error')
-    @patch('suse_migration_services.logger.log.info')
-    @patch('suse_migration_services.command.Command.run')
-    @patch('suse_migration_services.units.prepare.Fstab')
-    @patch('os.path.exists')
-    @patch('shutil.copy')
-    @patch('os.listdir')
     def test_main_raises_and_umount_file_system(
         self, mock_os_listdir, mock_shutil_copy, mock_os_path_exists,
         mock_Fstab, mock_Command_run,
@@ -84,88 +62,79 @@ class TestSetupPrepare(object):
     @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.prepare.Fstab')
-    @patch('suse_migration_services.units.prepare.log.set_logfile')
     @patch('os.path.exists')
     @patch('shutil.copy')
     @patch('os.listdir')
     def test_main(
         self, mock_os_listdir, mock_shutil_copy, mock_os_path_exists,
-        mock_set_logfile, mock_Fstab, mock_Command_run, mock_info
+        mock_Fstab, mock_Command_run, mock_info
     ):
         fstab = Mock()
         mock_Fstab.return_value = fstab
         mock_os_listdir.return_value = ['foo', 'bar']
         mock_os_path_exists.return_value = True
-        with patch('builtins.open', create=True) as mock_open:
-            mock_open.return_value = MagicMock(spec=io.IOBase)
-            main()
-            assert mock_shutil_copy.call_args_list == [
-                call('/system-root/etc/SUSEConnect', '/etc/SUSEConnect'),
-                call('/system-root/etc/hosts', '/etc/hosts'),
-                call(
-                    '/system-root/usr/share/pki/trust/anchors/foo',
-                    '/usr/share/pki/trust/anchors/'
-                ),
-                call(
-                    '/system-root/usr/share/pki/trust/anchors/bar',
-                    '/usr/share/pki/trust/anchors/'
-                )
-            ]
-            assert mock_Command_run.call_args_list == [
-                call(
-                    [
-                        'update-ca-certificates'
-                    ]
-                ),
-                call(
-                    [
-                        'mount', '--bind', '/system-root/etc/zypp',
-                        '/etc/zypp'
-                    ]
-                ),
-                call(
-                    [
-                        'mount', '-t', 'devtmpfs', 'devtmpfs',
-                        '/system-root/dev'
-                    ]
-                ),
-                call(
-                    [
-                        'mount', '-t', 'proc', 'proc',
-                        '/system-root/proc'
-                    ]
-                ),
-                call(
-                    [
-                        'mount', '-t', 'sysfs', 'sysfs',
-                        '/system-root/sys'
-                    ]
-                )
-            ]
-            fstab.read.assert_called_once_with(
-                '/etc/system-root.fstab'
+        main()
+        assert mock_shutil_copy.call_args_list == [
+            call('/system-root/etc/SUSEConnect', '/etc/SUSEConnect'),
+            call('/system-root/etc/hosts', '/etc/hosts'),
+            call(
+                '/system-root/usr/share/pki/trust/anchors/foo',
+                '/usr/share/pki/trust/anchors/'
+            ),
+            call(
+                '/system-root/usr/share/pki/trust/anchors/bar',
+                '/usr/share/pki/trust/anchors/'
             )
-            assert fstab.add_entry.call_args_list == [
-                call(
-                    '/system-root/etc/zypp', '/etc/zypp'
-                ),
-                call(
-                    'devtmpfs', '/system-root/dev'
-                ),
-                call(
-                    '/proc', '/system-root/proc'
-                ),
-                call(
-                    'sysfs', '/system-root/sys'
-                )
-            ]
-            fstab.export.assert_called_once_with(
-                '/etc/system-root.fstab'
+        ]
+        assert mock_Command_run.call_args_list == [
+            call(
+                [
+                    'update-ca-certificates'
+                ]
+            ),
+            call(
+                [
+                    'mount', '--bind', '/system-root/etc/zypp',
+                    '/etc/zypp'
+                ]
+            ),
+            call(
+                [
+                    'mount', '-t', 'devtmpfs', 'devtmpfs',
+                    '/system-root/dev'
+                ]
+            ),
+            call(
+                [
+                    'mount', '-t', 'proc', 'proc',
+                    '/system-root/proc'
+                ]
+            ),
+            call(
+                [
+                    'mount', '-t', 'sysfs', 'sysfs',
+                    '/system-root/sys'
+                ]
             )
-            mock_open.assert_called_once_with(
-                '/system-root/var/log/distro_migration.log', 'w'
+        ]
+        fstab.read.assert_called_once_with(
+            '/etc/system-root.fstab'
+        )
+        assert fstab.add_entry.call_args_list == [
+            call(
+                '/system-root/etc/zypp', '/etc/zypp'
+            ),
+            call(
+                'devtmpfs', '/system-root/dev'
+            ),
+            call(
+                '/proc', '/system-root/proc'
+            ),
+            call(
+                'sysfs', '/system-root/sys'
             )
-            mock_set_logfile.assert_called_once_with(
-                '/system-root/var/log/distro_migration.log'
-            )
-            assert mock_info.called
+        ]
+        fstab.export.assert_called_once_with(
+            '/etc/system-root.fstab'
+        )
+        assert mock_info.called

--- a/test/unit/units/reboot_test.py
+++ b/test/unit/units/reboot_test.py
@@ -19,9 +19,8 @@ class TestKernelReboot(object):
     @patch('os.path.exists')
     @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.command.Command.run')
-    @patch('suse_migration_services.path.Path.wipe')
     def test_main_kexec_reboot(
-        self, mock_Path_wipe, mock_Command_run, mock_info, mock_path_exists
+        self, mock_Command_run, mock_info, mock_path_exists
     ):
         mock_path_exists.return_value = False
         main()
@@ -29,9 +28,6 @@ class TestKernelReboot(object):
             '/etc/sle-migration-service'
         )
         assert mock_info.called
-        mock_Path_wipe.assert_called_once_with(
-            '/etc/sle-migration-service'
-        )
         mock_Command_run.assert_called_once_with(
             ['kexec', '--exec']
         )
@@ -39,17 +35,13 @@ class TestKernelReboot(object):
     @patch('suse_migration_services.logger.log.warning')
     @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.command.Command.run')
-    @patch('suse_migration_services.path.Path.wipe')
     def test_main_force_reboot(
-        self, mock_Path_wipe, mock_Command_run, mock_info, mock_warning
+        self, mock_Command_run, mock_info, mock_warning
     ):
         mock_Command_run.side_effect = [
             Exception, None
         ]
         main()
-        mock_Path_wipe.assert_called_once_with(
-            '/etc/sle-migration-service'
-        )
         assert mock_info.called
         assert mock_Command_run.call_args_list == [
             call(['kexec', '--exec']),


### PR DESCRIPTION
The earliest opportunity to setup the log file and the
debug flag is directly after the mount-system code has
successfully mounted the target to migrate. At this point
we should init the logfile and also the debugging if
needed. The code before this commit has potential to
not even reach the log/debug setup. With this commit
the only requirement is a successful mount of the target
system.