### PR TITLE
Fixup udev reload on rule changes

### DIFF
--- a/suse_migration_services/units/post_mount_system.py
+++ b/suse_migration_services/units/post_mount_system.py
@@ -55,3 +55,6 @@ def main():
         Command.run(
             ['udevadm', 'trigger', '--type=subsystems', '--action=add']
         )
+        Command.run(
+            ['udevadm', 'trigger', '--type=devices', '--action=add']
+        )

--- a/test/unit/units/post_mount_system_test.py
+++ b/test/unit/units/post_mount_system_test.py
@@ -26,5 +26,6 @@ class TestPostMountSystem(object):
         ]
         assert mock_Command_run.call_args_list == [
             call(['udevadm', 'control', '--reload']),
-            call(['udevadm', 'trigger', '--type=subsystems', '--action=add'])
+            call(['udevadm', 'trigger', '--type=subsystems', '--action=add']),
+            call(['udevadm', 'trigger', '--type=devices', '--action=add'])
         ]


### PR DESCRIPTION
The current restart sequence is missing the actual set/change
of device nodes. This also prevented network interface names
to be added/renamed.