### PR TITLE
Robust detection of root device

### DIFF
--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -14,9 +14,8 @@ else
 fi
 
 migration_iso=$(echo /usr/share/migration-image/*-Migration.*.iso)
-root_device=$(lsblk -p -n -r -o NAME,MOUNTPOINT | grep -E "/$" | uniq | cut -f1 -d" ")
+root_device=$(findmnt -n -f -o SOURCE /)
 root_uuid=$(blkid -s UUID -o value "${root_device}")
-root_type=$(blkid -s TYPE -o value "${root_device}")
 boot_options="rd.live.image root=live:CDLABEL=CDROM"
 if mdadm --detail "${root_device}" &>/dev/null; then
     boot_options="${boot_options} rd.auto"
@@ -28,7 +27,6 @@ if grub_file_is_not_garbage "${migration_iso}"; then
     boot_device_id="$(grub_get_device_id "${GRUB_DEVICE_BOOT}")"
     printf "menuentry '%s' %s \${menuentry_id_option} '%s' {\n" \
         "${OS}" "${CLASS}" "Migration-${boot_device_id}"
-    printf "    insmod %s\n" "${root_type}"
     printf "    search --no-floppy --fs-uuid --set=root %s\n" "${root_uuid}"
     printf "    set isofile='%s'\n" \
         "${migration_iso}"

--- a/package/suse-migration-sle15-activation-spec-template
+++ b/package/suse-migration-sle15-activation-spec-template
@@ -28,6 +28,7 @@ BuildRoot:        %{_tmppath}/%{name}-%{version}-build
 BuildArch:        noarch
 BuildRequires:    grub2
 Requires:         SLES15-Migration
+Requires:         util-linux
 Requires:         grub2
 
 %description -n suse-migration-sle15-activation


### PR DESCRIPTION
Use the findmnt tool to detect the currently active root device
This is related to Issue #134