### PR TITLE
Allow two ways to start the migration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 # Manifest describing source package contents
 
+prune grub.d
+
 graft tools
 graft suse_migration_services/units
 graft package

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,15 @@ build: check test
 	# provide rpm rpmlintrc
 	cp package/suse-migration-services-rpmlintrc dist
 
+sle15_activation: check
+	rm -f dist/*
+	git log grub.d | helper/changelog_generator |\
+		helper/changelog_descending > \
+		dist/suse-migration-sle15-activation.changes
+	cp package/suse-migration-sle15-activation-spec-template \
+		dist/suse-migration-sle15-activation.spec
+	tar -czf dist/suse-migration-sle15-activation.tar.gz grub.d
+
 .PHONY: test
 test:
 	tox -e unit_py3

--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -102,6 +102,18 @@ To install the distribution migration system run:
 [listing]
 tux > sudo zypper in SLES15-Migration
 
+[NOTE]
+The `run_migration` utility is based on `kexec` to boot the live image
+kernel. Not all Cloud Service Providers supports this method. Especially
+those using Xen based virtualization, like on Amazon EC2, will not work.
+In this case additionally install the package:
+
+[listing]
+tux > sudo zypper in suse-migration-sle15-activation
+
+The install of the package modifies the bootloader configuration such
+that on the next boot the system will boot into the upgrade image.
+
 == Optional Customization of the Upgrade Process
 The upgrade live image is pre-configured to run without any further
 setup. The migration system reads a custom configuration file from the
@@ -175,6 +187,13 @@ by calling the following command:
 
 [listing]
 tux > sudo run_migration
+
+[NOTE]
+If the `suse-migration-sle15-activation` package was installed,
+start the migration by a reboot of the system as follows:
+
+[listing]
+tux > sudo reboot
 
 After the upgrade has started, the only way to access the system during the
 upgrade process is via ssh with a user called `migration`:

--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -1,0 +1,44 @@
+# SUSE Migration activation menu entry based on isofile
+
+. /usr/share/grub2/grub-mkconfig_lib
+
+CLASS="--class memtest86 --class gnu --class tools"
+
+if [ -z "${GRUB_DISTRIBUTOR}" ] ; then
+    OS=Migration
+else
+    OS="${GRUB_DISTRIBUTOR} Migration"
+    CLASS="--class $(
+        echo "${GRUB_DISTRIBUTOR}" | tr '[:upper:]' '[:lower:]' | cut -d' ' -f1
+    ) ${CLASS}"
+fi
+
+migration_iso=$(echo /usr/share/migration-image/*-Migration.*.iso)
+root_device=$(lsblk -p -n -r -o NAME,MOUNTPOINT | grep -E "/$" | uniq | cut -f1 -d" ")
+root_uuid=$(blkid -s UUID -o value "${root_device}")
+root_type=$(blkid -s TYPE -o value "${root_device}")
+boot_options="rd.live.image root=live:CDLABEL=CDROM"
+if mdadm --detail "${root_device}" &>/dev/null; then
+    boot_options="${boot_options} rd.auto"
+fi
+
+if grub_file_is_not_garbage "${migration_iso}"; then
+    kernel="(loop)/boot/x86_64/loader/linux"
+    initrd="(loop)/boot/x86_64/loader/initrd"
+    boot_device_id="$(grub_get_device_id "${GRUB_DEVICE_BOOT}")"
+    printf "menuentry '%s' %s \${menuentry_id_option} '%s' {\n" \
+        "${OS}" "${CLASS}" "Migration-${boot_device_id}"
+    printf "    insmod %s\n" "${root_type}"
+    printf "    search --no-floppy --fs-uuid --set=root %s\n" "${root_uuid}"
+    printf "    set isofile='%s'\n" \
+        "${migration_iso}"
+    printf "    loopback loop (\$root)\$isofile\n"
+    printf "    linux %s iso-scan/filename=\$isofile %s\n" \
+        "${kernel}" "${boot_options}"
+    printf "    initrd %s\n" \
+        "${initrd}"
+    printf "}\n"
+
+    printf "set default='%s'\n" "${OS}"
+    printf "set timeout=1\n"
+fi

--- a/package/suse-migration-sle15-activation-spec-template
+++ b/package/suse-migration-sle15-activation-spec-template
@@ -1,0 +1,58 @@
+#
+# spec file for package suse-migration-activation
+#
+# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+
+Name:             suse-migration-sle15-activation
+Version:          1.2.0
+Release:          0
+Url:              https://github.com/SUSE/suse-migration-services
+Summary:          SUSE Distribution SLE15 Migration Activation
+License:          GPL-3.0+
+Group:            System/Management
+Source:           suse-migration-sle15-activation.tar.gz
+BuildRoot:        %{_tmppath}/%{name}-%{version}-build
+BuildArch:        noarch
+BuildRequires:    grub2
+Requires:         SLES15-Migration
+Requires:         grub2
+
+%description -n suse-migration-sle15-activation
+Script code to activate the SLE15 migration image to be booted at
+next reboot of the machine.
+
+%prep
+%setup -q -n grub.d
+
+%build
+# nothing to do here
+
+%install
+install -D -m 755 99_migration \
+    %{buildroot}/etc/grub.d/99_migration
+
+%post
+/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
+
+%postun
+/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
+
+%files
+%defattr(-,root,root,-)
+%dir /etc/grub.d
+/etc/grub.d/*
+
+%changelog

--- a/suse_migration_services/units/grub_setup.py
+++ b/suse_migration_services/units/grub_setup.py
@@ -42,6 +42,7 @@ def main():
         log.info('Running grub setup service')
         migration_packages = [
             'SLE*-Migration',
+            'suse-migration-*-activation'
         ]
         log.info(
             'Uninstalling migration: {0}{1}'.format(

--- a/test/unit/units/grub_setup_test.py
+++ b/test/unit/units/grub_setup_test.py
@@ -37,7 +37,8 @@ class TestGrubSetup(object):
                 [
                     'chroot', '/system-root',
                     'zypper', '--non-interactive', '--no-gpg-checks',
-                    'remove', 'SLE*-Migration'
+                    'remove', 'SLE*-Migration',
+                    'suse-migration-*-activation'
                 ], raise_on_error=False
             ),
             call(

--- a/tools/run_migration
+++ b/tools/run_migration
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) 2019 SUSE Software Solutions Germany GmbH.  All rights reserved.
-# 
+#
 # This file is part of suse-migration-services.
 #
 # suse-migration-services is free software: you can redistribute it and/or

--- a/tox.ini
+++ b/tox.ini
@@ -48,4 +48,4 @@ usedevelop = True
 commands =
     flake8 --statistics -j auto --count {toxinidir}/suse_migration_services
     flake8 --statistics -j auto --count {toxinidir}/test/unit
-    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117 {toxinidir}/tools/* -s bash'
+    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117 {toxinidir}/tools/* {toxinidir}/grub.d/* -s bash'


### PR DESCRIPTION
Partially revert the no bootloader based startup
    
After testing the kexec based implementation to start the
migration live image, we found that kexec does not work in
all cloud providers. Especially those using Xen like AWS
do not work. Thus it's required to keep the alternative
bootloader based startup sequence