### PR TITLE
Fix grub setup if root is on a raid device

### DIFF
--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -17,12 +17,15 @@ migration_iso=$(echo /usr/share/migration-image/*-Migration.*.iso)
 root_device=$(lsblk -p -n -r -o NAME,MOUNTPOINT | grep -E "/$" | uniq | cut -f1 -d" ")
 root_uuid=$(blkid -s UUID -o value "${root_device}")
 root_type=$(blkid -s TYPE -o value "${root_device}")
+boot_options="rd.live.image root=live:CDLABEL=CDROM"
+if mdadm --detail "${root_device}" &>/dev/null; then
+    boot_options="${boot_options} rd.auto"
+fi
 
 if grub_file_is_not_garbage "${migration_iso}"; then
     kernel="(loop)/boot/x86_64/loader/linux"
     initrd="(loop)/boot/x86_64/loader/initrd"
     boot_device_id="$(grub_get_device_id "${GRUB_DEVICE_BOOT}")"
-    boot_options="rd.live.image root=live:CDLABEL=CDROM"
     printf "menuentry '%s' %s \${menuentry_id_option} '%s' {\n" \
         "${OS}" "${CLASS}" "Migration-${boot_device_id}"
     printf "    insmod %s\n" "${root_type}"


### PR DESCRIPTION
If the root filesystem is on a raid device the boot parameter
rd.auto must be passed to the boot such that the dracut raid
module can setup the raid prior to iso-scan.sh searching
through the devices. Related to Issue #96