### PR TITLE
Fixed network requirement

### DIFF
--- a/suse_migration_services/units/setup_host_network.py
+++ b/suse_migration_services/units/setup_host_network.py
@@ -67,6 +67,9 @@ def main():
         system_mount.add_entry(
             sysconfig_network, '/etc/sysconfig/network'
         )
+        Command.run(
+            ['systemctl', 'reload', 'network']
+        )
         system_mount.export(
             Defaults.get_system_mount_info_file()
         )

--- a/systemd/suse-migration-console-log.service
+++ b/systemd/suse-migration-console-log.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Show Migration Progress
-ConditionPathExists=/system-root/var/log/zypper_migrate.log
+ConditionPathExists=/system-root/var/log/distro_migration.log
 DefaultDependencies=no
 After=systemd-vconsole-setup.service suse-migration-prepare.service
 Wants=systemd-vconsole-setup.service

--- a/systemd/suse-migration-prepare.service
+++ b/systemd/suse-migration-prepare.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Prepare For Migration
-After=suse-migration-setup-host-network.service network.target
-Requires=suse-migration-mount-system.service suse-migration-setup-host-network.service
+After=suse-migration-setup-host-network.service
+Requires=suse-migration-mount-system.service suse-migration-setup-host-network.service network-online.target
 
 [Service]
 Type=oneshot

--- a/systemd/suse-migration-setup-host-network.service
+++ b/systemd/suse-migration-setup-host-network.service
@@ -2,7 +2,7 @@
 Description=Setup Migration Host Network
 After=suse-migration-mount-system.service
 Requires=suse-migration-mount-system.service
-Before=network-pre.target
+After=network.target
 
 [Service]
 Type=oneshot

--- a/test/unit/units/setup_host_network_test.py
+++ b/test/unit/units/setup_host_network_test.py
@@ -1,5 +1,5 @@
 from unittest.mock import (
-    patch, Mock
+    patch, call, Mock
 )
 from pytest import raises
 
@@ -54,12 +54,17 @@ class TestSetupHostNetwork(object):
         mock_shutil_copy.assert_called_once_with(
             '/system-root/etc/resolv.conf', '/etc/resolv.conf'
         )
-        mock_Command_run.assert_called_once_with(
-            [
-                'mount', '--bind', '/system-root/etc/sysconfig/network',
-                '/etc/sysconfig/network'
-            ]
-        )
+        assert mock_Command_run.call_args_list == [
+            call(
+                [
+                    'mount', '--bind', '/system-root/etc/sysconfig/network',
+                    '/etc/sysconfig/network'
+                ]
+            ),
+            call(
+                ['systemctl', 'reload', 'network']
+            )
+        ]
         fstab.read.assert_called_once_with(
             '/etc/system-root.fstab'
         )


### PR DESCRIPTION
To come up with a race free network start the setup-host-network
service has to be called after network.target. This ensures the
wicked service is already active. An active wicked service allows
for a reload of the network service. The setup-host-network
service overmounts /etc/sysconfig/network and reloads the network
service. That tells the running wicked service to elaborate
over the new ifcfg configurations and updates the network status.
In the prepare unit we require the network-online target which
makes sure it operates only on an online network.