### PR TITLE
Added systemctl status output to logfile

### DIFF
--- a/suse_migration_services/logger.py
+++ b/suse_migration_services/logger.py
@@ -163,7 +163,6 @@ class Logger(logging.Logger):
         :param string filename: logfile file path
         """
         try:
-            print(filename)
             logfile = logging.FileHandler(
                 filename=filename, encoding='utf-8'
             )

--- a/suse_migration_services/units/reboot.py
+++ b/suse_migration_services/units/reboot.py
@@ -35,6 +35,13 @@ def main():
         # Note:
         # After the migration process is finished, the system reboots
         # unless the debug file /etc/sle-migration-service is set.
+        log.info(
+            'Systemctl Status Information: {0}{1}'.format(
+                os.linesep, Command.run(
+                    ['systemctl', 'status', '-l', '--all'], raise_on_error=False
+                ).output
+            )
+        )
         if os.path.exists(debug_file):
             log.info('Reboot skipped due to debug flag set')
         else:

--- a/test/unit/units/reboot_test.py
+++ b/test/unit/units/reboot_test.py
@@ -1,5 +1,5 @@
 from unittest.mock import (
-    patch, call
+    patch, call, MagicMock
 )
 from suse_migration_services.units.reboot import main
 
@@ -28,9 +28,10 @@ class TestKernelReboot(object):
             '/etc/sle-migration-service'
         )
         assert mock_info.called
-        mock_Command_run.assert_called_once_with(
-            ['kexec', '--exec']
-        )
+        assert mock_Command_run.call_args_list == [
+            call(['systemctl', 'status', '-l', '--all'], raise_on_error=False),
+            call(['kexec', '--exec'])
+        ]
 
     @patch('suse_migration_services.logger.log.warning')
     @patch('suse_migration_services.logger.log.info')
@@ -39,11 +40,12 @@ class TestKernelReboot(object):
         self, mock_Command_run, mock_info, mock_warning
     ):
         mock_Command_run.side_effect = [
-            Exception, None
+            MagicMock(), Exception, None
         ]
         main()
         assert mock_info.called
         assert mock_Command_run.call_args_list == [
+            call(['systemctl', 'status', '-l', '--all'], raise_on_error=False),
             call(['kexec', '--exec']),
             call(['reboot', '-f'])
         ]


### PR DESCRIPTION
As part of the reboot service add the systemctl status information
collected up to that point into the logfile.