### PR TITLE
Support new cloud regionsrv client

### DIFF
--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -45,6 +45,9 @@ def main():
     suse_connect_setup = os.sep.join(
         [root_path, 'etc', 'SUSEConnect']
     )
+    suse_cloud_regionsrv_setup = os.sep.join(
+        [root_path, 'etc', 'regionserverclnt.cfg']
+    )
     hosts_setup = os.sep.join(
         [root_path, 'etc', 'hosts']
     )
@@ -54,6 +57,10 @@ def main():
     if os.path.exists(suse_connect_setup):
         shutil.copy(
             suse_connect_setup, '/etc/SUSEConnect'
+        )
+    if os.path.exists(suse_cloud_regionsrv_setup):
+        shutil.copy(
+            suse_cloud_regionsrv_setup, '/etc/regionserverclnt.cfg'
         )
     if os.path.exists(hosts_setup):
         shutil.copy(
@@ -78,6 +85,9 @@ def main():
     zypp_metadata = os.sep.join(
         [root_path, 'etc', 'zypp']
     )
+    zypp_plugins = os.sep.join(
+        [root_path, 'usr', 'lib', 'zypp', 'plugins']
+    )
     dev_mount_point = os.sep.join(
         [root_path, 'dev']
     )
@@ -99,6 +109,13 @@ def main():
         )
         system_mount.add_entry(
             zypp_metadata, '/etc/zypp'
+        )
+        log.info('Bind mounting /usr/lib/zypp/plugins')
+        Command.run(
+            ['mount', '--bind', zypp_plugins, '/usr/lib/zypp/plugins']
+        )
+        system_mount.add_entry(
+            zypp_plugins, '/usr/lib/zypp/plugins'
         )
         log.info('Mounting kernel file systems inside {0}'.format(root_path))
         Command.run(

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -19,6 +19,7 @@ import os
 import shutil
 
 # project
+from suse_migration_services.path import Path
 from suse_migration_services.command import Command
 from suse_migration_services.fstab import Fstab
 from suse_migration_services.defaults import Defaults
@@ -88,6 +89,9 @@ def main():
     zypp_plugins = os.sep.join(
         [root_path, 'usr', 'lib', 'zypp', 'plugins']
     )
+    cloud_register_metadata = os.sep.join(
+        [root_path, 'var', 'lib', 'cloudregister']
+    )
     dev_mount_point = os.sep.join(
         [root_path, 'dev']
     )
@@ -117,6 +121,15 @@ def main():
         system_mount.add_entry(
             zypp_plugins, '/usr/lib/zypp/plugins'
         )
+        if os.path.exists(cloud_register_metadata):
+            log.info('Bind mounting /var/lib/cloudregister')
+            Path.create('/var/lib/cloudregister')
+            Command.run(
+                [
+                    'mount', '--bind', cloud_register_metadata,
+                    '/var/lib/cloudregister'
+                ]
+            )
         log.info('Mounting kernel file systems inside {0}'.format(root_path))
         Command.run(
             ['mount', '-t', 'devtmpfs', 'devtmpfs', dev_mount_point]

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -76,6 +76,10 @@ class TestSetupPrepare(object):
         main()
         assert mock_shutil_copy.call_args_list == [
             call('/system-root/etc/SUSEConnect', '/etc/SUSEConnect'),
+            call(
+                '/system-root/etc/regionserverclnt.cfg',
+                '/etc/regionserverclnt.cfg'
+            ),
             call('/system-root/etc/hosts', '/etc/hosts'),
             call(
                 '/system-root/usr/share/pki/trust/anchors/foo',
@@ -96,6 +100,12 @@ class TestSetupPrepare(object):
                 [
                     'mount', '--bind', '/system-root/etc/zypp',
                     '/etc/zypp'
+                ]
+            ),
+            call(
+                [
+                    'mount', '--bind', '/system-root/usr/lib/zypp/plugins',
+                    '/usr/lib/zypp/plugins'
                 ]
             ),
             call(
@@ -123,6 +133,9 @@ class TestSetupPrepare(object):
         assert fstab.add_entry.call_args_list == [
             call(
                 '/system-root/etc/zypp', '/etc/zypp'
+            ),
+            call(
+                '/system-root/usr/lib/zypp/plugins', '/usr/lib/zypp/plugins'
             ),
             call(
                 'devtmpfs', '/system-root/dev'

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -62,12 +62,13 @@ class TestSetupPrepare(object):
     @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.prepare.Fstab')
+    @patch('suse_migration_services.units.prepare.Path')
     @patch('os.path.exists')
     @patch('shutil.copy')
     @patch('os.listdir')
     def test_main(
         self, mock_os_listdir, mock_shutil_copy, mock_os_path_exists,
-        mock_Fstab, mock_Command_run, mock_info
+        mock_Path, mock_Fstab, mock_Command_run, mock_info
     ):
         fstab = Mock()
         mock_Fstab.return_value = fstab
@@ -90,6 +91,9 @@ class TestSetupPrepare(object):
                 '/usr/share/pki/trust/anchors/'
             )
         ]
+        mock_Path.create.assert_called_once_with(
+            '/var/lib/cloudregister'
+        )
         assert mock_Command_run.call_args_list == [
             call(
                 [
@@ -106,6 +110,12 @@ class TestSetupPrepare(object):
                 [
                     'mount', '--bind', '/system-root/usr/lib/zypp/plugins',
                     '/usr/lib/zypp/plugins'
+                ]
+            ),
+            call(
+                [
+                    'mount', '--bind', '/system-root/var/lib/cloudregister',
+                    '/var/lib/cloudregister'
                 ]
             ),
             call(


### PR DESCRIPTION
The new cloud region service client comes with a plugin for
zypper that translates repo URIs into a specific plugin format
such that it's no longer possible to gain access to the SLES
repositories of our public cloud infrastructure by playing
tricks with snapshotting an on-demand instance without the
billingtag. However the new and fancy way makes migration of
such a system more difficult because the new repo URI format
must be known to zypper migration. This requires all software
components to be provided in the live migration image which
has been done in the image description but furthermore requires
that the cloud specific /etc/regionserverclnt.cfg and the
contents of /usr/lib/zypp/plugins from the system to migrate
are available in the migration live image. The later is
implemented in this commit and Fixes #69