### PR TITLE
Allow for vendor change during migration

### DIFF
--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -49,6 +49,7 @@ def main():
                     '--gpg-auto-import-keys',
                     '--no-selfupdate',
                     '--auto-agree-with-licenses',
+                    '--allow-vendor-change',
                     '--strict-errors-dist-migration',
                     '--replacefiles',
                     '--product', migration_config.get_migration_product(),
@@ -68,6 +69,7 @@ def main():
                     '--root', root_path,
                     'dup',
                     '--auto-agree-with-licenses',
+                    '--allow-vendor-change',
                     '--replacefiles',
                     '&>>', Defaults.get_migration_log_file()
                 ]

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -101,6 +101,7 @@ class TestMigration(object):
                 '--gpg-auto-import-keys '
                 '--no-selfupdate '
                 '--auto-agree-with-licenses '
+                '--allow-vendor-change '
                 '--strict-errors-dist-migration '
                 '--replacefiles '
                 '--product SLES/15/x86_64 '
@@ -131,6 +132,7 @@ class TestMigration(object):
                 '--root /system-root '
                 'dup '
                 '--auto-agree-with-licenses '
+                '--allow-vendor-change '
                 '--replacefiles '
                 '&>> /system-root/var/log/distro_migration.log'
             ], raise_on_error=False


### PR DESCRIPTION
The migration concept allows for the zypper dup as well as
for the zypper migrate approach. In the first case the user
is responsible for setting up the repos and we expect that
to be done in a way that vendor changes are acceptable. In
the second case a repository server is used to serve the
repos and we expect that registration instance to be trustworthy
such that potential vendor changes are also allowed