### PR TITLE
Provide detailed network information

### DIFF
--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -75,3 +75,7 @@ class Defaults(object):
         return os.sep.join(
             [self.get_system_root_path(), prefix_path, '.ssh/authorized_keys']
         )
+
+    @classmethod
+    def get_bonding_paths(self):
+        return '/proc/net/bonding/bond*'

--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -75,7 +75,3 @@ class Defaults(object):
         return os.sep.join(
             [self.get_system_root_path(), prefix_path, '.ssh/authorized_keys']
         )
-
-    @classmethod
-    def get_bonding_paths(self):
-        return '/proc/net/bonding/bond*'

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -124,13 +124,15 @@ def main():
                 ).output
             )
         )
-        log.info(
-            'Network Bonding {0}{1}'.format(
-                os.linesep, Command.run(
-                    ['cat', '/proc/net/bonding/bond*'], raise_on_error=False
-                ).output
+        bonding_paths = Defaults.get_bonding_paths()
+        if os.path.exists(os.path.dirname(bonding_paths)):
+            log.info(
+                'Network Bonding {0}{1}'.format(
+                    os.linesep, Command.run(
+                        ['cat', bonding_paths], raise_on_error=False
+                    ).output
+                )
             )
-        )
         log.info('Running prepare service')
         system_mount = Fstab()
         system_mount.read(

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -24,6 +24,9 @@ from suse_migration_services.command import Command
 from suse_migration_services.fstab import Fstab
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.logger import log
+from suse_migration_services.units.setup_host_network import (
+    log_network_details
+)
 
 from suse_migration_services.exceptions import (
     DistMigrationZypperMetaDataException
@@ -103,36 +106,7 @@ def main():
     )
     try:
         # log network info as network-online.target is done at this point
-        log.info(
-            'All Network Interfaces {0}{1}'.format(
-                os.linesep, Command.run(
-                    ['ip', 'a'], raise_on_error=False
-                ).output
-            )
-        )
-        log.info(
-            'Routing Tables {0}{1}'.format(
-                os.linesep, Command.run(
-                    ['ip', 'r'], raise_on_error=False
-                ).output
-            )
-        )
-        log.info(
-            'DNS Resolver {0}{1}'.format(
-                os.linesep, Command.run(
-                    ['cat', '/etc/resolv.conf'], raise_on_error=False
-                ).output
-            )
-        )
-        bonding_paths = Defaults.get_bonding_paths()
-        if os.path.exists(os.path.dirname(bonding_paths)):
-            log.info(
-                'Network Bonding {0}{1}'.format(
-                    os.linesep, Command.run(
-                        ['cat', bonding_paths], raise_on_error=False
-                    ).output
-                )
-            )
+        log_network_details()
         log.info('Running prepare service')
         system_mount = Fstab()
         system_mount.read(

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -102,6 +102,35 @@ def main():
         [root_path, 'sys']
     )
     try:
+        # log network info as network-online.target is done at this point
+        log.info(
+            'All Network Interfaces {0}{1}'.format(
+                os.linesep, Command.run(
+                    ['ip', 'a'], raise_on_error=False
+                ).output
+            )
+        )
+        log.info(
+            'Routing Tables {0}{1}'.format(
+                os.linesep, Command.run(
+                    ['ip', 'r'], raise_on_error=False
+                ).output
+            )
+        )
+        log.info(
+            'DNS Resolver {0}{1}'.format(
+                os.linesep, Command.run(
+                    ['cat', '/etc/resolv.conf'], raise_on_error=False
+                ).output
+            )
+        )
+        log.info(
+            'Network Bonding {0}{1}'.format(
+                os.linesep, Command.run(
+                    ['cat', '/proc/net/bonding/bond*'], raise_on_error=False
+                ).output
+            )
+        )
         log.info('Running prepare service')
         system_mount = Fstab()
         system_mount.read(

--- a/suse_migration_services/units/setup_host_network.py
+++ b/suse_migration_services/units/setup_host_network.py
@@ -84,3 +84,42 @@ def main():
                 issue
             )
         )
+
+
+def log_network_details():
+    """
+    Provide detailed information about the current network setup
+
+    The method must be called in an active and online network state to provide
+    most useful information about the network interfaces and its setup.
+    """
+    log.info(
+        'All Network Interfaces {0}{1}'.format(
+            os.linesep, Command.run(
+                ['ip', 'a'], raise_on_error=False
+            ).output
+        )
+    )
+    log.info(
+        'Routing Tables {0}{1}'.format(
+            os.linesep, Command.run(
+                ['ip', 'r'], raise_on_error=False
+            ).output
+        )
+    )
+    log.info(
+        'DNS Resolver {0}{1}'.format(
+            os.linesep, Command.run(
+                ['cat', '/etc/resolv.conf'], raise_on_error=False
+            ).output
+        )
+    )
+    bonding_paths = '/proc/net/bonding/bond*'
+    if os.path.exists(os.path.dirname(bonding_paths)):
+        log.info(
+            'Network Bonding {0}{1}'.format(
+                os.linesep, Command.run(
+                    ['cat', bonding_paths], raise_on_error=False
+                ).output
+            )
+        )

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -1,5 +1,5 @@
 from unittest.mock import (
-    patch, call, Mock
+    patch, call, Mock, MagicMock
 )
 
 from pytest import raises
@@ -26,7 +26,13 @@ class TestSetupPrepare(object):
     ):
         mock_os_listdir.return_value = None
         mock_os_path_exists.return_value = True
-        mock_Command_run.side_effect = Exception
+        mock_Command_run.side_effect = [
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            Exception
+        ]
         with raises(DistMigrationZypperMetaDataException):
             main()
             assert mock_info.called
@@ -54,6 +60,10 @@ class TestSetupPrepare(object):
         with raises(DistMigrationZypperMetaDataException):
             main()
             assert mock_Command_run.call_args_list == [
+                call(['ip', 'a'], raise_on_error=False),
+                call(['ip', 'r'], raise_on_error=False),
+                call(['cat', '/etc/resolv.conf'], raise_on_error=False),
+                call(['cat', '/proc/net/bonding/bond*'], raise_on_error=False),
                 call(['umount', '/system-root/sys'], raise_on_error=False),
                 call(['umount', '/system-root/proc'], raise_on_error=False),
                 call(['umount', '/system-root/dev'], raise_on_error=False)
@@ -99,6 +109,30 @@ class TestSetupPrepare(object):
                 [
                     'update-ca-certificates'
                 ]
+            ),
+            call(
+                [
+                    'ip', 'a'
+                ],
+                raise_on_error=False
+            ),
+            call(
+                [
+                    'ip', 'r'
+                ],
+                raise_on_error=False
+            ),
+            call(
+                [
+                    'cat', '/etc/resolv.conf'
+                ],
+                raise_on_error=False
+            ),
+            call(
+                [
+                    'cat', '/proc/net/bonding/bond*'
+                ],
+                raise_on_error=False
             ),
             call(
                 [

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -106,39 +106,22 @@ class TestSetupPrepare(object):
         )
         assert mock_Command_run.call_args_list == [
             call(
-                [
-                    'update-ca-certificates'
-                ]
+                ['update-ca-certificates']
             ),
             call(
-                [
-                    'ip', 'a'
-                ],
-                raise_on_error=False
+                ['ip', 'a'], raise_on_error=False
             ),
             call(
-                [
-                    'ip', 'r'
-                ],
-                raise_on_error=False
+                ['ip', 'r'], raise_on_error=False
             ),
             call(
-                [
-                    'cat', '/etc/resolv.conf'
-                ],
-                raise_on_error=False
+                ['cat', '/etc/resolv.conf'], raise_on_error=False
             ),
             call(
-                [
-                    'cat', '/proc/net/bonding/bond*'
-                ],
-                raise_on_error=False
+                ['cat', '/proc/net/bonding/bond*'], raise_on_error=False
             ),
             call(
-                [
-                    'mount', '--bind', '/system-root/etc/zypp',
-                    '/etc/zypp'
-                ]
+                ['mount', '--bind', '/system-root/etc/zypp', '/etc/zypp']
             ),
             call(
                 [
@@ -153,22 +136,13 @@ class TestSetupPrepare(object):
                 ]
             ),
             call(
-                [
-                    'mount', '-t', 'devtmpfs', 'devtmpfs',
-                    '/system-root/dev'
-                ]
+                ['mount', '-t', 'devtmpfs', 'devtmpfs', '/system-root/dev']
             ),
             call(
-                [
-                    'mount', '-t', 'proc', 'proc',
-                    '/system-root/proc'
-                ]
+                ['mount', '-t', 'proc', 'proc', '/system-root/proc']
             ),
             call(
-                [
-                    'mount', '-t', 'sysfs', 'sysfs',
-                    '/system-root/sys'
-                ]
+                ['mount', '-t', 'sysfs', 'sysfs', '/system-root/sys']
             )
         ]
         fstab.read.assert_called_once_with(

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -195,3 +195,6 @@ class TestSetupPrepare(object):
             '/etc/system-root.fstab'
         )
         assert mock_info.called
+        mock_Command_run.assert_any_call(
+            ['cat', '/proc/net/bonding/bond*'], raise_on_error=False
+        )


### PR DESCRIPTION
After network.online target is done, we log
the network status, interfaces and relevant information.

Fixes #84