### PR TITLE
Detect baseproduct on system to be migrated

### DIFF
--- a/test/data/etc/products.d/baseproduct
+++ b/test/data/etc/products.d/baseproduct
@@ -1,0 +1,78 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<product schemeversion="0">
+  <vendor>SUSE</vendor>
+  <name>SLES_SAP</name>
+  <version>12.3</version>
+  <baseversion>12</baseversion>
+  <patchlevel>3</patchlevel>
+  <release>0</release>
+  <endoflife />
+  <arch>x86_64</arch>
+  <cpeid>cpe:/o:suse:sles:12:sp3</cpeid>
+  <productline>sles</productline>
+  <codestream>
+    <name>SUSE Linux Enterprise Server 12</name>
+    <endoflife>2024-10-31</endoflife>
+  </codestream>
+  <register>
+    <target>sle-12-x86_64</target>
+    <updates>
+      <repository repoid="obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER:12-SP3:x86_64/update" />
+      <repository repoid="obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER:12-SP3:x86_64/update_debug" />
+      <repository repoid="obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER-INSTALLER:12-SP3:x86_64/update" />
+    </updates>
+  </register>
+  <upgrades />
+  <updaterepokey>A43242DKD</updaterepokey>
+  <summary>SUSE Linux Enterprise Server 12 SP3</summary>
+  <shortsummary>SLES12-SP3</shortsummary>
+  <description>SUSE Linux Enterprise offers a comprehensive
+        suite of products built on a single code base.
+        The platform addresses business needs from
+        the smallest thin-client devices to the world's
+        most powerful high-performance computing
+        and mainframe servers. SUSE Linux Enterprise
+        offers common management tools and technology
+        certifications across the platform, and
+        each product is enterprise-class.</description>
+  <linguas>
+    <language>cs</language>
+    <language>da</language>
+    <language>de</language>
+    <language>en</language>
+    <language>en_GB</language>
+    <language>en_US</language>
+    <language>es</language>
+    <language>fi</language>
+    <language>fr</language>
+    <language>hu</language>
+    <language>it</language>
+    <language>ja</language>
+    <language>nb</language>
+    <language>nl</language>
+    <language>pl</language>
+    <language>pt</language>
+    <language>pt_BR</language>
+    <language>ru</language>
+    <language>sv</language>
+    <language>zh</language>
+    <language>zh_CN</language>
+    <language>zh_TW</language>
+  </linguas>
+  <urls>
+    <url name="releasenotes">https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12-SP3/release-notes-sles.rpm</url>
+  </urls>
+  <buildconfig>
+    <producttheme>SLES</producttheme>
+  </buildconfig>
+  <installconfig>
+    <defaultlang>en_US</defaultlang>
+    <datadir>suse</datadir>
+    <descriptiondir>suse/setup/descr</descriptiondir>
+    <releasepackage flag="EQ" name="sles-release" release="4.3.1" version="12.3" />
+    <distribution>SUSE_SLE</distribution>
+  </installconfig>
+  <runtimeconfig />
+  <productdependency baseversion="12" flag="EQ" name="SUSE_SLE" patchlevel="3" relationship="provides" />
+  <productdependency baseversion="12" flag="EQ" name="SUSE_SLE-SP3" patchlevel="3" relationship="provides" />
+</product>

--- a/test/data/migration-config-detect-product.yml
+++ b/test/data/migration-config-detect-product.yml
@@ -1,0 +1,1 @@
+migration_product: 15.1/x86_64

--- a/test/unit/migration_config_test.py
+++ b/test/unit/migration_config_test.py
@@ -68,3 +68,18 @@ class TestMigrationConfig(object):
             mock_yaml_dump.assert_called_once_with(
                 self.config.config_data, file_handle, default_flow_style=False
             )
+
+    @patch.object(Defaults, 'get_migration_config_file')
+    @patch.object(Defaults, 'get_system_root_path')
+    @patch.object(MigrationConfig, '_write_config_file')
+    @patch('suse_migration_services.logger.log.info')
+    def test_update_migration_config_file_detect_product(
+        self, mock_info, mock_write_config_file, mock_get_system_root_path,
+        mock_get_migration_config_file  # , mock_ElementTree
+    ):
+        mock_get_system_root_path.return_value = '../data/'
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config-detect-product.yml'
+        self.config = MigrationConfig()
+        self.config.update_migration_config_file()
+        assert self.config.get_migration_product() == 'SLES_SAP/15.1/x86_64'

--- a/test/unit/units/mount_system_test.py
+++ b/test/unit/units/mount_system_test.py
@@ -135,7 +135,7 @@ class TestMountSystem(object):
         mock_get_migration_config_file.return_value = \
             '../data/migration-config.yml'
         mock_yaml_safe_load.return_value = {
-            'migration_product': 'SLES/15/x86_64'
+            'migration_product': '/15/x86_64'
         }
         with patch('builtins.open', create=True) as mock_open:
             main()


### PR DESCRIPTION
By default, the migration will target SLES 15,
however this may not always be the case, e.g. SLES SAP.

Fixes #129