### PR TITLE
Require SUSEConnect updated version

### DIFF
--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -35,6 +35,7 @@ Requires:         kexec-tools
 Requires:         ca-certificates
 Requires:         dialog
 Requires:         rsync
+Requires:         SUSEConnect >= 0.3.20
 Requires(preun):  systemd
 Requires(postun): systemd
 BuildArch:        noarch


### PR DESCRIPTION
In a failed distribution migration scenario,
zypper-migration does a rollback. During this
rollback, zypper tries to refresh deactivated
repos, making the rollback fail.

This has been fixed in the newer (0.3.20) version of SUSEConnect.

This Fixes #133