### PR TITLE
Rename config option to use zypper migration

### DIFF
--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -120,7 +120,7 @@ or for which the repository server has no upgrade path, it's required to
 switch off the use of the migration workflow.
 
 [listing]
-use_zypper_migration_plugin: true|false
+use_zypper_migration: true|false
 
 [NOTE]
 The use of the migration workflow is the default behavior. If the migration
@@ -140,7 +140,7 @@ following product specifications:
 migration_product: SLES/15/x86_64
 
 [NOTE]
-If `use_zypper_migration_plugin: false` is set, the value for the
+If `use_zypper_migration: false` is set, the value for the
 `migration_product` will not be effective because it's used only in
 combination with the Zypper migration workflow.
 

--- a/suse_migration_services/migration_config.py
+++ b/suse_migration_services/migration_config.py
@@ -87,7 +87,7 @@ class MigrationConfig(object):
         return self.config_data.get('debug', False)
 
     def is_zypper_migration_plugin_requested(self):
-        return self.config_data.get('use_zypper_migration_plugin', True)
+        return self.config_data.get('use_zypper_migration', True)
 
     def _write_config_file(self):
         with open(self.migration_config_file, 'w') as config:

--- a/test/data/migration-config-zypper-dup.yml
+++ b/test/data/migration-config-zypper-dup.yml
@@ -1,1 +1,1 @@
-use_zypper_migration_plugin: false
+use_zypper_migration: false


### PR DESCRIPTION
Rename the option to use zypper migration path, whether a plugin or
a sub-command is not relevant.

Fixes #118