### PR TITLE
- Only attempt to mount filesystems from the host that my be part of the "core system"

### DIFF
--- a/suse_migration_services/fstab.py
+++ b/suse_migration_services/fstab.py
@@ -58,6 +58,9 @@ class Fstab(object):
                         device_path = ''.join(
                             ['/dev/disk/by-label/', device.split('=')[1]]
                         )
+                    elif device.startswith('PARTUUID'):
+                        device_path = ''.join(
+                            ['/dev/disk/by-by-partuuid/', device.split('=')[1]]
                     else:
                         device_path = device
                     self.fstab.append(

--- a/suse_migration_services/units/mount_system.py
+++ b/suse_migration_services/units/mount_system.py
@@ -122,8 +122,15 @@ def initialize_logging():
 def mount_system(root_path, fstab):
     log.info('Mount system in {0}'.format(root_path))
     mount_list = []
+    # Having parts of the system on NFS is currently not supported
+    supported_mount_types = ['LABEL', 'PARTUUID', 'UUID']
     system_mount = Fstab()
     for fstab_entry in fstab.get_devices():
+        if '=' in fstab_entry.device:
+            if fstab_entry.device.split('=')[0] not in supported_mount_types:
+                continue
+        elif not fstab_entry.device.startswith('/dev'):
+            continue
         try:
             mountpoint = ''.join(
                 [root_path, fstab_entry.mountpoint]


### PR DESCRIPTION
  + Entries in fstab my include filesystems we do not care about for
    the migration, such as pointing to ISO files on local disk. Ignore such
    entries and only consider filesystems on devices

This addresses #110 