### PR TITLE
Allow to skip local fstab paths

### DIFF
--- a/suse_migration_services/fstab.py
+++ b/suse_migration_services/fstab.py
@@ -16,8 +16,10 @@
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
 import os
-
 from collections import namedtuple
+
+# project
+from suse_migration_services.logger import log
 
 
 class Fstab(object):
@@ -60,6 +62,13 @@ class Fstab(object):
                         )
                     else:
                         device_path = device
+                        if not os.path.exists(device_path):
+                            log.warning(
+                                'Device path {0} not found and skipped'.format(
+                                    device_path
+                                )
+                            )
+                            continue
                     self.fstab.append(
                         self.fstab_entry_type(
                             fstype=fstype,

--- a/suse_migration_services/fstab.py
+++ b/suse_migration_services/fstab.py
@@ -60,6 +60,10 @@ class Fstab(object):
                         device_path = ''.join(
                             ['/dev/disk/by-label/', device.split('=')[1]]
                         )
+                    elif device.startswith('PARTUUID'):
+                        device_path = ''.join(
+                            ['/dev/disk/by-partuuid/', device.split('=')[1]]
+                        )
                     else:
                         device_path = device
                         if not os.path.exists(device_path):

--- a/test/data/fstab
+++ b/test/data/fstab
@@ -2,6 +2,7 @@ UUID=bd604632-663b-4d4c-b5b0-8d8686267ea2  /          ext4  acl,user_xattr  0  1
 UUID=daa5a8c3-5c72-4343-a1d4-bb74ec4e586e  swap       swap  defaults        0  0
 UUID=FCF7-B051                             /boot/efi  vfat  defaults        0  0
 LABEL=foo  /home      ext4  defaults        0  0
+PARTUUID=3c8bd108-01 /bar ext4 defaults 0 0
 /dev/mynode /foo ext4 defaults 0 0
 
 # this comment line and the line above should be ignored by the parser

--- a/test/data/system-root.fstab
+++ b/test/data/system-root.fstab
@@ -1,6 +1,3 @@
-/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2 /system-root/ ext4 defaults 0 0
-/dev/disk/by-uuid/FCF7-B051 /system-root/boot/efi vfat defaults 0 0
-/dev/disk/by-label/foo /system-root/home          ext4 defaults 0 0
-/dev/mynode /system-root/foo                      ext4 defaults 0 0
-/system-root/etc/zypp /etc/zypp none defaults 0 0
-/system-root/etc/sysconfig/network /etc/sysconfig/network none defaults 0 0
+UUID=bd604632-663b-4d4c-b5b0-8d8686267ea2 /system-root/ ext4 defaults 0 0
+UUID=FCF7-B051 /system-root/boot/efi vfat defaults 0 0
+LABEL=foo /system-root/home          ext4 defaults 0 0

--- a/test/unit/fstab_test.py
+++ b/test/unit/fstab_test.py
@@ -6,9 +6,43 @@ from suse_migration_services.fstab import Fstab
 
 
 class TestFstab(object):
-    def setup(self):
+    @patch('os.path.exists')
+    def setup(self, mock_os_path_exists):
+        mock_os_path_exists.return_value = True
         self.fstab = Fstab()
         self.fstab.read('../data/fstab')
+
+    @patch('suse_migration_services.logger.log.warning')
+    @patch('os.path.exists')
+    def test_read_with_skipped_entries(
+        self, mock_os_path_exists, mock_log_warning
+    ):
+        mock_os_path_exists.return_value = False
+        fstab = Fstab()
+        fstab.read('../data/fstab')
+        mock_log_warning.assert_called_once_with(
+            'Device path /dev/mynode not found and skipped'
+        )
+        assert fstab.get_devices() == [
+            self.fstab.fstab_entry_type(
+                fstype='ext4',
+                mountpoint='/',
+                device='/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2',
+                options='acl,user_xattr'
+            ),
+            self.fstab.fstab_entry_type(
+                fstype='vfat',
+                mountpoint='/boot/efi',
+                device='/dev/disk/by-uuid/FCF7-B051',
+                options='defaults'
+            ),
+            self.fstab.fstab_entry_type(
+                fstype='ext4',
+                mountpoint='/home',
+                device='/dev/disk/by-label/foo',
+                options='defaults'
+            )
+        ]
 
     def test_get_devices(self):
         assert self.fstab.get_devices() == [

--- a/test/unit/fstab_test.py
+++ b/test/unit/fstab_test.py
@@ -41,6 +41,12 @@ class TestFstab(object):
                 mountpoint='/home',
                 device='/dev/disk/by-label/foo',
                 options='defaults'
+            ),
+            self.fstab.fstab_entry_type(
+                fstype='ext4',
+                mountpoint='/bar',
+                device='/dev/disk/by-partuuid/3c8bd108-01',
+                options='defaults'
             )
         ]
 
@@ -62,6 +68,12 @@ class TestFstab(object):
                 fstype='ext4',
                 mountpoint='/home',
                 device='/dev/disk/by-label/foo',
+                options='defaults'
+            ),
+            self.fstab.fstab_entry_type(
+                fstype='ext4',
+                mountpoint='/bar',
+                device='/dev/disk/by-partuuid/3c8bd108-01',
                 options='defaults'
             ),
             self.fstab.fstab_entry_type(

--- a/test/unit/units/mount_system_test.py
+++ b/test/unit/units/mount_system_test.py
@@ -52,9 +52,10 @@ class TestMountSystem(object):
     @patch.object(Defaults, 'get_migration_log_file')
     @patch('suse_migration_services.logger.log.error')
     @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.log.warning')
     @patch('suse_migration_services.command.Command.run')
     def test_mount_system_raises(
-            self, mock_Command_run, mock_info,
+            self, mock_Command_run, mock_warning, mock_info,
             mock_error, mock_log_file
     ):
         def command_calls(command):
@@ -133,7 +134,9 @@ class TestMountSystem(object):
             '../data/optional-migration-config.yml'
         mock_get_migration_config_file.return_value = \
             '../data/migration-config.yml'
-        mock_yaml_safe_load.return_value = {'migration_product': 'SLES/15/x86_64'}
+        mock_yaml_safe_load.return_value = {
+            'migration_product': 'SLES/15/x86_64'
+        }
         with patch('builtins.open', create=True) as mock_open:
             main()
             assert mock_update_migration_config_file.called

--- a/test/unit/units/mount_system_test.py
+++ b/test/unit/units/mount_system_test.py
@@ -177,6 +177,13 @@ class TestMountSystem(object):
                 call(
                     [
                         'mount', '-o', 'defaults',
+                        '/dev/disk/by-partuuid/3c8bd108-01',
+                        '/system-root/bar'
+                    ]
+                ),
+                call(
+                    [
+                        'mount', '-o', 'defaults',
                         '/dev/mynode',
                         '/system-root/foo'
                     ]
@@ -196,6 +203,11 @@ class TestMountSystem(object):
                 call(
                     '/dev/disk/by-label/foo',
                     '/system-root/home',
+                    'ext4'
+                ),
+                call(
+                    '/dev/disk/by-partuuid/3c8bd108-01',
+                    '/system-root/bar',
                     'ext4'
                 ),
                 call(

--- a/test/unit/units/reboot_test.py
+++ b/test/unit/units/reboot_test.py
@@ -46,18 +46,6 @@ class TestKernelReboot(object):
                 raise_on_error=False
             ),
             call(
-                ['umount', '--lazy', '/etc/sysconfig/network'],
-                raise_on_error=False
-            ),
-            call(
-                ['umount', '--lazy', '/etc/zypp'],
-                raise_on_error=False
-            ),
-            call(
-                ['umount', '--lazy', '/system-root/foo'],
-                raise_on_error=False
-            ),
-            call(
                 ['umount', '--lazy', '/system-root/home'],
                 raise_on_error=False
             ),
@@ -91,9 +79,6 @@ class TestKernelReboot(object):
             MagicMock(),
             MagicMock(),
             MagicMock(),
-            MagicMock(),
-            MagicMock(),
-            MagicMock(),
             Exception,
             None
         ]
@@ -103,18 +88,6 @@ class TestKernelReboot(object):
         assert mock_info.called
         assert mock_Command_run.call_args_list == [
             call(['systemctl', 'status', '-l', '--all'], raise_on_error=False),
-            call(
-                ['umount', '--lazy', '/etc/sysconfig/network'],
-                raise_on_error=False
-            ),
-            call(
-                ['umount', '--lazy', '/etc/zypp'],
-                raise_on_error=False
-            ),
-            call(
-                ['umount', '--lazy', '/system-root/foo'],
-                raise_on_error=False
-            ),
             call(
                 ['umount', '--lazy', '/system-root/home'],
                 raise_on_error=False


### PR DESCRIPTION
If a device path is referenced as local path in the fstab file
but can't be found on the system, this device path is skipped.
Usually a device path references a storage node that exists
as /dev/.. node on the machine. However it's possible to also
reference files e.g for loop mount in the fstab file. If that
file reference is not present in the live migration system it
is ignored because considered harmless. file references in
fstab are sometimes used for swapfiles or other file mapped
data. For the purpose of the migration we consider such paths
as not belonging to the system. This assumption of course
could be wrong which is why we also write a warning message
to the log file once this situation is disovered. This
Fixes #110