### PR TITLE
Gracefully handle syntax errors in custom config file

### DIFF
--- a/test/data/custom-migration-config-corrupt-mess.yml
+++ b/test/data/custom-migration-config-corrupt-mess.yml
@@ -1,0 +1,2 @@
+name: value_is_good
+but:this is horribly broken!

--- a/test/data/custom-migration-config-corrupt-string.yml
+++ b/test/data/custom-migration-config-corrupt-string.yml
@@ -1,0 +1,1 @@
+name:value_but_missing_whitespace_after_the_colon

--- a/test/data/custom-migration-config-just-comments.yml
+++ b/test/data/custom-migration-config-just-comments.yml
@@ -1,0 +1,1 @@
+# nothing to see here, move along

--- a/test/unit/migration_config_test.py
+++ b/test/unit/migration_config_test.py
@@ -68,3 +68,75 @@ class TestMigrationConfig(object):
             mock_yaml_dump.assert_called_once_with(
                 self.config.config_data, file_handle, default_flow_style=False
             )
+
+    @patch.object(MigrationConfig, '_write_config_file')
+    @patch('suse_migration_services.logger.log.info')
+    @patch.object(Defaults, 'get_migration_config_file')
+    @patch.object(Defaults, 'get_system_migration_custom_config_file')
+    def test_update_migration_config_file_empty(
+        self, mock_get_system_migration_config_custom_file,
+        mock_get_migration_config_file,
+        mock_info, mock_write_config_file,
+    ):
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config.yml'
+        mock_get_system_migration_config_custom_file.return_value = \
+            '../data/custom-migration-config-empty.yml'
+        self.config = MigrationConfig()
+        self.config.update_migration_config_file()
+        mock_info.assert_not_called()
+
+    @patch.object(MigrationConfig, '_write_config_file')
+    @patch('suse_migration_services.logger.log.info')
+    @patch.object(Defaults, 'get_migration_config_file')
+    @patch.object(Defaults, 'get_system_migration_custom_config_file')
+    def test_update_migration_config_file_just_comments(
+        self, mock_get_system_migration_config_custom_file,
+        mock_get_migration_config_file,
+        mock_info, mock_write_config_file,
+    ):
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config.yml'
+        mock_get_system_migration_config_custom_file.return_value = \
+            '../data/custom-migration-config-just-comments.yml'
+        self.config = MigrationConfig()
+        self.config.update_migration_config_file()
+        mock_info.assert_not_called()
+
+    @patch.object(MigrationConfig, '_write_config_file')
+    @patch('suse_migration_services.logger.log.warning')
+    @patch('suse_migration_services.logger.log.info')
+    @patch.object(Defaults, 'get_migration_config_file')
+    @patch.object(Defaults, 'get_system_migration_custom_config_file')
+    def test_update_migration_config_file_slightly_broken(
+        self, mock_get_system_migration_config_custom_file,
+        mock_get_migration_config_file,
+        mock_info, mock_warning, mock_write_config_file,
+    ):
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config.yml'
+        mock_get_system_migration_config_custom_file.return_value = \
+            '../data/custom-migration-config-corrupt-string.yml'
+        self.config = MigrationConfig()
+        self.config.update_migration_config_file()
+        mock_info.assert_not_called()
+        assert mock_warning.called
+
+    @patch.object(MigrationConfig, '_write_config_file')
+    @patch('suse_migration_services.logger.log.warning')
+    @patch('suse_migration_services.logger.log.info')
+    @patch.object(Defaults, 'get_migration_config_file')
+    @patch.object(Defaults, 'get_system_migration_custom_config_file')
+    def test_update_migration_config_file_very_broken(
+        self, mock_get_system_migration_config_custom_file,
+        mock_get_migration_config_file,
+        mock_info, mock_warning, mock_write_config_file,
+    ):
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config.yml'
+        mock_get_system_migration_config_custom_file.return_value = \
+            '../data/custom-migration-config-corrupt-mess.yml'
+        self.config = MigrationConfig()
+        self.config.update_migration_config_file()
+        mock_info.assert_not_called()
+        assert mock_warning.called


### PR DESCRIPTION
If /etc/sle-migration-service.yml is not valid YAML, or is empty, yaml.safe_load() will either return something that's not a dict, or will raise an exception.  Either way, this kills the suse-migration-mount-system service, resulting in an immediate reboot; the migration does not run, and you'll have something in the log like this:

```
    load_entry_point('suse-migration-services==1.0.4', 'console_scripts', 'suse-migration-mount-system')()
  File "/usr/lib/python3.6/site-packages/suse_migration_services/units/mount_system.py", line 89, in main
    MigrationConfig().update_migration_config_file()
  File "/usr/lib/python3.6/site-packages/suse_migration_services/migration_config.py", line 87, in update_migration_config_file
    self.config_data.update(new_config)
TypeError: 'NoneType' object is not iterable
suse-migration-mount-system.service: Main process exited, code=exited, status=1/FAILURE
```