### PR TITLE
Fixed reading of config files

### DIFF
--- a/suse_migration_services/migration_config.py
+++ b/suse_migration_services/migration_config.py
@@ -42,35 +42,34 @@ class MigrationConfig(object):
     version as part of the live migration image build.
     """
     def __init__(self):
-        self.config_data = {}
         self.migration_config_file = \
             Defaults.get_migration_config_file()
         self.migration_custom_file = \
             Defaults.get_system_migration_custom_config_file()
-        self.config_data = self._parse_config_file(self.migration_config_file)
+        self.config_data = self._parse_config_file(
+            self.migration_config_file
+        )
 
     def _parse_config_file(self, config_file):
         config_data = {}
-        with open(config_file, 'r') as config:
-            try:
-                validator = Validator(schema)
-                config_data = yaml.safe_load(config)
-                if config_data is None:
-                    # Config file is empty (or all comments), reset to empty dict
-                    config_data = {}
-                validator.validate(config_data)
-            except Exception as e:
-                message = 'Loading {0} failed: {1}: {2}'.format(
-                    config_file, type(e).__name__, e
-                )
-                log.error(message)
-                raise DistMigrationConfigDataException(message)
-            if validator.errors:
-                message = 'Validating {0} failed: {1}'.format(
-                    config_file, validator.errors
-                )
-                log.error(message)
-                raise DistMigrationConfigDataException(message)
+        if os.path.exists(config_file):
+            with open(config_file, 'r') as config:
+                try:
+                    validator = Validator(schema)
+                    config_data = yaml.safe_load(config) or {}
+                    validator.validate(config_data)
+                except Exception as e:
+                    message = 'Loading {0} failed: {1}: {2}'.format(
+                        config_file, type(e).__name__, e
+                    )
+                    log.error(message)
+                    raise DistMigrationConfigDataException(message)
+                if validator.errors:
+                    message = 'Validating {0} failed: {1}'.format(
+                        config_file, validator.errors
+                    )
+                    log.error(message)
+                    raise DistMigrationConfigDataException(message)
         return config_data
 
     def get_migration_product(self):

--- a/test/unit/migration_config_test.py
+++ b/test/unit/migration_config_test.py
@@ -44,9 +44,8 @@ class TestMigrationConfig(object):
             id='sles', id_like='suse', ansi_color='0;32',
             cpe_name='cpe:/o:suse:sles:15:sp1'
         )
-
         mock_get_system_root_path.return_value = '../data'
-        mock_get_os_release.return_value = os_release_result  # '../data/etc/os-release'
+        mock_get_os_release.return_value = os_release_result
         assert self.config.get_migration_product() == 'SLES/15.1/x86_64'
 
     def test_get_preserve_udev_rules_list(self):

--- a/test/unit/units/mount_system_test.py
+++ b/test/unit/units/mount_system_test.py
@@ -124,7 +124,7 @@ class TestMountSystem(object):
         fstab_mock.read.return_value = fstab.read('../data/fstab')
         fstab_mock.get_devices.return_value = fstab.get_devices()
         mock_is_mounted.side_effect = _is_mounted
-        mock_path_exists.side_effect = [True, False]
+        mock_path_exists.side_effect = [True, True, False]
         mock_Fstab.return_value = fstab_mock
         command = Mock()
         command.returncode = 1


### PR DESCRIPTION
There are two potential config files, both are optional
but one of them was opened in any case and if not present
raises an exception. This should not be the case and gets
fixed by this commit