### PR TITLE
Split activation package from services

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,10 @@
 # Manifest describing source package contents
 
+prune grub.d
+
 graft suse_migration_services/units
 graft package
 graft systemd
-graft grub.d
 
 include tox.ini
 include README.md

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,15 @@ build: check test
 	# provide rpm rpmlintrc
 	cp package/suse-migration-services-rpmlintrc dist
 
+sle15_activation: check
+	rm -f dist/*
+	git log grub.d | helper/changelog_generator |\
+		helper/changelog_descending > \
+		dist/suse-migration-sle15-activation.changes
+	cp package/suse-migration-sle15-activation-spec-template \
+		dist/suse-migration-sle15-activation.spec
+	tar -czf dist/suse-migration-sle15-activation.tar.gz grub.d
+
 .PHONY: test
 test:
 	tox -e unit_py3

--- a/package/suse-migration-services-rpmlintrc
+++ b/package/suse-migration-services-rpmlintrc
@@ -10,7 +10,3 @@ addFilter("systemd-service-without-service_del_preun .*")
 
 # Migration services runs once and never manually
 addFilter("suse-missing-rclink .*")
-
-# etc/grub.d plugins are called in the scope of grub2-mkconfig
-# None of them has a shebang because never called standalone
-addFilter("script-without-shebang .*")

--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -42,16 +42,6 @@ BuildArch:        noarch
 %description
 Systemd services to prepare and run a distribution migration process.
 
-%package -n suse-migration-activation
-Summary:        LoopBack Grub Activation
-License:        GPL-3.0+
-Group:          System/Management
-
-%description -n suse-migration-activation
-Script code to activate the migration image to be booted at next
-reboot of the machine. The script provided here is typically used
-as post script of the package provding the migration image
-
 %prep
 %setup -q -n suse_migration_services-%{version}
 
@@ -94,9 +84,6 @@ install -D -m 644 systemd/suse-migration-ssh-keys.service \
 install -D -m 644 systemd/suse-migration-console-log.service \
     %{buildroot}%{_unitdir}/suse-migration-console-log.service
 
-install -D -m 755 grub.d/99_migration \
-    %{buildroot}/etc/grub.d/99_migration
-
 # preun / postun
 # While the package provides services all services are one-shot.
 # Additionally this services runs as part of a live ISO migration
@@ -138,10 +125,5 @@ install -D -m 755 grub.d/99_migration \
 
 %{_bindir}/suse-migration-reboot
 %{_unitdir}/suse-migration-reboot.service
-
-%files -n suse-migration-activation
-%defattr(-,root,root,-)
-%dir /etc/grub.d
-/etc/grub.d/*
 
 %changelog

--- a/package/suse-migration-sle15-activation-spec-template
+++ b/package/suse-migration-sle15-activation-spec-template
@@ -1,0 +1,51 @@
+#
+# spec file for package suse-migration-activation
+#
+# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+
+Name:             suse-migration-sle15-activation
+Version:          1.2.0
+Release:          0
+Url:              https://github.com/SUSE/suse-migration-services
+Summary:          SUSE Distribution SLE15 Migration Activation
+License:          GPL-3.0+
+Group:            System/Management
+Source:           suse-migration-sle15-activation.tar.gz
+BuildRoot:        %{_tmppath}/%{name}-%{version}-build
+BuildArch:        noarch
+BuildRequires:    grub2
+Requires:         SLES15-Migration
+Requires:         grub2
+
+%description -n suse-migration-sle15-activation
+Script code to activate the SLE15 migration image to be booted at
+next reboot of the machine.
+
+%prep
+%setup -q -n grub.d
+
+install -D -m 755 99_migration \
+    %{buildroot}/etc/grub.d/99_migration
+
+%post
+/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
+
+%files
+%defattr(-,root,root,-)
+%dir /etc/grub.d
+/etc/grub.d/*
+
+%changelog


### PR DESCRIPTION
From a release process it doesn't make sense to keep the activation
script as a sub package of the services. The reason is because the
suse-migration-services package will be released to the migration
target distribution and the activation package will be released to
the migration start distribution. Thus the code is relevant on
different distributions and it is not useful to maintain that in
one package. This Fixes #74