### PR TITLE
Change debug flag file to option

### DIFF
--- a/suse_migration_services/migration_config.py
+++ b/suse_migration_services/migration_config.py
@@ -56,3 +56,6 @@ class MigrationConfig(object):
             raise DistMigrationProductNotFoundException(message)
 
         return migration_product
+
+    def is_debug_requested(self):
+        return self.config_data.get('debug', False)

--- a/suse_migration_services/units/reboot.py
+++ b/suse_migration_services/units/reboot.py
@@ -22,6 +22,7 @@ from suse_migration_services.command import Command
 from suse_migration_services.logger import log
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.fstab import Fstab
+from suse_migration_services.migration_config import MigrationConfig
 
 
 def main():
@@ -40,10 +41,6 @@ def main():
     reboot of the migration host with a potential active mount
     is something we accept
     """
-    debug_file = os.sep.join(
-        ['/etc', os.path.basename(Defaults.get_system_migration_debug_file())]
-    )
-
     try:
         log.info(
             'Systemctl Status Information: {0}{1}'.format(
@@ -52,7 +49,7 @@ def main():
                 ).output
             )
         )
-        if os.path.exists(debug_file):
+        if MigrationConfig().is_debug_requested():
             log.info('Reboot skipped due to debug flag set')
         else:
             log.info('Umounting system')

--- a/test/data/optional-migration-config.yml
+++ b/test/data/optional-migration-config.yml
@@ -1,0 +1,1 @@
+debug: true

--- a/test/unit/migration_config_test.py
+++ b/test/unit/migration_config_test.py
@@ -25,3 +25,6 @@ class TestMigrationConfig(object):
         with raises(DistMigrationProductNotFoundException):
             self.config.get_migration_product()
             assert mock_error.called
+
+    def test_is_debug_requested(self):
+        assert not self.config.is_debug_requested()


### PR DESCRIPTION
Before, to stop rebooting it was needed to place a
file as a debug flag. Now there must be a debug key option set
in the custom file.