### PR TITLE
Cleanup code for style and scope

### DIFF
--- a/suse_migration_services/command.py
+++ b/suse_migration_services/command.py
@@ -27,7 +27,7 @@ from .exceptions import (
 )
 
 
-class Command(object):
+class Command:
     """
     **Implements command invocation**
 
@@ -35,8 +35,8 @@ class Command(object):
     commands in blocking and non blocking mode. Control of
     stdout and stderr is given to the caller
     """
-    @classmethod
-    def run(self, command, custom_env=None, raise_on_error=True):
+    @staticmethod
+    def run(command, custom_env=None, raise_on_error=True):
         """
         Execute a program and block the caller. The return value
         is a hash containing the stdout, stderr and return code
@@ -110,8 +110,8 @@ class Command(object):
             returncode=process.returncode
         )
 
-    @classmethod
-    def call(self, command, custom_env=None):
+    @staticmethod
+    def call(command, custom_env=None):
         """
         Execute a program and return an io file handle pair back.
         stdout and stderr are both on different channels. The caller

--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -19,76 +19,80 @@ import os
 from collections import namedtuple
 
 
-class Defaults(object):
+class Defaults:
     """
     **Implements default values**
 
     Provides class methods for default values
     """
-    @classmethod
-    def get_system_root_path(self):
+    @staticmethod
+    def get_system_root_path():
         return '/system-root'
 
-    @classmethod
-    def get_migration_config_file(self):
+    @staticmethod
+    def get_migration_config_file():
         return '/etc/migration-config.yml'
 
-    @classmethod
-    def get_migration_log_file(self):
+    @staticmethod
+    def get_migration_log_file():
         return os.sep.join(
-            [self.get_system_root_path(), 'var/log/distro_migration.log']
+            [Defaults.get_system_root_path(), 'var/log/distro_migration.log']
         )
 
-    @classmethod
-    def get_system_migration_custom_config_file(self):
+    @staticmethod
+    def get_system_migration_custom_config_file():
         return os.sep.join(
-            [self.get_system_root_path(), 'etc/sle-migration-service.yml']
+            [Defaults.get_system_root_path(), 'etc/sle-migration-service.yml']
         )
 
-    @classmethod
-    def get_system_mount_info_file(self):
+    @staticmethod
+    def get_system_mount_info_file():
         return '/etc/system-root.fstab'
 
-    @classmethod
-    def get_grub_config_file(self):
+    @staticmethod
+    def get_grub_config_file():
         return 'boot/grub2/grub.cfg'
 
-    @classmethod
-    def get_target_kernel(self):
+    @staticmethod
+    def get_target_kernel():
         return 'boot/vmlinuz'
 
-    @classmethod
-    def get_target_initrd(self):
+    @staticmethod
+    def get_target_initrd():
         return 'boot/initrd'
 
-    @classmethod
-    def get_ssh_keys_paths(self):
+    @staticmethod
+    def get_ssh_keys_paths():
         return [
-            self._get_ssh_keys_path(self, 'home/*'),
-            self._get_ssh_keys_path(self, 'root')
+            Defaults._get_ssh_keys_path('home/*'),
+            Defaults._get_ssh_keys_path('root')
         ]
 
-    @classmethod
-    def get_migration_ssh_file(self):
+    @staticmethod
+    def get_migration_ssh_file():
         return '/home/migration/.ssh/authorized_keys'
 
-    def _get_ssh_keys_path(self, prefix_path):
+    @staticmethod
+    def _get_ssh_keys_path(prefix_path):
         return os.sep.join(
-            [self.get_system_root_path(), prefix_path, '.ssh/authorized_keys']
+            [
+                Defaults.get_system_root_path(), prefix_path,
+                '.ssh/authorized_keys'
+            ]
         )
 
-    @classmethod
-    def get_system_ssh_host_keys_glob_path(self):
+    @staticmethod
+    def get_system_ssh_host_keys_glob_path():
         return os.sep.join(
-            [self.get_system_root_path(), 'etc/ssh/ssh_host_*']
+            [Defaults.get_system_root_path(), 'etc/ssh/ssh_host_*']
         )
 
-    @classmethod
-    def get_system_sshd_config_path(self):
+    @staticmethod
+    def get_system_sshd_config_path():
         return '/etc/ssh/sshd_config'
 
-    @classmethod
-    def get_os_release(self):
+    @staticmethod
+    def get_os_release():
         with open('/etc/os-release', 'r') as handle:
             keys, values = zip(
                 *[

--- a/suse_migration_services/fstab.py
+++ b/suse_migration_services/fstab.py
@@ -22,7 +22,7 @@ from collections import namedtuple
 from suse_migration_services.logger import log
 
 
-class Fstab(object):
+class Fstab:
     """
     **Managing fstab values**
     """

--- a/suse_migration_services/migration_config.py
+++ b/suse_migration_services/migration_config.py
@@ -31,7 +31,7 @@ from suse_migration_services.exceptions import (
 )
 
 
-class MigrationConfig(object):
+class MigrationConfig:
     """
     **Implements reading of migration configuration file:**
 

--- a/suse_migration_services/path.py
+++ b/suse_migration_services/path.py
@@ -21,12 +21,12 @@ import os
 from .command import Command
 
 
-class Path(object):
+class Path:
     """
     **Directory path helpers**
     """
-    @classmethod
-    def create(self, path):
+    @staticmethod
+    def create(path):
         """
         Create path and all sub directories to target
 
@@ -36,8 +36,8 @@ class Path(object):
             ['mkdir', '-p', path]
         )
 
-    @classmethod
-    def wipe(self, path):
+    @staticmethod
+    def wipe(path):
         """
         Delete path and all contents
 
@@ -47,8 +47,8 @@ class Path(object):
             ['rm', '-r', '-f', path]
         )
 
-    @classmethod
-    def remove(self, path):
+    @staticmethod
+    def remove(path):
         """
         Delete empty path, causes an error if target is not empty
 
@@ -58,9 +58,9 @@ class Path(object):
             ['rmdir', path]
         )
 
-    @classmethod
+    @staticmethod
     def which(
-        self, filename, alternative_lookup_paths=None,
+        filename, alternative_lookup_paths=None,
         custom_env=None, access_mode=None
     ):
         """

--- a/suse_migration_services/suse_connect.py
+++ b/suse_migration_services/suse_connect.py
@@ -20,7 +20,7 @@ from suse_migration_services.command import Command
 from suse_migration_services.logger import log
 
 
-class SUSEConnect(object):
+class SUSEConnect:
     def is_registered(self):
         extensions_cmd_result = Command.run(
             ['SUSEConnect', '--list-extensions'],

--- a/suse_migration_services/suse_product.py
+++ b/suse_migration_services/suse_product.py
@@ -28,7 +28,7 @@ from suse_migration_services.exceptions import (
 )
 
 
-class SUSEBaseProduct(object):
+class SUSEBaseProduct:
     def __init__(self):
         root_path = Defaults.get_system_root_path()
         self.products_metadata = os.sep.join(

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -120,7 +120,10 @@ def main():
         )
         log.info('Bind mounting /usr/lib/zypp/plugins')
         Command.run(
-            ['mount', '--bind', zypp_plugins_services, '/usr/lib/zypp/plugins/services']
+            [
+                'mount', '--bind', zypp_plugins_services,
+                '/usr/lib/zypp/plugins/services'
+            ]
         )
         system_mount.add_entry(
             zypp_plugins_services, '/usr/lib/zypp/plugins/services'


### PR DESCRIPTION
Static methods should be explicitly written as such.
As we are on python3 there is no need to inherit from
Object for classes. Also respect the 80chars per line
limit