### PR TITLE
Rebuild grub conf on uninstall of activation rpm

### DIFF
--- a/package/suse-migration-sle15-activation-spec-template
+++ b/package/suse-migration-sle15-activation-spec-template
@@ -47,6 +47,9 @@ install -D -m 755 99_migration \
 %post
 /usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
 
+%postun
+/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
+
 %files
 %defattr(-,root,root,-)
 %dir /etc/grub.d


### PR DESCRIPTION
If the activation package is installed a grub config file
extension is applied. On uninstall of the package that
extension will be deleted but it only becomes effective
if the grub config will be rebuild. This Fixes #94