### PR TITLE
Fixed log reference in console log service

### DIFF
--- a/systemd/suse-migration-console-log.service
+++ b/systemd/suse-migration-console-log.service
@@ -7,7 +7,7 @@ Wants=systemd-vconsole-setup.service
 Conflicts=emergency.service emergency.target
 
 [Service]
-ExecStart=/usr/bin/dialog --tailbox /system-root/var/log/zypper_migrate.log 60 75
+ExecStart=/usr/bin/dialog --tailbox /system-root/var/log/distro_migration.log 60 75
 Type=simple
 Restart=always
 RestartSec=2


### PR DESCRIPTION
The systemd unit file was still pointing to the old file
name but that has changed to var/log/distro_migration.log