### PR TITLE
Fix network setup service

### DIFF
--- a/suse_migration_services/units/setup_host_network.py
+++ b/suse_migration_services/units/setup_host_network.py
@@ -67,12 +67,6 @@ def main():
         system_mount.add_entry(
             sysconfig_network, '/etc/sysconfig/network'
         )
-        Command.run(
-            ['systemctl', 'daemon-reload']
-        )
-        Command.run(
-            ['systemctl', 'restart', 'network']
-        )
         system_mount.export(
             Defaults.get_system_mount_info_file()
         )

--- a/systemd/suse-migration-setup-host-network.service
+++ b/systemd/suse-migration-setup-host-network.service
@@ -2,7 +2,7 @@
 Description=Setup Migration Host Network
 After=suse-migration-mount-system.service
 Requires=suse-migration-mount-system.service
-Before=network.target
+Before=network-pre.target
 
 [Service]
 Type=oneshot

--- a/test/unit/units/setup_host_network_test.py
+++ b/test/unit/units/setup_host_network_test.py
@@ -1,5 +1,5 @@
 from unittest.mock import (
-    patch, call, Mock
+    patch, Mock
 )
 from pytest import raises
 
@@ -54,20 +54,12 @@ class TestSetupHostNetwork(object):
         mock_shutil_copy.assert_called_once_with(
             '/system-root/etc/resolv.conf', '/etc/resolv.conf'
         )
-        assert mock_Command_run.call_args_list == [
-            call(
-                [
-                    'mount', '--bind', '/system-root/etc/sysconfig/network',
-                    '/etc/sysconfig/network'
-                ]
-            ),
-            call(
-                ['systemctl', 'daemon-reload']
-            ),
-            call(
-                ['systemctl', 'restart', 'network']
-            )
-        ]
+        mock_Command_run.assert_called_once_with(
+            [
+                'mount', '--bind', '/system-root/etc/sysconfig/network',
+                '/etc/sysconfig/network'
+            ]
+        )
         fstab.read.assert_called_once_with(
             '/etc/system-root.fstab'
         )


### PR DESCRIPTION
The network setup service for the migration inherits the
network as it is configured on the system to become migrated.
As part of that process the network is restarted through
systemctl. However this is a problem because it interferes
with the network service dependency chain. This could result
in a failed network startup depending on how fast other
services e.g dbus are up and running. So the way we do it
causes a race condition. This commit deletes the network
startup from our network setup service. Our network setup
service runs by definition of the unit file before the
network.target. This means at the time the network service
activates the network our setup routine is already done and
a normal network startup should be guaranteed.