### PR TITLE
Add option to configure reboot method

### DIFF
--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -194,6 +194,14 @@ be debugged.
 [listing]
 debug: true|false
 
+Configure Reboot Method::
+By default, the migration system uses `kexec` to boot back into the host
+system once migration is complete.  If this is in any way problematic,
+a regular `reboot` can be requested by setting `soft_reboot: false`.
+
+[listing]
+soft_reboot: true|false
+
 == Run the Migration
 After the install of the `SLES15-Migration` package, start the migration
 by calling the following command:

--- a/suse_migration_services/migration_config.py
+++ b/suse_migration_services/migration_config.py
@@ -103,6 +103,9 @@ class MigrationConfig(object):
     def is_zypper_migration_plugin_requested(self):
         return self.config_data.get('use_zypper_migration', True)
 
+    def is_soft_reboot_requested(self):
+        return self.config_data.get('soft_reboot', True)
+
     def _write_config_file(self):
         with open(self.migration_config_file, 'w') as config:
             yaml.dump(self.config_data, config, default_flow_style=False)

--- a/suse_migration_services/units/kernel_load.py
+++ b/suse_migration_services/units/kernel_load.py
@@ -24,6 +24,7 @@ from suse_migration_services.command import Command
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.logger import log
 from suse_migration_services.path import Path
+from suse_migration_services.migration_config import MigrationConfig
 
 from suse_migration_services.exceptions import (
     DistMigrationKernelRebootException
@@ -36,6 +37,10 @@ def main():
 
     Loads the new kernel/initrd after migration for system reboot
     """
+    if not MigrationConfig().is_soft_reboot_requested():
+        log.info('skipping kexec --load (hard reboot requested)')
+        return
+
     root_path = Defaults.get_system_root_path()
 
     target_kernel = os.sep.join([root_path, Defaults.get_target_kernel()])

--- a/test/data/migration-config-reboot.yml
+++ b/test/data/migration-config-reboot.yml
@@ -1,0 +1,1 @@
+soft_reboot: false

--- a/test/unit/units/kernel_load_test.py
+++ b/test/unit/units/kernel_load_test.py
@@ -72,6 +72,7 @@ class TestKernelLoad(object):
             assert result == grub_cmd_content
             assert mock_info.called
 
+    @patch.object(Defaults, 'get_migration_config_file')
     @patch('shutil.copy')
     @patch('suse_migration_services.logger.log.error')
     @patch('suse_migration_services.logger.log.info')
@@ -79,12 +80,14 @@ class TestKernelLoad(object):
     @patch('suse_migration_services.units.kernel_load._get_cmdline')
     def test_main_raises_on_kernel_load(
         self, mock_get_cmdline, mock_Command_run, mock_info,
-        mock_error, mock_shutil_copy
+        mock_error, mock_shutil_copy, mock_get_migration_config_file
     ):
         cmd_line = \
             'root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8' + \
             'splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw'
         mock_get_cmdline.return_value = cmd_line
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config.yml'
         mock_Command_run.side_effect = [
             None,
             Exception
@@ -107,18 +110,21 @@ class TestKernelLoad(object):
         assert mock_info.called
         assert mock_error.called
 
+    @patch.object(Defaults, 'get_migration_config_file')
     @patch('shutil.copy')
     @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.kernel_load._get_cmdline')
     def test_main(
         self, mock_get_cmdline, mock_Command_run, mock_info,
-        mock_shutil_copy
+        mock_shutil_copy, mock_get_migration_config_file
     ):
         cmd_line = \
             'root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8' + \
             'splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw'
         mock_get_cmdline.return_value = cmd_line
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config.yml'
         main()
         assert mock_Command_run.call_args_list == [
             call(
@@ -133,4 +139,23 @@ class TestKernelLoad(object):
                 ]
             )
         ]
+        assert mock_info.called
+
+    @patch.object(Defaults, 'get_migration_config_file')
+    @patch('shutil.copy')
+    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.command.Command.run')
+    @patch('suse_migration_services.units.kernel_load._get_cmdline')
+    def test_main_hard_reboot(
+        self, mock_get_cmdline, mock_Command_run, mock_info,
+        mock_shutil_copy, mock_get_migration_config_file
+    ):
+        cmd_line = \
+            'root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8' + \
+            'splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw'
+        mock_get_cmdline.return_value = cmd_line
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config-reboot.yml'
+        main()
+        assert mock_Command_run.call_args_list == []
         assert mock_info.called


### PR DESCRIPTION
This adds a use_reboot option, which if set invokes `reboot` to reboot into the host system, instead of using `kexec`.

Fixes #111

For some more context to this, @smithfarm and @gekios have experienced (virtualized) systems hanging after migration is complete when using `kexec` to reboot. Not every time, so it's intermittent, but it's still a problem for our SES CI testing. I built a test migration image which used `reboot -f` instead, which didn't seem to help (sometimes it just got stuck on the grub screen for no reason we could ascertain), then another version which just used `reboot` (without `-f`); the intermittent post-migration hangs went away when just using `reboot`.

For this implementation I somewhat arbitrarily went with `use_reboot: true|false`, because it was easy. If more flexibility is required for any reason we could maybe do something like `reboot_method: kexec|reboot -f|reboot` instead, but I'm not sure whether that's desirable or not. Feedback most appreciated :-)