### PR TITLE
Fix pattern for initrd

### DIFF
--- a/suse_migration_services/units/kernel_load.py
+++ b/suse_migration_services/units/kernel_load.py
@@ -43,9 +43,6 @@ def main():
     kexec_boot_data = '/var/tmp/kexec'
     Path.create(kexec_boot_data)
     shutil.copy(
-        target_kernel, kexec_boot_data
-    )
-    shutil.copy(
         target_initrd, kexec_boot_data
     )
     try:
@@ -54,13 +51,11 @@ def main():
         Command.run(
             [
                 'kexec',
-                '--load', os.sep.join(
-                    [kexec_boot_data, os.path.basename(target_kernel)]
-                ),
+                '--load', target_kernel,
                 '--initrd', os.sep.join(
                     [kexec_boot_data, os.path.basename(target_initrd)]
                 ),
-                '--command-line', _get_cmdline(target_kernel)
+                '--command-line', _get_cmdline(os.path.basename(target_kernel))
             ]
         )
     except Exception as issue:
@@ -87,9 +82,9 @@ def _get_cmdline(kernel_name):
                 grub_config_file_path
             )
         )
-    pattern = r'(?<=linux)[ \t]+{0}{1}.*'.format(os.sep, kernel_name)
     with open(grub_config_file_path) as grub_config_file:
         grub_content = grub_config_file.read()
+    pattern = r'(?<=linux)[ \t]+{0}([{1}|boot/{1}].*)'.format(os.sep, kernel_name)
     cmd_line = re.findall(pattern, grub_content)[0]
     cmd_line = cmd_line.split()
     cmd_line_options = []

--- a/test/data/fake_grub_with_bootpart.cfg
+++ b/test/data/fake_grub_with_bootpart.cfg
@@ -1,0 +1,36 @@
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'SLES15' --class sles --class gnu-linux --class gnu --class os $menuentry_id_option 'gnulinux-simple-ec7aaf92-30ea-4c07-991a-4700177ce1b8' {
+	load_video
+	set gfxpayload=keep
+	insmod gzio
+	insmod part_msdos
+	insmod ext2
+	set root='hd0,msdos1'
+	if [ x$feature_platform_search_hint = xy ]; then
+	  search --no-floppy --fs-uuid --set=root ec7aaf92-30ea-4c07-991a-4700177ce1b8
+	else
+	  search --no-floppy --fs-uuid --set=root ec7aaf92-30ea-4c07-991a-4700177ce1b8
+	fi
+	echo    'Loading Linux 4.12.4-25.25--default ...'
+	linux	/vmlinuz-4.12.14-25.25-default root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw
+	echo    'Loading initial ramdisk ...'
+	initrd	/initrd-4.12.14-25.25-default
+}
+submenu 'Advanced options for SLES15' --hotkey=1 $menuentry_id_options 'gnulinux-advanced-ec7aaf92-30ea-4c07-991a-4700177ce1b8'
+{
+	menuentry 'SLES15, with Linux 4.12.13-25.25-default' --hotkey=2 --class sles --class gnu-linux --class gnu --class os $menuentry_id_option 'gnulinux-ec7aaf92-30ea-4c07-991a-4700177ce1b8' {
+	load_video
+	set gfxpayload=keep
+	insmod gzio
+	insmod part_msdos
+	insmod ext2
+	set root='hd0,msdos1'
+	if [ x$feature_platform_search_hint = xy ]; then
+	  search --no-floppy --fs-uuid --set=root ec7aaf92-30ea-4c07-991a-4700177ce1b8
+	else
+	  search --no-floppy --fs-uuid --set=root ec7aaf92-30ea-4c07-991a-4700177ce1b8
+	fi
+	echo    'Loading Linux 4.12.14-25.25-default ...'
+	linux	/vmlinuz-4.12.14-25.25-default root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw
+	echo    'Loading initial ramdisk ...'
+	initrd	/initrd-4.12.14-25.25-default


### PR DESCRIPTION
When getting initrd inside grub for cmdline,
the pattern should find '/initrd'.