### PR TITLE
Prevent kernel filesystems from umount

### DIFF
--- a/suse_migration_services/units/mount_system.py
+++ b/suse_migration_services/units/mount_system.py
@@ -150,26 +150,17 @@ def mount_system(root_path, fstab):
         Command.run(
             ['mount', '-t', 'devtmpfs', 'devtmpfs', dev_mount_point]
         )
-        system_mount.add_entry(
-            'devtmpfs', dev_mount_point
-        )
         proc_mount_point = os.sep.join(
             [root_path, 'proc']
         )
         Command.run(
             ['mount', '-t', 'proc', 'proc', proc_mount_point]
         )
-        system_mount.add_entry(
-            '/proc', proc_mount_point
-        )
         sys_mount_point = os.sep.join(
             [root_path, 'sys']
         )
         Command.run(
             ['mount', '-t', 'sysfs', 'sysfs', sys_mount_point]
-        )
-        system_mount.add_entry(
-            'sysfs', sys_mount_point
         )
     except Exception as issue:
         log.error(

--- a/test/unit/units/mount_system_test.py
+++ b/test/unit/units/mount_system_test.py
@@ -223,15 +223,6 @@ class TestMountSystem(object):
                     '/dev/mynode',
                     '/system-root/foo',
                     'ext4'
-                ),
-                call(
-                    'devtmpfs', '/system-root/dev'
-                ),
-                call(
-                    '/proc', '/system-root/proc'
-                ),
-                call(
-                    'sysfs', '/system-root/sys'
                 )
             ]
             fstab_mock.export.assert_called_once_with(


### PR DESCRIPTION
Since the change to let systemd drive the reboot process
it is needed to keep the kernel filesystems proc, sys and dev
open to let systemd perform its job. The umounting prior to
reboot will be taken over by systemd as well. However if systemd
can't read e.g the state of kexec through /sys it can't
work as expected