### PR TITLE
Fixed static method call

### DIFF
--- a/suse_migration_services/suse_connect.py
+++ b/suse_migration_services/suse_connect.py
@@ -21,7 +21,8 @@ from suse_migration_services.logger import log
 
 
 class SUSEConnect:
-    def is_registered(self):
+    @staticmethod
+    def is_registered():
         extensions_cmd_result = Command.run(
             ['SUSEConnect', '--list-extensions'],
             raise_on_error=False


### PR DESCRIPTION
The method is_registered is implemented as object method
but is called as static method SUSEConnect.is_registered().
This is wrong and causes a python runtime error on missing
argument: self