### PR TITLE
Add support for zypper dup mode

### DIFF
--- a/suse_migration_services/migration_config.py
+++ b/suse_migration_services/migration_config.py
@@ -86,6 +86,9 @@ class MigrationConfig(object):
     def is_debug_requested(self):
         return self.config_data.get('debug', False)
 
+    def is_zypper_migration_plugin_requested(self):
+        return self.config_data.get('use_zypper_migration_plugin', True)
+
     def _write_config_file(self):
         with open(self.migration_config_file, 'w') as config:
             yaml.dump(self.config_data, config, default_flow_style=False)

--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -24,7 +24,8 @@ from suse_migration_services.defaults import Defaults
 from suse_migration_services.logger import log
 
 from suse_migration_services.exceptions import (
-    DistMigrationZypperException
+    DistMigrationZypperException,
+    DistMigrationCommandException
 )
 
 
@@ -39,23 +40,47 @@ def main():
 
     try:
         log.info('Running migrate service')
-        bash_command = ' '.join(
-            [
-                'zypper', 'migration',
-                '--non-interactive',
-                '--gpg-auto-import-keys',
-                '--no-selfupdate',
-                '--auto-agree-with-licenses',
-                '--strict-errors-dist-migration',
-                '--replacefiles',
-                '--product', MigrationConfig().get_migration_product(),
-                '--root', root_path,
-                '&>>', Defaults.get_migration_log_file()
-            ]
-        )
-        Command.run(
-            ['bash', '-c', bash_command]
-        )
+        migration_config = MigrationConfig()
+        if migration_config.is_zypper_migration_plugin_requested():
+            bash_command = ' '.join(
+                [
+                    'zypper', 'migration',
+                    '--non-interactive',
+                    '--gpg-auto-import-keys',
+                    '--no-selfupdate',
+                    '--auto-agree-with-licenses',
+                    '--strict-errors-dist-migration',
+                    '--replacefiles',
+                    '--product', migration_config.get_migration_product(),
+                    '--root', root_path,
+                    '&>>', Defaults.get_migration_log_file()
+                ]
+            )
+            Command.run(
+                ['bash', '-c', bash_command]
+            )
+        else:
+            bash_command = ' '.join(
+                [
+                    'zypper',
+                    '--non-interactive',
+                    '--gpg-auto-import-keys',
+                    '--root', root_path,
+                    'dup',
+                    '--auto-agree-with-licenses',
+                    '--replacefiles',
+                    '&>>', Defaults.get_migration_log_file()
+                ]
+            )
+            zypper_call = Command.run(
+                ['bash', '-c', bash_command], raise_on_error=False
+            )
+            if zypper_has_failed(zypper_call.returncode):
+                raise DistMigrationCommandException(
+                    '{0} failed with: {1}: {2}'.format(
+                        bash_command, zypper_call.output, zypper_call.error
+                    )
+                )
     except Exception as issue:
         etc_issue_path = os.sep.join(
             [root_path, 'etc/issue']
@@ -65,12 +90,44 @@ def main():
         )
         with open(etc_issue_path, 'w') as issue_file:
             issue_file.write(
-                'Migration has failed, for further details see {0}'
-                .format(log_path_migrated_system)
+                'Migration has failed, for further details see {0}'.format(
+                    log_path_migrated_system
+                )
             )
         log.error('migrate service failed with {0}'.format(issue))
         raise DistMigrationZypperException(
-            'Migration failed with {0}'.format(
-                issue
-            )
+            'Migration failed with {0}'.format(issue)
         )
+
+
+def zypper_has_failed(returncode):
+    """
+    Evaluate given result return code
+
+    In zypper any return code == 0 or >= 100 is considered success.
+    Any return code different from 0 and < 100 is treated as an
+    error we care for. Return codes >= 100 indicates an issue
+    like 'new kernel needs reboot of the system' or similar which
+    we don't care in the scope of image building
+
+    :param int returncode: return code number
+
+    :return: True|False
+
+    :rtype: boolean
+    """
+    if returncode == 0:
+        # All is good
+        return False
+    elif returncode == 104 or returncode == 105 or returncode == 106:
+        # Treat the following exit codes as error
+        # 104 - ZYPPER_EXIT_INF_CAP_NOT_FOUND
+        # 105 - ZYPPER_EXIT_ON_SIGNAL
+        # 106 - ZYPPER_EXIT_INF_REPOS_SKIPPED
+        return True
+    elif returncode >= 100:
+        # Treat all other 100 codes as non error codes
+        return False
+
+    # Treat any other error code as error
+    return True

--- a/test/data/migration-config-zypper-dup.yml
+++ b/test/data/migration-config-zypper-dup.yml
@@ -1,0 +1,1 @@
+use_zypper_migration_plugin: false

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -1,0 +1,10 @@
+from suse_migration_services.defaults import Defaults
+
+
+class TestDefaults(object):
+    def setup(self):
+        self.defaults = Defaults()
+
+    def test_get_migration_config_file(self):
+        assert self.defaults.get_migration_config_file() == \
+            '/etc/migration-config.yml'

--- a/test/unit/migration_config_test.py
+++ b/test/unit/migration_config_test.py
@@ -45,8 +45,11 @@ class TestMigrationConfig(object):
         assert self.config.is_debug_requested() is True
         assert mock_info.called
 
+    def test_is_zypper_migration_plugin_requested(self):
+        assert self.config.is_zypper_migration_plugin_requested() is True
+
     def test_is_debug_requested(self):
-        assert not self.config.is_debug_requested()
+        assert self.config.is_debug_requested() is False
 
     @patch('yaml.dump')
     def test_write_config_file(self, mock_yaml_dump):


### PR DESCRIPTION
By default the migration system uses the zypper migration plugin
to migrate the system. This works if the system is SLES registered
and an upgrade path from SCC exists. For system where this is not
possible an alternative method can be switched on with the
custom configuration option use_zypper_migration_plugin set
to: false. In this mode we just call zypper dup. Please note
this requires that the user has pre setup the repositories before
the migration system gets started. This Fixes #72