### PR TITLE
Bind mount usr/lib/zypp/plugins/services

### DIFF
--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -89,8 +89,8 @@ def main():
     zypp_metadata = os.sep.join(
         [root_path, 'etc', 'zypp']
     )
-    zypp_plugins = os.sep.join(
-        [root_path, 'usr', 'lib', 'zypp', 'plugins']
+    zypp_plugins_services = os.sep.join(
+        [root_path, 'usr', 'lib', 'zypp', 'plugins', 'services']
     )
     cloud_register_metadata = os.sep.join(
         [root_path, 'var', 'lib', 'cloudregister']
@@ -112,10 +112,10 @@ def main():
         )
         log.info('Bind mounting /usr/lib/zypp/plugins')
         Command.run(
-            ['mount', '--bind', zypp_plugins, '/usr/lib/zypp/plugins']
+            ['mount', '--bind', zypp_plugins_services, '/usr/lib/zypp/plugins/services']
         )
         system_mount.add_entry(
-            zypp_plugins, '/usr/lib/zypp/plugins'
+            zypp_plugins_services, '/usr/lib/zypp/plugins/services'
         )
         if os.path.exists(cloud_register_metadata):
             log.info('Bind mounting /var/lib/cloudregister')

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -125,8 +125,8 @@ class TestSetupPrepare(object):
             ),
             call(
                 [
-                    'mount', '--bind', '/system-root/usr/lib/zypp/plugins',
-                    '/usr/lib/zypp/plugins'
+                    'mount', '--bind', '/system-root/usr/lib/zypp/plugins/services',
+                    '/usr/lib/zypp/plugins/services'
                 ]
             ),
             call(
@@ -144,7 +144,8 @@ class TestSetupPrepare(object):
                 '/system-root/etc/zypp', '/etc/zypp'
             ),
             call(
-                '/system-root/usr/lib/zypp/plugins', '/usr/lib/zypp/plugins'
+                '/system-root/usr/lib/zypp/plugins/services',
+                '/usr/lib/zypp/plugins/services'
             )
         ]
         fstab.export.assert_called_once_with(


### PR DESCRIPTION
Bind mounting usr/lib/zypp/plugins causes that
old version of urlresolver gets called which
breaks the migration on the zypper level.

Instead of mounting all the plugins path, only services is needed.

This Fixes #151