### PR TITLE
Conditionally check if the system is registered

### DIFF
--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -19,6 +19,7 @@ import os
 import shutil
 
 # project
+from suse_migration_services.migration_config import MigrationConfig
 from suse_migration_services.path import Path
 from suse_migration_services.command import Command
 from suse_migration_services.fstab import Fstab
@@ -135,12 +136,14 @@ def main():
             Defaults.get_system_mount_info_file()
         )
         # Check if system is registered
-        if not SUSEConnect.is_registered():
-            message = 'System not registered. Aborting migration.'
-            log.error(message)
-            raise DistMigrationSystemNotRegisteredException(
-                message
-            )
+        migration_config = MigrationConfig()
+        if migration_config.is_zypper_migration_plugin_requested():
+            if not SUSEConnect.is_registered():
+                message = 'System not registered. Aborting migration.'
+                log.error(message)
+                raise DistMigrationSystemNotRegisteredException(
+                    message
+                )
     except Exception as issue:
         log.error(
             'Preparation of zypper metadata failed with {0}'.format(

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -71,6 +71,7 @@ class TestSetupPrepare(object):
             ]
 
     @patch.object(SUSEConnect, 'is_registered')
+    @patch('suse_migration_services.units.prepare.MigrationConfig')
     @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.prepare.Fstab')
@@ -80,8 +81,13 @@ class TestSetupPrepare(object):
     @patch('os.listdir')
     def test_main(
         self, mock_os_listdir, mock_shutil_copy, mock_os_path_exists,
-        mock_Path, mock_Fstab, mock_Command_run, mock_info, mock_is_registered
+        mock_Path, mock_Fstab, mock_Command_run, mock_info,
+        mock_MigrationConfig, mock_is_registered
     ):
+        migration_config = Mock()
+        migration_config.is_zypper_migration_plugin_requested.return_value = \
+            True
+        mock_MigrationConfig.return_value = migration_config
         fstab = Mock()
         mock_Fstab.return_value = fstab
         mock_os_listdir.return_value = ['foo', 'bar']
@@ -161,6 +167,7 @@ class TestSetupPrepare(object):
         )
 
     @patch.object(SUSEConnect, 'is_registered')
+    @patch('suse_migration_services.units.prepare.MigrationConfig')
     @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.logger.log.error')
     @patch('suse_migration_services.command.Command.run')
@@ -172,8 +179,12 @@ class TestSetupPrepare(object):
     def test_main_no_registered_instance(
         self, mock_os_listdir, mock_shutil_copy, mock_os_path_exists,
         mock_Path, mock_Fstab, mock_Command_run, mock_log_error,
-        mock_log_info, mock_is_registered
+        mock_log_info, mock_MigrationConfig, mock_is_registered
     ):
+        migration_config = Mock()
+        migration_config.is_zypper_migration_plugin_requested.return_value = \
+            True
+        mock_MigrationConfig.return_value = migration_config
         fstab = Mock()
         mock_Fstab.return_value = fstab
         mock_os_listdir.return_value = ['foo', 'bar']


### PR DESCRIPTION
Only if the zypper migration plugin is used it's required to
check if the system is registered. In case use_zypper_migration
is deactivated through the config file the migration will
run zypper dup with a customer specific set of repositories.
In this case it's not neccessarily required that this system
is registered to use a SUSE repository server.