### PR TITLE
Use `uniq` when finding root device in grub activation script

### DIFF
--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -14,7 +14,7 @@ else
 fi
 
 migration_iso=$(echo /usr/share/migration-image/*-Migration.*.iso)
-root_device=$(lsblk -p -n -r -o NAME,MOUNTPOINT | grep -E "/$" | cut -f1 -d" ")
+root_device=$(lsblk -p -n -r -o NAME,MOUNTPOINT | grep -E "/$" | uniq | cut -f1 -d" ")
 root_uuid=$(blkid -s UUID -o value "${root_device}")
 root_type=$(blkid -s TYPE -o value "${root_device}")
 


### PR DESCRIPTION
If the system is using mdraid on the root disk, the `lsblk` invocation
will return two lines matching "/$", e.g.:

/dev/md1
/dev/md1

This then breaks the subsequent `blkid` invocations, so $root_uuid and
$root_type are set to empty strings.  When you later boot into the
migration system, grub gives two errors:

error: one argument expected.
error: no such device: root.

Adding `uniq` fixes this.