### PR TITLE
Detect baseproduct name on system to be migrated

### DIFF
--- a/suse_migration_services/exceptions.py
+++ b/suse_migration_services/exceptions.py
@@ -119,3 +119,11 @@ class DistMigrationProductNotFoundException(DistMigrationException):
     """
     Exception raised if the target product to migrate is not found
     """
+
+
+class DistMigrationSUSEBaseProductException(DistMigrationException):
+    """
+    Exception raised if the syncing of the product information
+    from the bind mounted etc/products.d location into the
+    migrated system has failed
+    """

--- a/suse_migration_services/suse_product.py
+++ b/suse_migration_services/suse_product.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2019 SUSE Linux LLC.  All rights reserved.
+#
+# This file is part of suse-migration-services.
+#
+# suse-migration-services is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# suse-migration-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
+#
+import os
+import glob
+from xml.etree.ElementTree import ElementTree
+
+# project
+from suse_migration_services.defaults import Defaults
+from suse_migration_services.command import Command
+from suse_migration_services.logger import log
+from suse_migration_services.exceptions import (
+    DistMigrationSUSEBaseProductException
+)
+
+
+class SUSEBaseProduct(object):
+    def __init__(self):
+        root_path = Defaults.get_system_root_path()
+        self.products_metadata = os.sep.join(
+            [root_path, 'etc', 'products.d']
+        )
+        self.prod_filenames = glob.glob(
+            os.path.join(self.products_metadata, '*.prod')
+        )
+        base_product_files = []
+        xml = ElementTree()
+        for prod_filename in self.prod_filenames:
+            print(prod_filename)
+            try:
+                xml.parse(prod_filename)
+                register_sections = xml.findall('register')
+                for register in register_sections:
+                    flavor = register.findall('flavor')
+                    if not flavor:
+                        base_product_files.append(prod_filename)
+
+            except Exception as issue:
+                message = \
+                    'Parsing XML file {0} failed with: {1}'.format(
+                        prod_filename, issue
+                    )
+                log.warning(message)
+
+        if len(base_product_files) != 1:
+            if not base_product_files:
+                message = 'There is no baseproduct'
+            else:
+                message = (
+                    'Found multiple product definitions '
+                    'without element <flavor>: \n{0}'
+                    .format('\n'.join(base_product_files))
+                )
+            log.error(message)
+            raise DistMigrationSUSEBaseProductException(message)
+
+        self.base_product = base_product_files[0]
+
+    def delete_target_registration(self):
+        self.backup_products_metadata()
+        xml = ElementTree()
+        try:
+            xml.parse(self.base_product)
+            register_sections = xml.findall('register')
+            for register in register_sections:
+                target_sections = register.findall('target')
+                for target in target_sections:
+                    register.remove(target)
+            xml.write(
+                self.base_product, encoding="UTF-8", xml_declaration=True
+            )
+        except Exception as issue:
+            log.error(
+                'Could not delete target registration with {0}'.format(issue)
+            )
+
+    def backup_products_metadata(self):
+        """
+        Back up the products information.
+
+        In case migration fails and the migration rolls back to the
+        previous state. The rollback restores this info back in place.
+        """
+        log.info('Creating backup of Product data')
+        Command.run(
+            [
+                'rsync', '-zav', '--delete', self.products_metadata + os.sep,
+                '/tmp/products.d.backup/'
+            ]
+        )
+
+    def get_tag(self, tag):
+        """Get the content of tag if any."""
+        xml = ElementTree()
+        try:
+            xml.parse(self.base_product)
+            tag_nodes = xml.findall(tag)
+            return [tag_node.text for tag_node in tag_nodes]
+        except Exception as issue:
+            # if we are here, it means no potentially no migration
+            # product is defined
+            log.warning(
+                'Parsing XML file {0} failed with: {1}'
+                .format(self.base_product, issue)
+            )

--- a/test/unit/suse_product_test.py
+++ b/test/unit/suse_product_test.py
@@ -1,0 +1,63 @@
+from xml.etree.ElementTree import ElementTree
+from unittest.mock import patch
+
+from pytest import raises
+
+from suse_migration_services.suse_product import SUSEBaseProduct
+from suse_migration_services.defaults import Defaults
+from suse_migration_services.exceptions import (
+    DistMigrationSUSEBaseProductException
+)
+
+
+class TestSUSEProduct(object):
+    @patch.object(Defaults, 'get_system_root_path')
+    def setup(
+        self, mock_get_system_root_path
+    ):
+        mock_get_system_root_path.return_value = '../data/'
+        self.suse_product = SUSEBaseProduct()
+
+    @patch.object(Defaults, 'get_system_root_path')
+    @patch('suse_migration_services.suse_product.ElementTree.parse')
+    @patch('suse_migration_services.logger.log.warning')
+    @patch('suse_migration_services.logger.log.error')
+    def test_baseproduct_raises(
+        self, mock_error, mock_warning,
+        mock_ElementTree_parse, mock_get_system_root_path
+    ):
+        mock_ElementTree_parse.side_effect = Exception
+        mock_get_system_root_path.return_value = '../data'
+        with raises(DistMigrationSUSEBaseProductException):
+            SUSEBaseProduct()
+        assert mock_warning.call_count == 2
+        assert mock_error.called
+
+    @patch.object(SUSEBaseProduct, 'backup_products_metadata')
+    @patch('suse_migration_services.suse_product.ElementTree')
+    @patch('suse_migration_services.logger.log.error')
+    def test_delete_target_registration_raises(
+        self, mock_error, mock_ElementTree,
+        mock_backup_product_md
+    ):
+        mock_ElementTree().parse.side_effect = Exception
+        self.suse_product.delete_target_registration()
+        mock_error.assert_called_once()
+
+    @patch('suse_migration_services.suse_product.ElementTree')
+    def test_baseproduct_tag_text(
+        self, mock_ElementTree
+    ):
+        xml = ElementTree()
+        mock_ElementTree.return_value = xml
+        product_name = self.suse_product.get_tag('name')
+        assert product_name[0] == 'SLES'
+
+    @patch('suse_migration_services.logger.log.warning')
+    @patch('suse_migration_services.suse_product.ElementTree')
+    def test_baseproduct_tag_text_raises(
+        self, mock_ElementTree, mock_warning
+    ):
+        mock_ElementTree().parse.side_effect = Exception
+        self.suse_product.get_tag('name')
+        assert mock_warning.called

--- a/test/unit/units/product_setup_test.py
+++ b/test/unit/units/product_setup_test.py
@@ -4,33 +4,13 @@ from unittest.mock import (
 )
 from pytest import raises
 
-from suse_migration_services.units.product_setup import (
-    main, get_baseproduct, delete_target_registration
-)
+from suse_migration_services.units.product_setup import main
 from suse_migration_services.exceptions import (
     DistMigrationProductSetupException
 )
 
 
 class TestProductSetup(object):
-    @patch('suse_migration_services.units.product_setup.ElementTree.parse')
-    @patch('suse_migration_services.logger.log.warning')
-    def test_get_baseproduct_raises(
-        self, mock_warning, mock_ElementTree_parse
-    ):
-        mock_ElementTree_parse.side_effect = Exception
-        get_baseproduct('../data/etc/products.d/')
-        assert mock_warning.call_count == 2
-
-    @patch('suse_migration_services.units.product_setup.ElementTree')
-    @patch('suse_migration_services.logger.log.error')
-    def test_delete_target_registration_raises(
-        self, mock_error, mock_ElementTree
-    ):
-        mock_ElementTree.side_effect = Exception
-        delete_target_registration('../data/etc/products.d')
-        mock_error.assert_called_once()
-
     @patch('suse_migration_services.defaults.Defaults.get_system_root_path')
     @patch('suse_migration_services.logger.log.error')
     @patch('suse_migration_services.logger.log.info')
@@ -56,7 +36,7 @@ class TestProductSetup(object):
         mock_error.assert_called_with('Base Product update failed with: '
                                       'There is no baseproduct')
 
-    @patch('suse_migration_services.units.product_setup.ElementTree')
+    @patch('suse_migration_services.suse_product.ElementTree')
     @patch('suse_migration_services.defaults.Defaults.get_system_root_path')
     @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.command.Command.run')


### PR DESCRIPTION
By default, the migration will target SLES 15,
however this may not always be the case, e.g. SLES SAP.

Fixes #129