### PR TITLE
Allow specify target

### DIFF
--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -39,9 +39,16 @@ class Defaults(object):
         )
 
     @classmethod
-    def get_system_migration_debug_file(self):
+    def get_system_migration_config_file(self):
         return os.sep.join(
-            [self.get_system_root_path(), 'etc/sle-migration-service']
+            [self.get_system_root_path(), 'etc/sle-migration-service.yml']
+        )
+
+    @classmethod
+    def get_system_migration_config_values(self):
+        return dict(
+            debug='false',
+            migration='migration'
         )
 
     @classmethod

--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -45,13 +45,6 @@ class Defaults(object):
         )
 
     @classmethod
-    def get_system_migration_config_values(self):
-        return dict(
-            debug='false',
-            migration='migration'
-        )
-
-    @classmethod
     def get_system_mount_info_file(self):
         return '/etc/system-root.fstab'
 

--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -84,9 +84,15 @@ def get_migration_product():
     zypper migration call
     """
     config = _read_migration_config()
-    return config['migration']['target']['product']
+    migration_product = config['migration']['target']['product']
+    target_products = dict(ses='SLES/15.1/x86_64', sles='SLES/15/x86_64')
+    if migration_product in target_products:
+        migration_product = target_products[migration_product]
+
+    log.info('The migration product is {0}'.format(migration_product))
+    return migration_product
 
 
 def _read_migration_config():
     with open(Defaults.get_migration_config_file(), 'r') as config:
-        return yaml.load(config)
+        return yaml.full_load(config)

--- a/suse_migration_services/units/mount_system.py
+++ b/suse_migration_services/units/mount_system.py
@@ -110,7 +110,7 @@ def main():
     mount_system(root_path, fstab)
 
     initialize_logging()
-    initialize_system_config()
+    initialize_migration_config()
 
 
 def initialize_logging():
@@ -119,7 +119,7 @@ def initialize_logging():
         log.set_logfile(Defaults.get_migration_log_file())
 
 
-def initialize_system_config():
+def initialize_migration_config():
     migration_config_file = Defaults.get_system_migration_config_file()
     # delete potentially existing migration config file from migration live system
     Path.wipe(
@@ -135,10 +135,10 @@ def initialize_system_config():
         target_config_file_path = os.sep.join(
             ['/etc', os.path.basename(migration_config_file)]
         )
-        create_migration_file(target_config_file_path)
+        create_migration_config_file(target_config_file_path)
 
 
-def create_migration_file(target_config_file_path):
+def create_migration_config_file(target_config_file_path):
     data = Defaults.get_system_migration_config_values()
 
     with open(target_config_file_path, 'w') as config:

--- a/suse_migration_services/units/reboot.py
+++ b/suse_migration_services/units/reboot.py
@@ -16,6 +16,7 @@
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import yaml
 
 # project
 from suse_migration_services.command import Command
@@ -27,10 +28,6 @@ def main():
     """
     DistMigration reboot with new kernel
     """
-    debug_file = os.sep.join(
-        ['/etc', os.path.basename(Defaults.get_system_migration_debug_file())]
-    )
-
     try:
         # Note:
         # After the migration process is finished, the system reboots
@@ -42,7 +39,7 @@ def main():
                 ).output
             )
         )
-        if os.path.exists(debug_file):
+        if is_debug_mode():
             log.info('Reboot skipped due to debug flag set')
         else:
             log.info('Reboot system: [kexec]')
@@ -57,3 +54,19 @@ def main():
         Command.run(
             ['reboot', '-f']
         )
+
+
+def is_debug_mode():
+    """
+    Returns True or False depending on debug mode
+    """
+    migration_config_file = os.sep.join(
+        ['/etc', os.path.basename(Defaults.get_system_migration_config_file())]
+    )
+    config = _read_system_migration_config(migration_config_file)
+    return config['debug']
+
+
+def _read_system_migration_config(config_file_path):
+    with open(config_file_path, 'r') as config:
+        return yaml.load(config)

--- a/suse_migration_services/units/reboot.py
+++ b/suse_migration_services/units/reboot.py
@@ -61,9 +61,10 @@ def is_debug_mode():
     Returns True or False depending on debug property of system
     migration config file
     """
-    migration_config_file = os.sep.join(
-        ['/etc', os.path.basename(Defaults.get_system_migration_config_file())]
-    )
-    with open(migration_config_file, 'r') as config:
-        config = yaml.load(config)
-    return config['debug']
+    with open(Defaults.get_migration_config_file(), 'r') as config:
+        config = yaml.full_load(config)
+        is_debug_mode = False
+        if 'debug' in config:
+            is_debug_mode = config['debug']
+
+        return is_debug_mode

--- a/suse_migration_services/units/reboot.py
+++ b/suse_migration_services/units/reboot.py
@@ -58,15 +58,12 @@ def main():
 
 def is_debug_mode():
     """
-    Returns True or False depending on debug mode
+    Returns True or False depending on debug property of system
+    migration config file
     """
     migration_config_file = os.sep.join(
         ['/etc', os.path.basename(Defaults.get_system_migration_config_file())]
     )
-    config = _read_system_migration_config(migration_config_file)
+    with open(migration_config_file, 'r') as config:
+        config = yaml.load(config)
     return config['debug']
-
-
-def _read_system_migration_config(config_file_path):
-    with open(config_file_path, 'r') as config:
-        return yaml.load(config)

--- a/test/data/system_migration_service.yml
+++ b/test/data/system_migration_service.yml
@@ -1,2 +1,5 @@
 debug: true
-migration: 'migration'
+migration:
+  type: 'migration'
+  target:
+    product: 'sles'

--- a/test/data/system_migration_service.yml
+++ b/test/data/system_migration_service.yml
@@ -1,0 +1,2 @@
+debug: true
+migration: 'migration'

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -60,3 +60,30 @@ class TestMigration(object):
             ]
         )
         assert mock_info.called
+
+    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.command.Command.run')
+    @patch.object(Defaults, 'get_migration_config_file')
+    def test_main_specified_product(
+        self, mock_get_migration_config_file,
+        mock_Command_run, mock_info
+    ):
+        mock_get_migration_config_file.return_value = \
+            '../data/system_migration_service.yml'
+        main()
+        mock_Command_run.assert_called_once_with(
+            [
+                'bash', '-c',
+                'zypper migration '
+                '--non-interactive '
+                '--gpg-auto-import-keys '
+                '--no-selfupdate '
+                '--auto-agree-with-licenses '
+                '--strict-errors-dist-migration '
+                '--replacefiles '
+                '--product SLES/15/x86_64 '
+                '--root /system-root '
+                '&>> /system-root/var/log/distro_migration.log'
+            ]
+        )
+        assert mock_info.called

--- a/test/unit/units/mount_system_test.py
+++ b/test/unit/units/mount_system_test.py
@@ -204,7 +204,7 @@ class TestMountSystem(object):
     @patch('suse_migration_services.units.mount_system.Fstab')
     @patch('suse_migration_services.units.mount_system.is_mounted')
     @patch('os.path.exists')
-    def test_main_create_migration_config(
+    def test_main_create_migration_config_file(
         self, mock_path_exists, mock_is_mounted, mock_Fstab,
         mock_Command_run, mock_info  # , mock_log_file
     ):

--- a/test/unit/units/reboot_test.py
+++ b/test/unit/units/reboot_test.py
@@ -2,12 +2,23 @@ from unittest.mock import (
     patch, call, MagicMock
 )
 from suse_migration_services.units.reboot import main, is_debug_mode
+from suse_migration_services.defaults import Defaults
 
 
 class TestKernelReboot(object):
-    @patch('os.sep')
-    def test_is_debug_mode(self, mock_os_sep_join):
-        mock_os_sep_join.join.return_value = '../data/system_migration_service.yml'
+    @patch.object(Defaults, 'get_migration_config_file')
+    def test_is_not_debug_mode(self, mock_get_migration_config_file):
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config.yml'
+
+        result = is_debug_mode()
+        assert not result
+
+    @patch.object(Defaults, 'get_migration_config_file')
+    def test_is_debug_mode(self, mock_get_migration_config_file):
+        mock_get_migration_config_file.return_value = \
+            '../data/system_migration_service.yml'
+
         result = is_debug_mode()
         assert result
 

--- a/test/unit/units/reboot_test.py
+++ b/test/unit/units/reboot_test.py
@@ -1,47 +1,53 @@
 from unittest.mock import (
     patch, call, MagicMock
 )
-from suse_migration_services.units.reboot import main
+from suse_migration_services.units.reboot import main, _read_system_migration_config
+import yaml
 
 
 class TestKernelReboot(object):
-    @patch('os.path.exists')
-    @patch('suse_migration_services.logger.log.warning')
+    def test_read_system_migration_config(self):
+        result = _read_system_migration_config('../data/system_migration_service.yml')
+        assert result == {'debug': True, 'migration': 'migration'}
+
+    @patch('suse_migration_services.units.reboot._read_system_migration_config')
     @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.command.Command.run')
     def test_main_skip_reboot_due_to_debug_file_set(
-        self, mock_Command_run, mock_info, mock_warning, mock_path_exists
+        self, mock_Command_run, mock_info, mock_read_values
     ):
-        mock_path_exists.return_value = True
+        with open('../data/system_migration_service.yml') as fake_config:
+            fake_config = yaml.load(fake_config)
         main()
         assert mock_info.called
 
+    @patch('suse_migration_services.units.reboot.is_debug_mode')
     @patch('os.path.exists')
     @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.command.Command.run')
     def test_main_kexec_reboot(
-        self, mock_Command_run, mock_info, mock_path_exists
+        self, mock_Command_run, mock_info, mock_path_exists, mock_mode
     ):
         mock_path_exists.return_value = False
+        mock_mode.return_value = False
         main()
-        mock_path_exists.assert_called_once_with(
-            '/etc/sle-migration-service'
-        )
         assert mock_info.called
         assert mock_Command_run.call_args_list == [
             call(['systemctl', 'status', '-l', '--all'], raise_on_error=False),
             call(['kexec', '--exec'])
         ]
 
+    @patch('suse_migration_services.units.reboot.is_debug_mode')
     @patch('suse_migration_services.logger.log.warning')
     @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.command.Command.run')
     def test_main_force_reboot(
-        self, mock_Command_run, mock_info, mock_warning
+        self, mock_Command_run, mock_info, mock_warning, mock_path_exists
     ):
         mock_Command_run.side_effect = [
             MagicMock(), Exception, None
         ]
+        mock_path_exists.return_value = False
         main()
         assert mock_info.called
         assert mock_Command_run.call_args_list == [


### PR DESCRIPTION
Allow specify target product to migrate in optional
configuration file, following a defined structure.
It merges the new configuration into the provided file,
so the services handles only one file.
This Fixes #73
