### PR TITLE
Ignore blank lines and comments when parsing fstab

### DIFF
--- a/suse_migration_services/fstab.py
+++ b/suse_migration_services/fstab.py
@@ -43,6 +43,8 @@ class Fstab(object):
         with open(filename) as fstab:
             for line in fstab.readlines():
                 mount_record = line.split()
+                if not mount_record or mount_record[0].startswith('#'):
+                    continue
                 device = mount_record[0]
                 mountpoint = mount_record[1]
                 fstype = mount_record[2]

--- a/test/data/fstab
+++ b/test/data/fstab
@@ -3,3 +3,5 @@ UUID=daa5a8c3-5c72-4343-a1d4-bb74ec4e586e  swap       swap  defaults        0  0
 UUID=FCF7-B051                             /boot/efi  vfat  defaults        0  0
 LABEL=foo  /home      ext4  defaults        0  0
 /dev/mynode /foo ext4 defaults 0 0
+
+# this comment line and the line above should be ignored by the parser


### PR DESCRIPTION
This fixes the commented / blank line issue mentioned in #110