### PR TITLE
Perform reboot through systemd

### DIFF
--- a/suse_migration_services/units/reboot.py
+++ b/suse_migration_services/units/reboot.py
@@ -67,9 +67,14 @@ def main():
                     )
                 )
             log.info(
-                'Reboot system: [kexec]: {0}{1}'.format(
+                # reboot is performed through systemd. The call through
+                # systemd checks if there is a kexec loaded kernel and
+                # transparently turns 'systemctl reboot' into
+                # 'systemctl kexec'. Thus both ways, soft and hard
+                # reboot are managed in one call.
+                'Reboot system: {0}{1}'.format(
                     os.linesep, Command.run(
-                        ['kexec', '--exec']
+                        ['systemctl', 'reboot']
                     )
                 )
             )
@@ -79,5 +84,5 @@ def main():
         # Keep fingers crossed:
         log.warning('Reboot system: [Force Reboot]')
         Command.run(
-            ['reboot', '-f']
+            ['systemctl', '--force', 'reboot']
         )

--- a/test/unit/units/reboot_test.py
+++ b/test/unit/units/reboot_test.py
@@ -57,7 +57,7 @@ class TestKernelReboot(object):
                 ['umount', '--lazy', '/system-root/'],
                 raise_on_error=False
             ),
-            call(['kexec', '--exec'])
+            call(['systemctl', 'reboot'])
         ]
 
     @patch.object(Defaults, 'get_migration_config_file')
@@ -100,8 +100,8 @@ class TestKernelReboot(object):
                 ['umount', '--lazy', '/system-root/'],
                 raise_on_error=False
             ),
-            call(['kexec', '--exec']),
-            call(['reboot', '-f'])
+            call(['systemctl', 'reboot']),
+            call(['systemctl', '--force', 'reboot'])
         ]
         mock_warning.assert_called_once_with(
             'Reboot system: [Force Reboot]'


### PR DESCRIPTION
reboot is performed through systemd. The call through systemd
checks if there is a kexec loaded kernel and transparently
turns 'systemctl reboot' into 'systemctl kexec'. Thus both ways,
soft and hard reboot are managed in one call. This is related
to Issue #111