### PR TITLE
Fixed registration check

### DIFF
--- a/suse_migration_services/suse_connect.py
+++ b/suse_migration_services/suse_connect.py
@@ -18,13 +18,21 @@
 # project
 from suse_migration_services.command import Command
 from suse_migration_services.logger import log
+from suse_migration_services.defaults import Defaults
 
 
 class SUSEConnect:
     @staticmethod
     def is_registered():
+        """
+        Run SUSEConnect to list available extensions and modules.
+        If that list exists the system is registered. If this
+        information cannot be provided for some reason, the system
+        is considered unregistered
+        """
+        root_path = Defaults.get_system_root_path()
         extensions_cmd_result = Command.run(
-            ['SUSEConnect', '--list-extensions'],
+            ['chroot', root_path, 'SUSEConnect', '--list-extensions'],
             raise_on_error=False
         )
         result = True

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -98,12 +98,6 @@ def main():
         [root_path, 'var', 'lib', 'cloudregister']
     )
     try:
-        # System must be registered for the migration to succeed
-        if not SUSEConnect.is_registered():
-            message = 'System not registered. Aborting migration.'
-            log.error(message)
-            raise DistMigrationSystemNotRegisteredException(message)
-
         # log network info as network-online.target is done at this point
         log_network_details()
         log.info('Running prepare service')
@@ -140,6 +134,13 @@ def main():
         system_mount.export(
             Defaults.get_system_mount_info_file()
         )
+        # Check if system is registered
+        if not SUSEConnect.is_registered():
+            message = 'System not registered. Aborting migration.'
+            log.error(message)
+            raise DistMigrationSystemNotRegisteredException(
+                message
+            )
     except Exception as issue:
         log.error(
             'Preparation of zypper metadata failed with {0}'.format(

--- a/test/unit/suse_connect_test.py
+++ b/test/unit/suse_connect_test.py
@@ -14,16 +14,28 @@ class TestSUSEConnect(object):
         command = Mock()
         command.returncode = 0
         mock_Command_run.return_value = command
-        assert SUSEConnect().is_registered()
+        assert SUSEConnect().is_registered() is True
+        mock_Command_run.assert_called_once_with(
+            [
+                'chroot', '/system-root', 'SUSEConnect',
+                '--list-extensions'
+            ], raise_on_error=False
+        )
 
     @patch('suse_migration_services.logger.log.error')
     @patch('suse_migration_services.command.Command.run')
     def test_is_not_registered(
-            self, mock_Command_run, mock_error
+        self, mock_Command_run, mock_error
     ):
         command = Mock()
         command.returncode = 1
         command.output = 'it is not registered'
         mock_Command_run.return_value = command
-        assert not SUSEConnect().is_registered()
+        assert SUSEConnect().is_registered() is False
+        mock_Command_run.assert_called_once_with(
+            [
+                'chroot', '/system-root', 'SUSEConnect',
+                '--list-extensions'
+            ], raise_on_error=False
+        )
         mock_error.assert_called_once_with('it is not registered')

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -128,7 +128,8 @@ class TestSetupPrepare(object):
             ),
             call(
                 [
-                    'mount', '--bind', '/system-root/usr/lib/zypp/plugins/services',
+                    'mount', '--bind',
+                    '/system-root/usr/lib/zypp/plugins/services',
                     '/usr/lib/zypp/plugins/services'
                 ]
             ),
@@ -160,14 +161,23 @@ class TestSetupPrepare(object):
         )
 
     @patch.object(SUSEConnect, 'is_registered')
+    @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.logger.log.error')
     @patch('suse_migration_services.command.Command.run')
+    @patch('suse_migration_services.units.prepare.Fstab')
+    @patch('suse_migration_services.units.prepare.Path')
     @patch('os.path.exists')
+    @patch('shutil.copy')
+    @patch('os.listdir')
     def test_main_no_registered_instance(
-        self, mock_os_path_exists, mock_Command_run,
-        mock_error, mock_is_registered
+        self, mock_os_listdir, mock_shutil_copy, mock_os_path_exists,
+        mock_Path, mock_Fstab, mock_Command_run, mock_log_error,
+        mock_log_info, mock_is_registered
     ):
-        mock_os_path_exists.return_value = False
+        fstab = Mock()
+        mock_Fstab.return_value = fstab
+        mock_os_listdir.return_value = ['foo', 'bar']
+        mock_os_path_exists.return_value = True
         mock_is_registered.return_value = False
         with raises(DistMigrationZypperMetaDataException):
             main()


### PR DESCRIPTION
The SUSEConnect call to check if the system is registered was
called in the live migration system environment. Of course there
it will fail because the live migration system is never registered.
The call has to be performed chrooted inside of the system we
want to migrate. Thus the caller arguments as well as the call
time in the preparation unit needs a fix