### PR TITLE
Fixed network setup

### DIFF
--- a/suse_migration_services/units/setup_host_network.py
+++ b/suse_migration_services/units/setup_host_network.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import glob
 import os
 import shutil
 
@@ -52,8 +53,11 @@ def main():
         resolv_conf, '/etc/resolv.conf'
     )
 
-    sysconfig_network = os.sep.join(
-        [root_path, 'etc', 'sysconfig', 'network']
+    sysconfig_network_providers = os.sep.join(
+        [root_path, 'etc', 'sysconfig', 'network', 'providers']
+    )
+    sysconfig_interfaces = os.sep.join(
+        [root_path, 'etc', 'sysconfig', 'network', '*']
     )
     try:
         log.info('Running setup host network service')
@@ -62,11 +66,19 @@ def main():
             Defaults.get_system_mount_info_file()
         )
         Command.run(
-            ['mount', '--bind', sysconfig_network, '/etc/sysconfig/network']
+            [
+                'mount', '--bind', sysconfig_network_providers,
+                '/etc/sysconfig/network/providers'
+            ]
         )
         system_mount.add_entry(
-            sysconfig_network, '/etc/sysconfig/network'
+            sysconfig_network_providers, '/etc/sysconfig/network/providers'
         )
+        for interface_setup in glob.glob(sysconfig_interfaces):
+            if os.path.isfile(interface_setup):
+                shutil.copy(
+                    interface_setup, '/etc/sysconfig/network'
+                )
         Command.run(
             ['systemctl', 'reload', 'network']
         )

--- a/suse_migration_services/units/setup_host_network.py
+++ b/suse_migration_services/units/setup_host_network.py
@@ -56,7 +56,7 @@ def main():
     sysconfig_network_providers = os.sep.join(
         [root_path, 'etc', 'sysconfig', 'network', 'providers']
     )
-    sysconfig_interfaces = os.sep.join(
+    sysconfig_network_setup = os.sep.join(
         [root_path, 'etc', 'sysconfig', 'network', '*']
     )
     try:
@@ -74,10 +74,10 @@ def main():
         system_mount.add_entry(
             sysconfig_network_providers, '/etc/sysconfig/network/providers'
         )
-        for interface_setup in glob.glob(sysconfig_interfaces):
-            if os.path.isfile(interface_setup):
+        for network_setup in glob.glob(sysconfig_network_setup):
+            if os.path.isfile(network_setup):
                 shutil.copy(
-                    interface_setup, '/etc/sysconfig/network'
+                    network_setup, '/etc/sysconfig/network'
                 )
         Command.run(
             ['systemctl', 'reload', 'network']

--- a/test/unit/units/setup_host_network_test.py
+++ b/test/unit/units/setup_host_network_test.py
@@ -43,22 +43,42 @@ class TestSetupHostNetwork(object):
     @patch('suse_migration_services.units.setup_host_network.Fstab')
     @patch('os.path.exists')
     @patch('shutil.copy')
+    @patch('glob.glob')
+    @patch('os.path.isfile')
     def test_main(
-        self, mock_shutil_copy, mock_os_path_exists,
+        self, mock_isfile, mock_glob, mock_shutil_copy, mock_os_path_exists,
         mock_Fstab, mock_Command_run, mock_info
     ):
         fstab = Mock()
         mock_Fstab.return_value = fstab
+        mock_glob.return_value = [
+            '/system-root/etc/sysconfig/network/ifcfg-eth0',
+            '/system-root/etc/sysconfig/network/dhcp'
+        ]
+        mock_isfile.return_value = True
         mock_os_path_exists.return_value = True
         main()
-        mock_shutil_copy.assert_called_once_with(
-            '/system-root/etc/resolv.conf', '/etc/resolv.conf'
+
+        mock_glob.assert_called_once_with(
+            '/system-root/etc/sysconfig/network/*'
         )
+        assert mock_shutil_copy.call_args_list == [
+            call('/system-root/etc/resolv.conf', '/etc/resolv.conf'),
+            call(
+                '/system-root/etc/sysconfig/network/ifcfg-eth0',
+                '/etc/sysconfig/network'
+            ),
+            call(
+                '/system-root/etc/sysconfig/network/dhcp',
+                '/etc/sysconfig/network'
+            )
+        ]
         assert mock_Command_run.call_args_list == [
             call(
                 [
-                    'mount', '--bind', '/system-root/etc/sysconfig/network',
-                    '/etc/sysconfig/network'
+                    'mount', '--bind',
+                    '/system-root/etc/sysconfig/network/providers',
+                    '/etc/sysconfig/network/providers'
                 ]
             ),
             call(
@@ -69,7 +89,8 @@ class TestSetupHostNetwork(object):
             '/etc/system-root.fstab'
         )
         fstab.add_entry.assert_called_once_with(
-            '/system-root/etc/sysconfig/network', '/etc/sysconfig/network'
+            '/system-root/etc/sysconfig/network/providers',
+            '/etc/sysconfig/network/providers'
         )
         fstab.export.assert_called_once_with(
             '/etc/system-root.fstab'


### PR DESCRIPTION
The network setup was based on an overlay bind mount of the
entire /etc/sysconfig/network directory. However that directory
also contains script code and functions that are used by system
tools like netconfig. The scripts here are not compatible between
distributions. Thus the overmount of /etc/sysconfig/network/scripts
from SLE12 to SLE15 as one example breaks the netconfig tool and
prevents the update of the /etc/resolv.conf file on network
restart. Other negative effects of that overmounting are likely.
Therefore this commit changes the way we inherit the network setup.
Only the plugin directory and the interface configurations are
taken from the host, all the rest stays untouched.