### PR TITLE
Added post mount service

### DIFF
--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -155,6 +155,12 @@ preserve:
 ￼   - /etc/udev/rules.d/a.rules
 ￼   - /etc/udev/rules.d/b.rules
 
+[NOTE]
+udev rules that require custom drivers will not have the desired effect
+as the migration system will not include these drivers and therefore
+execution of those rules will fail. Rules with such properties should
+not be listed.
+
 Enable Debug Mode::
 If enabled, prevents the upgrade system from rewinding the setup
 steps and rebooting due to a failed upgrade, allowing the issue to

--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -144,6 +144,17 @@ If `use_zypper_migration: false` is set, the value for the
 `migration_product` will not be effective because it's used only in
 combination with the Zypper migration workflow.
 
+Preserve System Data::
+Preserve custom data file(s) e.g udev rules from the system
+to be migrated into the upgrade live system and make sure
+they will become effective.
+
+[listing]
+preserve:
+  rules:
+￼   - /etc/udev/rules.d/a.rules
+￼   - /etc/udev/rules.d/b.rules
+
 Enable Debug Mode::
 If enabled, prevents the upgrade system from rewinding the setup
 steps and rebooting due to a failed upgrade, allowing the issue to

--- a/helper/service.tree
+++ b/helper/service.tree
@@ -1,0 +1,7 @@
+suse-migration-mount-system -> [
+    suse-migration-ssh-keys,
+    suse-migration-post-mount-system.service -> suse-migration-setup-host-network -> suse-migration-prepare -> [
+        suse-migration-console-log,
+        suse-migration-product-setup -> suse-migration -> suse-migration-grub-setup -> suse-migration-kernel-load -> suse-migration-reboot
+    ]
+]

--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -54,6 +54,9 @@ python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 install -D -m 644 systemd/suse-migration-mount-system.service \
     %{buildroot}%{_unitdir}/suse-migration-mount-system.service
 
+install -D -m 644 systemd/suse-migration-post-mount-system.service \
+    %{buildroot}%{_unitdir}/suse-migration-post-mount-system.service
+
 install -D -m 644 systemd/suse-migration-setup-host-network.service \
     %{buildroot}%{_unitdir}/suse-migration-setup-host-network.service
 
@@ -97,6 +100,9 @@ install -D -m 644 systemd/suse-migration-console-log.service \
 
 %{_bindir}/suse-migration-mount-system
 %{_unitdir}/suse-migration-mount-system.service
+
+%{_bindir}/suse-migration-post-mount-system
+%{_unitdir}/suse-migration-post-mount-system.service
 
 %{_bindir}/suse-migration-setup-host-network
 %{_unitdir}/suse-migration-setup-host-network.service

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ config = {
             'suse-migration-grub-setup=suse_migration_services.units.grub_setup:main',
             'suse-migration-kernel-load=suse_migration_services.units.kernel_load:main',
             'suse-migration-reboot=suse_migration_services.units.reboot:main',
-            'suse-migration-product-setup=suse_migration_services.units.product_setup:main'
+            'suse-migration-product-setup=suse_migration_services.units.product_setup:main',
+            'suse-migration-post-mount-system=suse_migration_services.units.post_mount_system:main'
         ]
     },
     'include_package_data': True,

--- a/suse_migration_services/migration_config.py
+++ b/suse_migration_services/migration_config.py
@@ -63,6 +63,20 @@ class MigrationConfig(object):
 
         return migration_product
 
+    def get_preserve_udev_rules_list(self):
+        """
+        Returns list of udev rule file(s)
+
+        The returned file list is used to make those rule files
+        available to the migration live system such that the
+        same behavior the rules apply on the system to be
+        upgraded also applies to the live migration system
+        while the upgrade runs
+        """
+        preserve_data = self.config_data.get('preserve')
+        if preserve_data:
+            return preserve_data.get('rules')
+
     def update_migration_config_file(self):
         """
         Update the default migration configuration with custom values

--- a/suse_migration_services/units/post_mount_system.py
+++ b/suse_migration_services/units/post_mount_system.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2019 SUSE Linux LLC.  All rights reserved.
+#
+# This file is part of suse-migration-services.
+#
+# suse-migration-services is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# suse-migration-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
+#
+import os
+import shutil
+
+# project
+from suse_migration_services.defaults import Defaults
+from suse_migration_services.logger import log
+from suse_migration_services.migration_config import MigrationConfig
+from suse_migration_services.command import Command
+
+
+def main():
+    """
+    DistMigration post mount actions
+
+    Preserve custom data file(s) e.g udev rules from the system
+    to be migrated to the live migration system and activate
+    those file changes to become effective
+    """
+    root_path = Defaults.get_system_root_path()
+
+    migration_config = MigrationConfig()
+    system_udev_rules = migration_config.get_preserve_udev_rules_list()
+    if system_udev_rules:
+        for rule_file in system_udev_rules:
+            target_rule_dir = os.path.dirname(rule_file)
+            source_rule_file = os.path.normpath(
+                os.sep.join([root_path, rule_file])
+            )
+            log.info(
+                'Copy udev rule: {0} to: {1}'.format(
+                    source_rule_file, target_rule_dir
+                )
+            )
+            shutil.copy(source_rule_file, target_rule_dir)
+        Command.run(
+            ['udevadm', 'control', '--reload']
+        )
+        Command.run(
+            ['udevadm', 'trigger', '--type=subsystems', '--action=add']
+        )

--- a/systemd/suse-migration-post-mount-system.service
+++ b/systemd/suse-migration-post-mount-system.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Preserve Data After System Mount
+After=suse-migration-mount-system.service
+Requires=suse-migration-mount-system.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/suse-migration-post-mount
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/suse-migration-setup-host-network.service
+++ b/systemd/suse-migration-setup-host-network.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Setup Migration Host Network
-After=suse-migration-mount-system.service
-Requires=suse-migration-mount-system.service
+After=suse-migration-mount-system.service suse-migration-post-mount-system.service
+Requires=suse-migration-mount-system.service suse-migration-post-mount-system.service
 After=network.target
 
 [Service]

--- a/test/data/migration-config.yml
+++ b/test/data/migration-config.yml
@@ -1,1 +1,6 @@
 migration_product: 'SLES/15/x86_64'
+
+preserve:
+  rules:
+     - /etc/udev/rules.d/a.rules
+     - /etc/udev/rules.d/b.rules

--- a/test/unit/migration_config_test.py
+++ b/test/unit/migration_config_test.py
@@ -27,6 +27,11 @@ class TestMigrationConfig(object):
     def test_get_migration_product(self):
         assert self.config.get_migration_product() == 'SLES/15/x86_64'
 
+    def test_get_preserve_udev_rules_list(self):
+        assert self.config.get_preserve_udev_rules_list() == [
+            '/etc/udev/rules.d/a.rules', '/etc/udev/rules.d/b.rules'
+        ]
+
     @patch('suse_migration_services.logger.log.error')
     def test_get_migration_product_targets(self, mock_error):
         self.config.config_data = {'not_migration_product': 'another_info'}

--- a/test/unit/units/post_mount_system_test.py
+++ b/test/unit/units/post_mount_system_test.py
@@ -1,0 +1,30 @@
+from unittest.mock import (
+    patch, call
+)
+
+from suse_migration_services.units.post_mount_system import main
+from suse_migration_services.defaults import Defaults
+
+
+class TestPostMountSystem(object):
+    @patch.object(Defaults, 'get_migration_config_file')
+    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.command.Command.run')
+    @patch('suse_migration_services.defaults.Defaults.get_system_root_path')
+    @patch('shutil.copy')
+    def test_main(
+        self, mock_shutil_copy, mock_get_system_root_path,
+        mock_Command_run, mock_log_info, mock_get_migration_config_file
+    ):
+        mock_get_system_root_path.return_value = '../data'
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config.yml'
+        main()
+        assert mock_shutil_copy.call_args_list == [
+            call('../data/etc/udev/rules.d/a.rules', '/etc/udev/rules.d'),
+            call('../data/etc/udev/rules.d/b.rules', '/etc/udev/rules.d')
+        ]
+        assert mock_Command_run.call_args_list == [
+            call(['udevadm', 'control', '--reload']),
+            call(['udevadm', 'trigger', '--type=subsystems', '--action=add'])
+        ]


### PR DESCRIPTION
The post mount service is used to preserve data from the
system to be migrated into the live migration system directly
after the mounting of the system to be migrated. It is is
also responsible for making that data effective in the live
migration system. The current implementation allows for
preserving udev rules file and make them active.
This Fixes #100