### PR TITLE
Fixed reboot call procedure

### DIFF
--- a/suse_migration_services/units/reboot.py
+++ b/suse_migration_services/units/reboot.py
@@ -66,15 +66,14 @@ def main():
                         )
                     )
                 )
+            if not MigrationConfig().is_soft_reboot_requested():
+                restart_system = 'reboot'
+            else:
+                restart_system = 'kexec'
             log.info(
-                # reboot is performed through systemd. The call through
-                # systemd checks if there is a kexec loaded kernel and
-                # transparently turns 'systemctl reboot' into
-                # 'systemctl kexec'. Thus both ways, soft and hard
-                # reboot are managed in one call.
                 'Reboot system: {0}{1}'.format(
                     os.linesep, Command.run(
-                        ['systemctl', 'reboot']
+                        ['systemctl', restart_system]
                     )
                 )
             )

--- a/test/data/migration-config-hard-reboot.yml
+++ b/test/data/migration-config-hard-reboot.yml
@@ -1,0 +1,1 @@
+soft_reboot: false

--- a/test/unit/units/reboot_test.py
+++ b/test/unit/units/reboot_test.py
@@ -57,7 +57,7 @@ class TestKernelReboot(object):
                 ['umount', '--lazy', '/system-root/'],
                 raise_on_error=False
             ),
-            call(['systemctl', 'reboot'])
+            call(['systemctl', 'kexec'])
         ]
 
     @patch.object(Defaults, 'get_migration_config_file')
@@ -83,7 +83,7 @@ class TestKernelReboot(object):
             None
         ]
         mock_get_migration_config_file.return_value = \
-            '../data/migration-config.yml'
+            '../data/migration-config-hard-reboot.yml'
         main()
         assert mock_info.called
         assert mock_Command_run.call_args_list == [


### PR DESCRIPTION
the systemd magic that detects whether to do kexec or not, is only
applied if we invoke reboot. systemd internally maps reboot to one or
the other of 'systemctl reboot' or 'systemctl kexec'. Therefore the
current implementation which just call 'systemctl reboot' does not
transparently detect for kexec. As we don't want to rely on the
magic behind the reboot call we explicitly call systemctl with
reboot or kecec depending on the configured soft_reboot
configuration option. This is then also in line with the code
that runs 'kexec load' which also depends on the configured
soft_reboot value.