### PR TITLE
Try to mount raid1 partitions

### DIFF
--- a/suse_migration_services/units/mount_system.py
+++ b/suse_migration_services/units/mount_system.py
@@ -77,7 +77,7 @@ def main():
     log.info('Mount system service: mounting all entries')
     for entry in lsblk_call.output.split(os.linesep):
         block_record = entry.split()
-        if block_record and block_record[1] == 'part':
+        if block_record and (block_record[1] == 'part' or block_record[1].startswith('raid')):
             try:
                 Command.run(
                     ['mount', block_record[0], root_path],


### PR DESCRIPTION
`lsblk` returns "raid1" for /dev/md devices, so we need to attempt
to mount these as well as regular partitions in case the root disk
is on mdraid. Fixes #96.