### PR TITLE
Add schema validation for migration config file

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -1,2 +1,3 @@
 setuptools
 PyYAML
+cerberus

--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -28,6 +28,7 @@ BuildRoot:        %{_tmppath}/%{name}-%{version}-build
 BuildRequires:    python3-devel
 BuildRequires:    python3-setuptools
 BuildRequires:    systemd-rpm-macros
+Requires:         python3-Cerberus
 Requires:         python3-PyYAML
 Requires:         python3-setuptools
 Requires:         util-linux

--- a/suse_migration_services/exceptions.py
+++ b/suse_migration_services/exceptions.py
@@ -127,3 +127,9 @@ class DistMigrationSUSEBaseProductException(DistMigrationException):
     from the bind mounted etc/products.d location into the
     migrated system has failed
     """
+
+
+class DistMigrationConfigDataException(DistMigrationException):
+    """
+    Exception raised if the custom config file is invalid or corrupt
+    """

--- a/suse_migration_services/schema.py
+++ b/suse_migration_services/schema.py
@@ -1,0 +1,29 @@
+schema = {
+    'debug': {
+        'required': False,
+        'type': 'boolean'
+    },
+    'migration_product': {
+        'required': False,
+        'type': 'string'
+    },
+    'preserve': {
+        'required': False,
+        'type': 'dict',
+        'schema': {
+            'rules': {
+                'required': True,
+                'type': 'list',
+                'nullable': False
+            }
+        }
+    },
+    'soft_reboot': {
+        'required': False,
+        'type': 'boolean'
+    },
+    'use_zypper_migration': {
+        'required': False,
+        'type': 'boolean'
+    }
+}

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -95,15 +95,6 @@ def main():
     cloud_register_metadata = os.sep.join(
         [root_path, 'var', 'lib', 'cloudregister']
     )
-    dev_mount_point = os.sep.join(
-        [root_path, 'dev']
-    )
-    proc_mount_point = os.sep.join(
-        [root_path, 'proc']
-    )
-    sys_mount_point = os.sep.join(
-        [root_path, 'sys']
-    )
     try:
         # log network info as network-online.target is done at this point
         log_network_details()
@@ -135,25 +126,6 @@ def main():
                     '/var/lib/cloudregister'
                 ]
             )
-        log.info('Mounting kernel file systems inside {0}'.format(root_path))
-        Command.run(
-            ['mount', '-t', 'devtmpfs', 'devtmpfs', dev_mount_point]
-        )
-        system_mount.add_entry(
-            'devtmpfs', dev_mount_point
-        )
-        Command.run(
-            ['mount', '-t', 'proc', 'proc', proc_mount_point]
-        )
-        system_mount.add_entry(
-            '/proc', proc_mount_point
-        )
-        Command.run(
-            ['mount', '-t', 'sysfs', 'sysfs', sys_mount_point]
-        )
-        system_mount.add_entry(
-            'sysfs', sys_mount_point
-        )
         system_mount.export(
             Defaults.get_system_mount_info_file()
         )
@@ -163,11 +135,8 @@ def main():
                 issue
             )
         )
-        log.info('Unmounting kernel file systems, if any')
-        for entry in reversed(system_mount.get_devices()):
-            Command.run(
-                ['umount', entry.mountpoint], raise_on_error=False
-            )
+        # Not unmounting any of the bind mounts above; the reboot
+        # service should take care of that anyway
         raise DistMigrationZypperMetaDataException(
             'Preparation of zypper metadata failed with {0}'.format(
                 issue

--- a/test/data/custom-migration-config-corrupt-mess.yml
+++ b/test/data/custom-migration-config-corrupt-mess.yml
@@ -1,0 +1,2 @@
+name: value_is_good
+but:this is horribly broken!

--- a/test/data/custom-migration-config-corrupt-string.yml
+++ b/test/data/custom-migration-config-corrupt-string.yml
@@ -1,0 +1,1 @@
+name:value_but_missing_whitespace_after_the_colon

--- a/test/data/custom-migration-config-just-comments.yml
+++ b/test/data/custom-migration-config-just-comments.yml
@@ -1,0 +1,1 @@
+# nothing to see here, move along

--- a/test/data/custom-migration-config-violates-schema.yml
+++ b/test/data/custom-migration-config-violates-schema.yml
@@ -1,0 +1,3 @@
+debug: 'must be boolean'
+preserve: 'must be a dict'
+this_key: 'is not even in the schema!'

--- a/test/unit/migration_config_test.py
+++ b/test/unit/migration_config_test.py
@@ -7,6 +7,7 @@ import io
 from suse_migration_services.migration_config import MigrationConfig
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.exceptions import (
+    DistMigrationConfigDataException,
     DistMigrationProductNotFoundException
 )
 
@@ -68,3 +69,97 @@ class TestMigrationConfig(object):
             mock_yaml_dump.assert_called_once_with(
                 self.config.config_data, file_handle, default_flow_style=False
             )
+
+    @patch.object(MigrationConfig, '_write_config_file')
+    @patch('suse_migration_services.logger.log.info')
+    @patch.object(Defaults, 'get_migration_config_file')
+    @patch.object(Defaults, 'get_system_migration_custom_config_file')
+    def test_update_migration_config_file_empty(
+        self, mock_get_system_migration_config_custom_file,
+        mock_get_migration_config_file,
+        mock_info, mock_write_config_file,
+    ):
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config.yml'
+        mock_get_system_migration_config_custom_file.return_value = \
+            '../data/custom-migration-config-empty.yml'
+        self.config = MigrationConfig()
+        self.config.update_migration_config_file()
+        mock_info.assert_not_called()
+
+    @patch.object(MigrationConfig, '_write_config_file')
+    @patch('suse_migration_services.logger.log.info')
+    @patch.object(Defaults, 'get_migration_config_file')
+    @patch.object(Defaults, 'get_system_migration_custom_config_file')
+    def test_update_migration_config_file_just_comments(
+        self, mock_get_system_migration_config_custom_file,
+        mock_get_migration_config_file,
+        mock_info, mock_write_config_file,
+    ):
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config.yml'
+        mock_get_system_migration_config_custom_file.return_value = \
+            '../data/custom-migration-config-just-comments.yml'
+        self.config = MigrationConfig()
+        self.config.update_migration_config_file()
+        mock_info.assert_not_called()
+
+    @patch.object(MigrationConfig, '_write_config_file')
+    @patch('suse_migration_services.logger.log.error')
+    @patch('suse_migration_services.logger.log.info')
+    @patch.object(Defaults, 'get_migration_config_file')
+    @patch.object(Defaults, 'get_system_migration_custom_config_file')
+    def test_update_migration_config_file_slightly_broken(
+        self, mock_get_system_migration_config_custom_file,
+        mock_get_migration_config_file,
+        mock_info, mock_error, mock_write_config_file,
+    ):
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config.yml'
+        mock_get_system_migration_config_custom_file.return_value = \
+            '../data/custom-migration-config-corrupt-string.yml'
+        self.config = MigrationConfig()
+        with raises(DistMigrationConfigDataException):
+            self.config.update_migration_config_file()
+        mock_info.assert_not_called()
+        assert mock_error.called
+
+    @patch.object(MigrationConfig, '_write_config_file')
+    @patch('suse_migration_services.logger.log.error')
+    @patch('suse_migration_services.logger.log.info')
+    @patch.object(Defaults, 'get_migration_config_file')
+    @patch.object(Defaults, 'get_system_migration_custom_config_file')
+    def test_update_migration_config_file_very_broken(
+        self, mock_get_system_migration_config_custom_file,
+        mock_get_migration_config_file,
+        mock_info, mock_error, mock_write_config_file,
+    ):
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config.yml'
+        mock_get_system_migration_config_custom_file.return_value = \
+            '../data/custom-migration-config-corrupt-mess.yml'
+        self.config = MigrationConfig()
+        with raises(DistMigrationConfigDataException):
+            self.config.update_migration_config_file()
+        mock_info.assert_not_called()
+        assert mock_error.called
+
+    @patch.object(MigrationConfig, '_write_config_file')
+    @patch('suse_migration_services.logger.log.error')
+    @patch('suse_migration_services.logger.log.info')
+    @patch.object(Defaults, 'get_migration_config_file')
+    @patch.object(Defaults, 'get_system_migration_custom_config_file')
+    def test_update_migration_config_file_violates_schema(
+        self, mock_get_system_migration_config_custom_file,
+        mock_get_migration_config_file,
+        mock_info, mock_error, mock_write_config_file,
+    ):
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config.yml'
+        mock_get_system_migration_config_custom_file.return_value = \
+            '../data/custom-migration-config-violates-schema.yml'
+        self.config = MigrationConfig()
+        with raises(DistMigrationConfigDataException):
+            self.config.update_migration_config_file()
+        mock_info.assert_not_called()
+        assert mock_error.called

--- a/test/unit/units/mount_system_test.py
+++ b/test/unit/units/mount_system_test.py
@@ -187,6 +187,15 @@ class TestMountSystem(object):
                         '/dev/mynode',
                         '/system-root/foo'
                     ]
+                ),
+                call(
+                    ['mount', '-t', 'devtmpfs', 'devtmpfs', '/system-root/dev']
+                ),
+                call(
+                    ['mount', '-t', 'proc', 'proc', '/system-root/proc']
+                ),
+                call(
+                    ['mount', '-t', 'sysfs', 'sysfs', '/system-root/sys']
                 )
             ]
             assert fstab_mock.add_entry.call_args_list == [
@@ -214,6 +223,15 @@ class TestMountSystem(object):
                     '/dev/mynode',
                     '/system-root/foo',
                     'ext4'
+                ),
+                call(
+                    'devtmpfs', '/system-root/dev'
+                ),
+                call(
+                    '/proc', '/system-root/proc'
+                ),
+                call(
+                    'sysfs', '/system-root/sys'
                 )
             ]
             fstab_mock.export.assert_called_once_with(

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -134,15 +134,6 @@ class TestSetupPrepare(object):
                     'mount', '--bind', '/system-root/var/lib/cloudregister',
                     '/var/lib/cloudregister'
                 ]
-            ),
-            call(
-                ['mount', '-t', 'devtmpfs', 'devtmpfs', '/system-root/dev']
-            ),
-            call(
-                ['mount', '-t', 'proc', 'proc', '/system-root/proc']
-            ),
-            call(
-                ['mount', '-t', 'sysfs', 'sysfs', '/system-root/sys']
             )
         ]
         fstab.read.assert_called_once_with(
@@ -154,15 +145,6 @@ class TestSetupPrepare(object):
             ),
             call(
                 '/system-root/usr/lib/zypp/plugins', '/usr/lib/zypp/plugins'
-            ),
-            call(
-                'devtmpfs', '/system-root/dev'
-            ),
-            call(
-                '/proc', '/system-root/proc'
-            ),
-            call(
-                'sysfs', '/system-root/sys'
             )
         ]
         fstab.export.assert_called_once_with(


### PR DESCRIPTION
If the custom config file is empty or contains only comment lines, it will now be ignored (rather than raising an exception and killing the migration). If the file is corrupt somehow, or violates schema validation, an error will be logged and the migration will abort.

Validation is *also* applied to the default config file (the one inside the migration image).  This makes automated testing easy, because we'll effectively do automatic validation on any of the test config files, whether they're for default config or custom config.

There is one problem with the current implementation: if either the default config file *or* the custom config file is broken in some way, and an exception is raised, the subsequent grub setup service fails, and I have no idea why. The log file says:

```
[INFO    ]: 06:09:31 | Running grub setup service
[INFO    ]: 06:09:32 | Uninstalling migration:
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following 2 packages are going to be REMOVED:
  SLES15-SES-Migration suse-migration-sle15-activation

2 packages to remove.
After the operation, 245.1 MiB will be freed.
Continue? [y/n/...? shows all options] (y): y
(1/2) Removing suse-migration-sle15-activation-1.2.0-20.11.noarch [.....done]
Additional rpm output:
awk: fatal: cannot open file `/proc/self/mountinfo' for reading (No such file or directory)
/usr/sbin/grub2-probe: error: cannot find a device for / (is /dev mounted?).
warning: %postun(suse-migration-sle15-activation-1.2.0-20.11.noarch) scriptlet failed, exit status 1

(2/2) Removing SLES15-SES-Migration-1.15.2.tserong.8-33.x86_64 [.....done]

[ERROR   ]: 06:09:32 | Update grub failed with chroot: stderr: awk: fatal: cannot open file `/proc/self/mountinfo' for reading (No such file or directory)
/usr/sbin/grub2-probe: error: cannot find a device for / (is /dev mounted?).
, stdout: (no output on stdout)
```

This means the migration package is removed, but the grub config is not updated correctly, so the next reboot tries to load the migration again, and gets stuck in grub complaining about a
missing ISO. Any assistance would be much appreciated...