### PR TITLE
Auto detect migration product

### DIFF
--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -8,7 +8,7 @@ Marcus Schäfer; Jesús Velázquez
 :Authors: Marcus Schäfer and Jesús Bermúdez Velázquez
 :Publication_Date: TBD
 :Latest_Version: 1.1.0
-:Contributors: 
+:Contributors:
 :Repo: https://github.com/SUSE/suse-migration-services[suse-migration-services]
 
 ifdef::env-github[]
@@ -154,12 +154,14 @@ manually. Once done, the upgrade process uses `zypper dup` and expects
 all required repositories to be setup correctly.
 
 Specify Migration Product::
-With the SLES15-Migration package a predefined product setup is
-already applied. That setting can be overwritten with one of the
+With the SLES15-Migration package an auto detected product is
+already applied. If that detection failed, the setting can be overwritten with one of the
 following product specifications:
 
 * SLES/15/x86_64
 * SLES/15.1/x86_64
+* SLES_SAP/15/x86_64
+* SLES_SAP/15.1/x86_64
 
 [listing]
 migration_product: SLES/15/x86_64

--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -16,6 +16,7 @@
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
 import os
+from collections import namedtuple
 
 
 class Defaults(object):
@@ -85,3 +86,16 @@ class Defaults(object):
     @classmethod
     def get_system_sshd_config_path(self):
         return '/etc/ssh/sshd_config'
+
+    @classmethod
+    def get_os_release(self):
+        with open('/etc/os-release', 'r') as handle:
+            keys, values = zip(
+                *[
+                    (key.lower(), value.strip('\'"')) for (key, value) in (
+                        line.strip().split('=', 1) for line in
+                        handle.read().strip().split(os.linesep)
+                    )
+                ]
+            )
+            return namedtuple('OSRelease', keys)(*values)

--- a/suse_migration_services/migration_config.py
+++ b/suse_migration_services/migration_config.py
@@ -21,6 +21,7 @@ from textwrap import dedent
 
 # project
 from suse_migration_services.defaults import Defaults
+from suse_migration_services.suse_product import SUSEBaseProduct
 from suse_migration_services.logger import log
 from suse_migration_services.exceptions import (
     DistMigrationProductNotFoundException
@@ -53,13 +54,17 @@ class MigrationConfig(object):
         The value returned is passed to the --product option in the
         zypper migration call
         """
+        # check for a custom migration product
         migration_product = self.config_data.get('migration_product')
         if not migration_product:
-            message = (
-                'Migration product not found, aborting migration attempt.'
-            )
-            log.error(message)
-            raise DistMigrationProductNotFoundException(message)
+            migration_product = SUSEBaseProduct().get_product_name()
+            if not migration_product:
+                # auto detection went wrong
+                message = (
+                    'Migration product not found, aborting migration attempt.'
+                )
+                log.error(message)
+                raise DistMigrationProductNotFoundException(message)
 
         return migration_product
 

--- a/suse_migration_services/suse_product.py
+++ b/suse_migration_services/suse_product.py
@@ -117,3 +117,23 @@ class SUSEBaseProduct(object):
                 'Parsing XML file {0} failed with: {1}'
                 .format(self.base_product, issue)
             )
+
+    def get_product_name(self):
+        """Get the product name to be migrated to."""
+        migration_product_name = None
+        try:
+            name = self.get_tag('name')[0]
+            arch = self.get_tag('arch')[0]
+            if name and arch:
+                migration_product_name = '/'.join(
+                    [name, self.get_default_target_version(), arch]
+                )
+        except Exception as issue:
+            log.error(
+                'Base product could not be detected: {0}.'.format(issue)
+            )
+
+        return migration_product_name
+
+    def get_default_target_version(self):
+        return Defaults.get_os_release().version_id

--- a/test/data/migration-config.yml
+++ b/test/data/migration-config.yml
@@ -1,5 +1,3 @@
-migration_product: 'SLES/15/x86_64'
-
 preserve:
   rules:
      - /etc/udev/rules.d/a.rules

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -1,3 +1,9 @@
+from unittest.mock import (
+    patch, MagicMock
+)
+import io
+from collections import namedtuple
+
 from suse_migration_services.defaults import Defaults
 
 
@@ -8,3 +14,37 @@ class TestDefaults(object):
     def test_get_migration_config_file(self):
         assert self.defaults.get_migration_config_file() == \
             '/etc/migration-config.yml'
+
+    def test_get_os_release(self):
+        os_release_tuple = namedtuple(
+            'OSRelease', [
+                'name', 'version', 'version_id',
+                'pretty_name', 'id', 'id_like', 'ansi_color', 'cpe_name'
+            ]
+        )
+        os_release_result = os_release_tuple(
+            name='SLES', version='15-SP1', version_id='15.1',
+            pretty_name='SUSE Linux Enterprise Server 15 SP1',
+            id='sles', id_like='suse', ansi_color='0;32',
+            cpe_name='cpe:/o:suse:sles:15:sp1'
+        )
+        os_release_content = ('NAME="SLES"\n'
+                              'VERSION="15-SP1"\n'
+                              'VERSION_ID="15.1"\n'
+                              'PRETTY_NAME="SUSE Linux Enterprise Server 15 SP1"\n'
+                              'ID="sles"\n'
+                              'ID_LIKE="suse"\n'
+                              'ANSI_COLOR="0;32"\n'
+                              'CPE_NAME="cpe:/o:suse:sles:15:sp1"')
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open_os_release = MagicMock(spec=io.IOBase)
+
+            def open_file(filename, mode):
+                if filename == '/etc/os-release':
+                    return mock_open_os_release.return_value
+
+            mock_open.side_effect = open_file
+            file_handle = \
+                mock_open_os_release.return_value.__enter__.return_value
+            file_handle.read.return_value = os_release_content
+            assert self.defaults.get_os_release() == os_release_result

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -6,6 +6,7 @@ from pytest import raises
 
 from suse_migration_services.units.migrate import main
 from suse_migration_services.defaults import Defaults
+from suse_migration_services.migration_config import MigrationConfig
 from suse_migration_services.exceptions import (
     DistMigrationZypperException
 )
@@ -82,14 +83,16 @@ class TestMigration(object):
             zypper_call.returncode = 107
             main()
 
+    @patch.object(MigrationConfig, 'get_migration_product')
     @patch('suse_migration_services.command.Command.run')
     @patch.object(Defaults, 'get_migration_config_file')
     @patch('suse_migration_services.logger.log.error')
     @patch('suse_migration_services.logger.log.info')
     def test_main_zypper_migration_plugin(
         self, mock_info, mock_error, mock_get_migration_config_file,
-        mock_Command_run
+        mock_Command_run, mock_get_system_root_path
     ):
+        mock_get_system_root_path.return_value = 'SLES/15/x86_64'
         mock_get_migration_config_file.return_value = \
             '../data/migration-config.yml'
         main()


### PR DESCRIPTION
As there could be different targets (SLES, SLES_SAP, etc)
instead of setting the target in the custom file, the migration
system auto detects the migration product.

This Fixes #129