### PR TITLE
Cleanup and fix logging

### DIFF
--- a/suse_migration_services/command.py
+++ b/suse_migration_services/command.py
@@ -15,16 +15,20 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import logging
 import select
 import os
 import subprocess
 from collections import namedtuple
 
 # project
-from .exceptions import (
+from suse_migration_services.defaults import Defaults
+from suse_migration_services.exceptions import (
     DistMigrationCommandException,
     DistMigrationCommandNotFoundException
 )
+
+log = logging.getLogger(Defaults.get_migration_log_name())
 
 
 class Command:
@@ -83,6 +87,7 @@ class Command:
             else:
                 raise DistMigrationCommandNotFoundException(message)
         try:
+            log.info('Calling: {0}'.format(command))
             process = subprocess.Popen(
                 command,
                 stdout=subprocess.PIPE,
@@ -152,6 +157,7 @@ class Command:
                 'Command "%s" not found in the environment' % command[0]
             )
         try:
+            log.info('Calling: {0}'.format(command))
             process = subprocess.Popen(
                 command,
                 stdout=subprocess.PIPE,

--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -34,6 +34,10 @@ class Defaults:
         return '/etc/migration-config.yml'
 
     @staticmethod
+    def get_migration_log_name():
+        return 'suse-migration'
+
+    @staticmethod
     def get_migration_log_file():
         return os.sep.join(
             [Defaults.get_system_root_path(), 'var/log/distro_migration.log']

--- a/suse_migration_services/fstab.py
+++ b/suse_migration_services/fstab.py
@@ -15,11 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import logging
 import os
 from collections import namedtuple
 
 # project
-from suse_migration_services.logger import log
+from suse_migration_services.defaults import Defaults
+
+log = logging.getLogger(Defaults.get_migration_log_name())
 
 
 class Fstab:

--- a/suse_migration_services/migration_config.py
+++ b/suse_migration_services/migration_config.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import logging
 import yaml
 import os
 from textwrap import dedent
@@ -23,12 +24,13 @@ from cerberus import Validator
 # project
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.suse_product import SUSEBaseProduct
-from suse_migration_services.logger import log
 from suse_migration_services.schema import schema
 from suse_migration_services.exceptions import (
     DistMigrationConfigDataException,
     DistMigrationProductNotFoundException
 )
+
+log = logging.getLogger(Defaults.get_migration_log_name())
 
 
 class MigrationConfig:

--- a/suse_migration_services/path.py
+++ b/suse_migration_services/path.py
@@ -18,7 +18,7 @@
 import os
 
 # project
-from .command import Command
+from suse_migration_services.command import Command
 
 
 class Path:

--- a/suse_migration_services/suse_connect.py
+++ b/suse_migration_services/suse_connect.py
@@ -15,10 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import logging
+
 # project
 from suse_migration_services.command import Command
-from suse_migration_services.logger import log
 from suse_migration_services.defaults import Defaults
+
+log = logging.getLogger(Defaults.get_migration_log_name())
 
 
 class SUSEConnect:

--- a/suse_migration_services/suse_product.py
+++ b/suse_migration_services/suse_product.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import logging
 import os
 import glob
 from xml.etree.ElementTree import ElementTree
@@ -22,10 +23,11 @@ from xml.etree.ElementTree import ElementTree
 # project
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.command import Command
-from suse_migration_services.logger import log
 from suse_migration_services.exceptions import (
     DistMigrationSUSEBaseProductException
 )
+
+log = logging.getLogger(Defaults.get_migration_log_name())
 
 
 class SUSEBaseProduct:

--- a/suse_migration_services/units/grub_setup.py
+++ b/suse_migration_services/units/grub_setup.py
@@ -15,12 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import logging
 import os
 
 # project
 from suse_migration_services.command import Command
 from suse_migration_services.defaults import Defaults
-from suse_migration_services.logger import log
+from suse_migration_services.logger import Logger
 
 from suse_migration_services.exceptions import (
     DistMigrationGrubConfigException
@@ -35,6 +36,8 @@ def main():
     Uninstall live migration packages such that they are no longer
     part of the now migrated system.
     """
+    Logger.setup()
+    log = logging.getLogger(Defaults.get_migration_log_name())
     root_path = Defaults.get_system_root_path()
     grub_config_file = Defaults.get_grub_config_file()
 

--- a/suse_migration_services/units/kernel_load.py
+++ b/suse_migration_services/units/kernel_load.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import logging
 import re
 import os
 import shutil
@@ -22,7 +23,7 @@ import shutil
 # project
 from suse_migration_services.command import Command
 from suse_migration_services.defaults import Defaults
-from suse_migration_services.logger import log
+from suse_migration_services.logger import Logger
 from suse_migration_services.path import Path
 from suse_migration_services.migration_config import MigrationConfig
 
@@ -37,6 +38,8 @@ def main():
 
     Loads the new kernel/initrd after migration for system reboot
     """
+    Logger.setup()
+    log = logging.getLogger(Defaults.get_migration_log_name())
     if not MigrationConfig().is_soft_reboot_requested():
         log.info('skipping kexec --load (hard reboot requested)')
         return
@@ -73,6 +76,7 @@ def main():
 
 
 def _get_cmdline(kernel_name):
+    log = logging.getLogger(Defaults.get_migration_log_name())
     log.info('Getting cmdline for {0}'.format(kernel_name))
     grub_config_file_path = os.sep.join(
         [Defaults.get_system_root_path(), Defaults.get_grub_config_file()]

--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -15,13 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import logging
 import os
 
 # project
 from suse_migration_services.migration_config import MigrationConfig
 from suse_migration_services.command import Command
 from suse_migration_services.defaults import Defaults
-from suse_migration_services.logger import log
+from suse_migration_services.logger import Logger
 
 from suse_migration_services.exceptions import (
     DistMigrationZypperException,
@@ -36,6 +37,8 @@ def main():
     Call zypper migration plugin and migrate the system.
     The output of the call is logged on the system to migrate
     """
+    Logger.setup()
+    log = logging.getLogger(Defaults.get_migration_log_name())
     root_path = Defaults.get_system_root_path()
 
     try:

--- a/suse_migration_services/units/post_mount_system.py
+++ b/suse_migration_services/units/post_mount_system.py
@@ -15,12 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import logging
 import os
 import shutil
 
 # project
 from suse_migration_services.defaults import Defaults
-from suse_migration_services.logger import log
+from suse_migration_services.logger import Logger
 from suse_migration_services.migration_config import MigrationConfig
 from suse_migration_services.command import Command
 
@@ -33,6 +34,8 @@ def main():
     to be migrated to the live migration system and activate
     those file changes to become effective
     """
+    Logger.setup()
+    log = logging.getLogger(Defaults.get_migration_log_name())
     root_path = Defaults.get_system_root_path()
 
     migration_config = MigrationConfig()

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import logging
 import os
 import shutil
 
@@ -25,7 +26,7 @@ from suse_migration_services.command import Command
 from suse_migration_services.fstab import Fstab
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.suse_connect import SUSEConnect
-from suse_migration_services.logger import log
+from suse_migration_services.logger import Logger
 from suse_migration_services.units.setup_host_network import (
     log_network_details
 )
@@ -48,6 +49,8 @@ def main():
     information from the target system. This service makes the necessary
     information available inside the live system that performs the migration.
     """
+    Logger.setup()
+    log = logging.getLogger(Defaults.get_migration_log_name())
     root_path = Defaults.get_system_root_path()
     suse_connect_setup = os.sep.join(
         [root_path, 'etc', 'SUSEConnect']

--- a/suse_migration_services/units/product_setup.py
+++ b/suse_migration_services/units/product_setup.py
@@ -15,8 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import logging
+
 # project
-from suse_migration_services.logger import log
+from suse_migration_services.defaults import Defaults
+from suse_migration_services.logger import Logger
 from suse_migration_services.suse_product import SUSEBaseProduct
 
 from suse_migration_services.exceptions import (
@@ -35,6 +38,8 @@ def main():
     data such that the plugin's rollback mechanism is not
     negatively influenced.
     """
+    Logger.setup()
+    log = logging.getLogger(Defaults.get_migration_log_name())
     try:
         # Note:
         # zypper implements a handling for the distro_target attribute.

--- a/suse_migration_services/units/reboot.py
+++ b/suse_migration_services/units/reboot.py
@@ -15,11 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import logging
 import os
 
 # project
 from suse_migration_services.command import Command
-from suse_migration_services.logger import log
+from suse_migration_services.logger import Logger
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.fstab import Fstab
 from suse_migration_services.migration_config import MigrationConfig
@@ -41,6 +42,8 @@ def main():
     reboot of the migration host with a potential active mount
     is something we accept
     """
+    Logger.setup()
+    log = logging.getLogger(Defaults.get_migration_log_name())
     try:
         log.info(
             'Systemctl Status Information: {0}{1}'.format(

--- a/suse_migration_services/units/setup_host_network.py
+++ b/suse_migration_services/units/setup_host_network.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import logging
 import glob
 import os
 import shutil
@@ -23,7 +24,7 @@ import shutil
 from suse_migration_services.command import Command
 from suse_migration_services.fstab import Fstab
 from suse_migration_services.defaults import Defaults
-from suse_migration_services.logger import log
+from suse_migration_services.logger import Logger
 
 from suse_migration_services.exceptions import (
     DistMigrationNameResolverException,
@@ -39,6 +40,8 @@ def main():
     to become migrated. This includes the import of the resolver
     and network configuration from the migration host
     """
+    Logger.setup()
+    log = logging.getLogger(Defaults.get_migration_log_name())
     root_path = Defaults.get_system_root_path()
 
     resolv_conf = os.sep.join(
@@ -105,6 +108,7 @@ def log_network_details():
     The method must be called in an active and online network state to provide
     most useful information about the network interfaces and its setup.
     """
+    log = logging.getLogger(Defaults.get_migration_log_name())
     log.info(
         'All Network Interfaces {0}{1}'.format(
             os.linesep, Command.run(

--- a/suse_migration_services/units/ssh_keys.py
+++ b/suse_migration_services/units/ssh_keys.py
@@ -15,13 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import logging
 import glob
 import shutil
 import os
 
 # project
 from suse_migration_services.defaults import Defaults
-from suse_migration_services.logger import log
+from suse_migration_services.logger import Logger
 from suse_migration_services.command import Command
 
 
@@ -32,6 +33,8 @@ def main():
     Copy the authoritation key found to the migration user
     directory in order to access through ssh
     """
+    Logger.setup()
+    log = logging.getLogger(Defaults.get_migration_log_name())
     ssh_keys_glob_paths = Defaults.get_ssh_keys_paths()
     migration_ssh_file = Defaults.get_migration_ssh_file()
     system_ssh_host_keys_glob_path = \

--- a/test/unit/logger_test.py
+++ b/test/unit/logger_test.py
@@ -1,122 +1,17 @@
+import io
 from unittest.mock import (
-    patch, Mock
-)
-from pytest import raises
-from collections import namedtuple
-from suse_migration_services.defaults import Defaults
-import logging
-
-from suse_migration_services.logger import (
-    LoggerSchedulerFilter,
-    InfoFilter,
-    DebugFilter,
-    ErrorFilter,
-    WarningFilter,
-    log_init,
-    log
-)
-from suse_migration_services.exceptions import (
-    DistMigrationLoggingException
+    patch, MagicMock
 )
 
-
-class TestLoggerSchedulerFilter(object):
-    def setup(self):
-        self.scheduler_filter = LoggerSchedulerFilter()
-
-    def test_filter(self):
-        MyRecord = namedtuple(
-            'MyRecord',
-            'name'
-        )
-        ignorables = [
-            'apscheduler.scheduler',
-            'apscheduler.executors.default'
-        ]
-        for ignorable in ignorables:
-            record = MyRecord(name=ignorable)
-            assert self.scheduler_filter.filter(record) is False
+from suse_migration_services.logger import Logger
 
 
-class TestInfoFilter(object):
-    def setup(self):
-        self.info_filter = InfoFilter()
-
-    def test_filter(self):
-        MyRecord = namedtuple(
-            'MyRecord',
-            'levelno'
-        )
-        record = MyRecord(levelno=logging.INFO)
-        assert self.info_filter.filter(record) is True
-        record = MyRecord(levelno=logging.ERROR)
-        assert self.info_filter.filter(record) is None
-
-
-class TestDebugFilter(object):
-    def setup(self):
-        self.debug_filter = DebugFilter()
-
-    def test_filter(self):
-        MyRecord = namedtuple(
-            'MyRecord',
-            'levelno'
-        )
-        record = MyRecord(levelno=logging.DEBUG)
-        assert self.debug_filter.filter(record) is True
-        record = MyRecord(levelno=logging.INFO)
-        assert self.debug_filter.filter(record) is None
-
-
-class TestErrorFilter(object):
-    def setup(self):
-        self.error_filter = ErrorFilter()
-
-    def test_filter(self):
-        MyRecord = namedtuple(
-            'MyRecord',
-            'levelno'
-        )
-        record = MyRecord(levelno=logging.ERROR)
-        assert self.error_filter.filter(record) is True
-        record = MyRecord(levelno=logging.WARNING)
-        assert self.error_filter.filter(record) is None
-
-
-class TestWarningFilter(object):
-    def setup(self):
-        self.warning_filter = WarningFilter()
-
-    def test_filter(self):
-        MyRecord = namedtuple(
-            'MyRecord',
-            'levelno'
-        )
-        record = MyRecord(levelno=logging.WARNING)
-        assert self.warning_filter.filter(record) is True
-        record = MyRecord(levelno=logging.ERROR)
-        assert self.warning_filter.filter(record) is None
-
-
-class TestLogger(object):
-    def test_set_logfile_path_not_found(self):
-        with raises(DistMigrationLoggingException):
-            log.set_logfile(Defaults.get_migration_log_file())
-
-    @patch('logging.FileHandler')
-    def test_set_logfile(self, mock_file_handler):
-        log.set_logfile('../data/logfile')
-        mock_file_handler.assert_called_once_with(
-            filename='../data/logfile', encoding='utf-8'
-        )
-
-    @patch('os.path.exists')
-    @patch('logging.getLogger')
-    def test_log_init(self, mock_get_logger, mock_os_path_exists):
-        log = Mock()
-        mock_os_path_exists.return_value = True
-        mock_get_logger.return_value = log
-        log_init()
-        log.set_logfile.assert_called_once_with(
-            '/system-root/var/log/distro_migration.log'
-        )
+class TestLogger:
+    def test_setup(self):
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            logger = Logger()
+            logger.setup()
+            mock_open.assert_called_once_with(
+                '/system-root/var/log/distro_migration.log', 'a', encoding=None
+            )

--- a/test/unit/migration_config_test.py
+++ b/test/unit/migration_config_test.py
@@ -56,9 +56,8 @@ class TestMigrationConfig(object):
     @patch.object(Defaults, 'get_os_release')
     @patch.object(SUSEBaseProduct, 'get_tag')
     @patch.object(Defaults, 'get_system_root_path')
-    @patch('suse_migration_services.logger.log.error')
     def test_get_migration_product_targets(
-        self, mock_error, mock_get_system_root_path,
+        self, mock_get_system_root_path,
         mock_get_product_name, mock_get_os_release
     ):
         os_release_tuple = namedtuple(
@@ -80,15 +79,13 @@ class TestMigrationConfig(object):
 
         with raises(DistMigrationProductNotFoundException):
             self.config.get_migration_product()
-            assert mock_error.called
 
     @patch.object(Defaults, 'get_os_release')
     @patch.object(SUSEBaseProduct, 'get_product_name')
     @patch.object(Defaults, 'get_system_root_path')
     @patch.object(MigrationConfig, '_write_config_file')
-    @patch('suse_migration_services.logger.log.info')
     def test_update_migration_config_file_no_autodetect(
-        self, mock_info, mock_write_config_file,
+        self, mock_write_config_file,
         mock_get_system_root_path, mock_get_product_name,
         mock_get_os_release
     ):
@@ -110,7 +107,6 @@ class TestMigrationConfig(object):
         self.config.update_migration_config_file()
         assert self.config.get_migration_product() == 'SLES/15.1/x86_64'
         assert self.config.is_debug_requested() is True
-        assert mock_info.called
 
     def test_is_zypper_migration_plugin_requested(self):
         assert self.config.is_zypper_migration_plugin_requested() is True
@@ -132,13 +128,12 @@ class TestMigrationConfig(object):
             )
 
     @patch.object(MigrationConfig, '_write_config_file')
-    @patch('suse_migration_services.logger.log.info')
     @patch.object(Defaults, 'get_migration_config_file')
     @patch.object(Defaults, 'get_system_migration_custom_config_file')
     def test_update_migration_config_file_empty(
         self, mock_get_system_migration_config_custom_file,
         mock_get_migration_config_file,
-        mock_info, mock_write_config_file,
+        mock_write_config_file,
     ):
         mock_get_migration_config_file.return_value = \
             '../data/migration-config.yml'
@@ -146,16 +141,14 @@ class TestMigrationConfig(object):
             '../data/custom-migration-config-empty.yml'
         self.config = MigrationConfig()
         self.config.update_migration_config_file()
-        mock_info.assert_not_called()
 
     @patch.object(MigrationConfig, '_write_config_file')
-    @patch('suse_migration_services.logger.log.info')
     @patch.object(Defaults, 'get_migration_config_file')
     @patch.object(Defaults, 'get_system_migration_custom_config_file')
     def test_update_migration_config_file_just_comments(
         self, mock_get_system_migration_config_custom_file,
         mock_get_migration_config_file,
-        mock_info, mock_write_config_file,
+        mock_write_config_file,
     ):
         mock_get_migration_config_file.return_value = \
             '../data/migration-config.yml'
@@ -163,17 +156,13 @@ class TestMigrationConfig(object):
             '../data/custom-migration-config-just-comments.yml'
         self.config = MigrationConfig()
         self.config.update_migration_config_file()
-        mock_info.assert_not_called()
 
     @patch.object(MigrationConfig, '_write_config_file')
-    @patch('suse_migration_services.logger.log.error')
-    @patch('suse_migration_services.logger.log.info')
     @patch.object(Defaults, 'get_migration_config_file')
     @patch.object(Defaults, 'get_system_migration_custom_config_file')
     def test_update_migration_config_file_slightly_broken(
         self, mock_get_system_migration_config_custom_file,
-        mock_get_migration_config_file,
-        mock_info, mock_error, mock_write_config_file,
+        mock_get_migration_config_file, mock_write_config_file,
     ):
         mock_get_migration_config_file.return_value = \
             '../data/migration-config.yml'
@@ -182,18 +171,13 @@ class TestMigrationConfig(object):
         self.config = MigrationConfig()
         with raises(DistMigrationConfigDataException):
             self.config.update_migration_config_file()
-        mock_info.assert_not_called()
-        assert mock_error.called
 
     @patch.object(MigrationConfig, '_write_config_file')
-    @patch('suse_migration_services.logger.log.error')
-    @patch('suse_migration_services.logger.log.info')
     @patch.object(Defaults, 'get_migration_config_file')
     @patch.object(Defaults, 'get_system_migration_custom_config_file')
     def test_update_migration_config_file_very_broken(
         self, mock_get_system_migration_config_custom_file,
-        mock_get_migration_config_file,
-        mock_info, mock_error, mock_write_config_file,
+        mock_get_migration_config_file, mock_write_config_file,
     ):
         mock_get_migration_config_file.return_value = \
             '../data/migration-config.yml'
@@ -202,18 +186,13 @@ class TestMigrationConfig(object):
         self.config = MigrationConfig()
         with raises(DistMigrationConfigDataException):
             self.config.update_migration_config_file()
-        mock_info.assert_not_called()
-        assert mock_error.called
 
     @patch.object(MigrationConfig, '_write_config_file')
-    @patch('suse_migration_services.logger.log.error')
-    @patch('suse_migration_services.logger.log.info')
     @patch.object(Defaults, 'get_migration_config_file')
     @patch.object(Defaults, 'get_system_migration_custom_config_file')
     def test_update_migration_config_file_violates_schema(
         self, mock_get_system_migration_config_custom_file,
-        mock_get_migration_config_file,
-        mock_info, mock_error, mock_write_config_file,
+        mock_get_migration_config_file, mock_write_config_file,
     ):
         mock_get_migration_config_file.return_value = \
             '../data/migration-config.yml'
@@ -222,5 +201,3 @@ class TestMigrationConfig(object):
         self.config = MigrationConfig()
         with raises(DistMigrationConfigDataException):
             self.config.update_migration_config_file()
-        mock_info.assert_not_called()
-        assert mock_error.called

--- a/test/unit/suse_connect_test.py
+++ b/test/unit/suse_connect_test.py
@@ -1,3 +1,5 @@
+import logging
+from pytest import fixture
 from unittest.mock import (
     patch, Mock
 )
@@ -7,6 +9,10 @@ from suse_migration_services.suse_connect import SUSEConnect
 
 
 class TestSUSEConnect(object):
+    @fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
     @patch('suse_migration_services.command.Command.run')
     def test_is_registered(
         self, mock_Command_run
@@ -22,20 +28,18 @@ class TestSUSEConnect(object):
             ], raise_on_error=False
         )
 
-    @patch('suse_migration_services.logger.log.error')
     @patch('suse_migration_services.command.Command.run')
-    def test_is_not_registered(
-        self, mock_Command_run, mock_error
-    ):
+    def test_is_not_registered(self, mock_Command_run):
         command = Mock()
         command.returncode = 1
         command.output = 'it is not registered'
         mock_Command_run.return_value = command
-        assert SUSEConnect().is_registered() is False
-        mock_Command_run.assert_called_once_with(
-            [
-                'chroot', '/system-root', 'SUSEConnect',
-                '--list-extensions'
-            ], raise_on_error=False
-        )
-        mock_error.assert_called_once_with('it is not registered')
+        with self._caplog.at_level(logging.ERROR):
+            assert SUSEConnect().is_registered() is False
+            mock_Command_run.assert_called_once_with(
+                [
+                    'chroot', '/system-root', 'SUSEConnect',
+                    '--list-extensions'
+                ], raise_on_error=False
+            )
+            assert 'it is not registered' in self._caplog.text

--- a/test/unit/suse_product_test.py
+++ b/test/unit/suse_product_test.py
@@ -20,29 +20,21 @@ class TestSUSEProduct(object):
 
     @patch.object(Defaults, 'get_system_root_path')
     @patch('suse_migration_services.suse_product.ElementTree.parse')
-    @patch('suse_migration_services.logger.log.warning')
-    @patch('suse_migration_services.logger.log.error')
     def test_baseproduct_raises(
-        self, mock_error, mock_warning,
-        mock_ElementTree_parse, mock_get_system_root_path
+        self, mock_ElementTree_parse, mock_get_system_root_path
     ):
         mock_ElementTree_parse.side_effect = Exception
         mock_get_system_root_path.return_value = '../data'
         with raises(DistMigrationSUSEBaseProductException):
             SUSEBaseProduct()
-        assert mock_warning.call_count == 2
-        assert mock_error.called
 
     @patch.object(SUSEBaseProduct, 'backup_products_metadata')
     @patch('suse_migration_services.suse_product.ElementTree')
-    @patch('suse_migration_services.logger.log.error')
     def test_delete_target_registration_raises(
-        self, mock_error, mock_ElementTree,
-        mock_backup_product_md
+        self, mock_ElementTree, mock_backup_product_md
     ):
         mock_ElementTree().parse.side_effect = Exception
         self.suse_product.delete_target_registration()
-        mock_error.assert_called_once()
 
     @patch('suse_migration_services.suse_product.ElementTree')
     def test_baseproduct_tag_text(
@@ -53,11 +45,7 @@ class TestSUSEProduct(object):
         product_name = self.suse_product.get_tag('name')
         assert product_name[0] == 'SLES'
 
-    @patch('suse_migration_services.logger.log.warning')
     @patch('suse_migration_services.suse_product.ElementTree')
-    def test_baseproduct_tag_text_raises(
-        self, mock_ElementTree, mock_warning
-    ):
+    def test_baseproduct_tag_text_raises(self, mock_ElementTree):
         mock_ElementTree().parse.side_effect = Exception
         self.suse_product.get_tag('name')
-        assert mock_warning.called

--- a/test/unit/units/grub_setup_test.py
+++ b/test/unit/units/grub_setup_test.py
@@ -10,12 +10,10 @@ from suse_migration_services.exceptions import (
 
 
 class TestGrubSetup(object):
-    @patch('suse_migration_services.logger.log.error')
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     def test_main_raises_on_grub_update(
-        self, mock_Command_run,
-        mock_info, mock_error
+        self, mock_Command_run, mock_logger_setup
     ):
         mock_Command_run.side_effect = [
             None,
@@ -23,13 +21,11 @@ class TestGrubSetup(object):
         ]
         with raises(DistMigrationGrubConfigException):
             main()
-            assert mock_info.called
-            assert mock_error.called
 
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     def test_main(
-        self, mock_Command_run, mock_info
+        self, mock_Command_run, mock_logger_setup
     ):
         main()
         assert mock_Command_run.call_args_list == [
@@ -48,4 +44,3 @@ class TestGrubSetup(object):
                 ]
             )
         ]
-        assert mock_info.called

--- a/test/unit/units/kernel_load_test.py
+++ b/test/unit/units/kernel_load_test.py
@@ -14,21 +14,18 @@ from suse_migration_services.exceptions import (
 
 
 class TestKernelLoad(object):
-    @patch('suse_migration_services.logger.log.error')
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('os.path.exists')
     def test_get_cmd_line_grub_cfg_not_present(
-        self, mock_os_path_exists, mock_info, mock_error
+        self, mock_os_path_exists, mock_logger_setup
     ):
         mock_os_path_exists.return_value = False
         with raises(DistMigrationKernelRebootException):
             _get_cmdline(Defaults.get_grub_config_file())
-            assert mock_info.called
-            assert mock_error.called
 
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('os.path.exists')
-    def test_get_cmd_line(self, mock_path_exists, mock_info):
+    def test_get_cmd_line(self, mock_path_exists, mock_logger_setup):
         mock_path_exists.return_value = True
         with open('../data/fake_grub.cfg') as fake_grub:
             fake_grub_data = fake_grub.read()
@@ -46,12 +43,11 @@ class TestKernelLoad(object):
                 '/system-root/boot/grub2/grub.cfg'
             )
             assert result == grub_cmd_content
-            assert mock_info.called
 
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('os.path.exists')
     def test_get_cmd_line_extra_boot_partition(
-        self, mock_path_exists, mock_info
+        self, mock_path_exists, mock_logger_setup
     ):
         mock_path_exists.return_value = True
         with open('../data/fake_grub_with_bootpart.cfg') as fake_grub:
@@ -70,17 +66,15 @@ class TestKernelLoad(object):
                 '/system-root/boot/grub2/grub.cfg'
             )
             assert result == grub_cmd_content
-            assert mock_info.called
 
     @patch.object(Defaults, 'get_migration_config_file')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('shutil.copy')
-    @patch('suse_migration_services.logger.log.error')
-    @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.kernel_load._get_cmdline')
     def test_main_raises_on_kernel_load(
-        self, mock_get_cmdline, mock_Command_run, mock_info,
-        mock_error, mock_shutil_copy, mock_get_migration_config_file
+        self, mock_get_cmdline, mock_Command_run, mock_shutil_copy,
+        mock_logger_setup, mock_get_migration_config_file
     ):
         cmd_line = \
             'root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8' + \
@@ -107,17 +101,15 @@ class TestKernelLoad(object):
                 ]
             )
         ]
-        assert mock_info.called
-        assert mock_error.called
 
     @patch.object(Defaults, 'get_migration_config_file')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('shutil.copy')
-    @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.kernel_load._get_cmdline')
     def test_main(
-        self, mock_get_cmdline, mock_Command_run, mock_info,
-        mock_shutil_copy, mock_get_migration_config_file
+        self, mock_get_cmdline, mock_Command_run, mock_shutil_copy,
+        mock_logger_setup, mock_get_migration_config_file
     ):
         cmd_line = \
             'root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8' + \
@@ -139,16 +131,15 @@ class TestKernelLoad(object):
                 ]
             )
         ]
-        assert mock_info.called
 
     @patch.object(Defaults, 'get_migration_config_file')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('shutil.copy')
-    @patch('suse_migration_services.logger.log.info')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.kernel_load._get_cmdline')
     def test_main_hard_reboot(
-        self, mock_get_cmdline, mock_Command_run, mock_info,
-        mock_shutil_copy, mock_get_migration_config_file
+        self, mock_get_cmdline, mock_Command_run, mock_shutil_copy,
+        mock_logger_setup, mock_get_migration_config_file
     ):
         cmd_line = \
             'root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8' + \
@@ -158,4 +149,3 @@ class TestKernelLoad(object):
             '../data/migration-config-reboot.yml'
         main()
         assert mock_Command_run.call_args_list == []
-        assert mock_info.called

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -16,10 +16,9 @@ class TestMigration(object):
     @patch('suse_migration_services.defaults.Defaults.get_system_root_path')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.migrate.MigrationConfig')
-    @patch('suse_migration_services.logger.log.error')
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     def test_main_zypper_migration_plugin_raises(
-        self, mock_info, mock_error, mock_MigrationConfig, mock_Command_run,
+        self, mock_logger_setup, mock_MigrationConfig, mock_Command_run,
         mock_get_system_root_path
     ):
         migration_config = Mock()
@@ -46,10 +45,9 @@ class TestMigration(object):
     @patch('suse_migration_services.defaults.Defaults.get_system_root_path')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.migrate.MigrationConfig')
-    @patch('suse_migration_services.logger.log.error')
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     def test_main_zypper_dup_raises(
-        self, mock_info, mock_error, mock_MigrationConfig, mock_Command_run,
+        self, mock_logger_setup, mock_MigrationConfig, mock_Command_run,
         mock_get_system_root_path
     ):
         migration_config = Mock()
@@ -86,10 +84,9 @@ class TestMigration(object):
     @patch.object(MigrationConfig, 'get_migration_product')
     @patch('suse_migration_services.command.Command.run')
     @patch.object(Defaults, 'get_migration_config_file')
-    @patch('suse_migration_services.logger.log.error')
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     def test_main_zypper_migration_plugin(
-        self, mock_info, mock_error, mock_get_migration_config_file,
+        self, mock_logger_setup, mock_get_migration_config_file,
         mock_Command_run, mock_get_system_root_path
     ):
         mock_get_system_root_path.return_value = 'SLES/15/x86_64'
@@ -115,10 +112,9 @@ class TestMigration(object):
 
     @patch('suse_migration_services.command.Command.run')
     @patch.object(Defaults, 'get_migration_config_file')
-    @patch('suse_migration_services.logger.log.error')
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     def test_main_zypper_dup(
-        self, mock_info, mock_error, mock_get_migration_config_file,
+        self, mock_logger_setup, mock_get_migration_config_file,
         mock_Command_run
     ):
         zypper_call = Mock()

--- a/test/unit/units/post_mount_system_test.py
+++ b/test/unit/units/post_mount_system_test.py
@@ -8,13 +8,13 @@ from suse_migration_services.defaults import Defaults
 
 class TestPostMountSystem(object):
     @patch.object(Defaults, 'get_migration_config_file')
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.defaults.Defaults.get_system_root_path')
     @patch('shutil.copy')
     def test_main(
         self, mock_shutil_copy, mock_get_system_root_path,
-        mock_Command_run, mock_log_info, mock_get_migration_config_file
+        mock_Command_run, mock_logger_setup, mock_get_migration_config_file
     ):
         mock_get_system_root_path.return_value = '../data'
         mock_get_migration_config_file.return_value = \

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -13,8 +13,7 @@ from suse_migration_services.exceptions import (
 
 
 class TestSetupPrepare(object):
-    @patch('suse_migration_services.logger.log.error')
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.prepare.Fstab')
     @patch('os.path.exists')
@@ -22,8 +21,7 @@ class TestSetupPrepare(object):
     @patch('os.listdir')
     def test_main_raises_on_zypp_bind(
         self, mock_os_listdir, mock_shutil_copy, mock_os_path_exists,
-        mock_Fstab, mock_Command_run,
-        mock_info, mock_error
+        mock_Fstab, mock_Command_run, mock_logger_setup
     ):
         mock_os_listdir.return_value = None
         mock_os_path_exists.return_value = True
@@ -36,11 +34,8 @@ class TestSetupPrepare(object):
         ]
         with raises(DistMigrationZypperMetaDataException):
             main()
-            assert mock_info.called
-            assert mock_error.called
 
-    @patch('suse_migration_services.logger.log.error')
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.prepare.Fstab')
     @patch('os.path.exists')
@@ -48,8 +43,7 @@ class TestSetupPrepare(object):
     @patch('os.listdir')
     def test_main_raises_and_umount_file_system(
         self, mock_os_listdir, mock_shutil_copy, mock_os_path_exists,
-        mock_Fstab, mock_Command_run,
-        mock_info, mock_error
+        mock_Fstab, mock_Command_run, mock_logger_setup
     ):
         fstab = Fstab()
         fstab_mock = Mock()
@@ -72,7 +66,7 @@ class TestSetupPrepare(object):
 
     @patch.object(SUSEConnect, 'is_registered')
     @patch('suse_migration_services.units.prepare.MigrationConfig')
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.prepare.Fstab')
     @patch('suse_migration_services.units.prepare.Path')
@@ -81,7 +75,7 @@ class TestSetupPrepare(object):
     @patch('os.listdir')
     def test_main(
         self, mock_os_listdir, mock_shutil_copy, mock_os_path_exists,
-        mock_Path, mock_Fstab, mock_Command_run, mock_info,
+        mock_Path, mock_Fstab, mock_Command_run, mock_logger_setup,
         mock_MigrationConfig, mock_is_registered
     ):
         migration_config = Mock()
@@ -161,15 +155,13 @@ class TestSetupPrepare(object):
         fstab.export.assert_called_once_with(
             '/etc/system-root.fstab'
         )
-        assert mock_info.called
         mock_Command_run.assert_any_call(
             ['cat', '/proc/net/bonding/bond*'], raise_on_error=False
         )
 
     @patch.object(SUSEConnect, 'is_registered')
     @patch('suse_migration_services.units.prepare.MigrationConfig')
-    @patch('suse_migration_services.logger.log.info')
-    @patch('suse_migration_services.logger.log.error')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.prepare.Fstab')
     @patch('suse_migration_services.units.prepare.Path')
@@ -178,8 +170,8 @@ class TestSetupPrepare(object):
     @patch('os.listdir')
     def test_main_no_registered_instance(
         self, mock_os_listdir, mock_shutil_copy, mock_os_path_exists,
-        mock_Path, mock_Fstab, mock_Command_run, mock_log_error,
-        mock_log_info, mock_MigrationConfig, mock_is_registered
+        mock_Path, mock_Fstab, mock_Command_run, mock_logger_setup,
+        mock_MigrationConfig, mock_is_registered
     ):
         migration_config = Mock()
         migration_config.is_zypper_migration_plugin_requested.return_value = \

--- a/test/unit/units/reboot_test.py
+++ b/test/unit/units/reboot_test.py
@@ -1,35 +1,38 @@
+import logging
 from unittest.mock import (
     patch, call, MagicMock, Mock
 )
+from pytest import fixture
 from suse_migration_services.units.reboot import main
 from suse_migration_services.fstab import Fstab
 from suse_migration_services.defaults import Defaults
 
 
 class TestKernelReboot(object):
-    @patch('suse_migration_services.logger.log.warning')
-    @patch('suse_migration_services.logger.log.info')
+    @fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.reboot.MigrationConfig')
     def test_main_skip_reboot_due_to_debug_file_set(
-        self, mock_MigrationConfig, mock_Command_run, mock_info,
-        mock_warning
+        self, mock_MigrationConfig, mock_Command_run, mock_logger_setup
     ):
         config = Mock()
         config.is_debug_requested.return_value = True
         mock_MigrationConfig.return_value = config
-        main()
-        assert mock_info.call_args_list[1] == call(
-            'Reboot skipped due to debug flag set'
-        )
+        with self._caplog.at_level(logging.INFO):
+            main()
+            assert 'Reboot skipped due to debug flag set' in self._caplog.text
 
     @patch.object(Defaults, 'get_migration_config_file')
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.reboot.Fstab')
     def test_main_kexec_reboot(
         self, mock_Fstab, mock_Command_run,
-        mock_info, mock_get_migration_config_file
+        mock_logger_setup, mock_get_migration_config_file
     ):
         fstab = Fstab()
         fstab_mock = Mock()
@@ -39,7 +42,6 @@ class TestKernelReboot(object):
         mock_get_migration_config_file.return_value = \
             '../data/migration-config.yml'
         main()
-        assert mock_info.called
         assert mock_Command_run.call_args_list == [
             call(
                 ['systemctl', 'status', '-l', '--all'],
@@ -61,13 +63,12 @@ class TestKernelReboot(object):
         ]
 
     @patch.object(Defaults, 'get_migration_config_file')
-    @patch('suse_migration_services.logger.log.warning')
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.reboot.Fstab')
     def test_main_force_reboot(
-        self, mock_Fstab, mock_Command_run, mock_info,
-        mock_warning, mock_get_migration_config_file
+        self, mock_Fstab, mock_Command_run, mock_logger_setup,
+        mock_get_migration_config_file
     ):
         fstab = Fstab()
         fstab_mock = Mock()
@@ -84,25 +85,26 @@ class TestKernelReboot(object):
         ]
         mock_get_migration_config_file.return_value = \
             '../data/migration-config-hard-reboot.yml'
-        main()
-        assert mock_info.called
-        assert mock_Command_run.call_args_list == [
-            call(['systemctl', 'status', '-l', '--all'], raise_on_error=False),
-            call(
-                ['umount', '--lazy', '/system-root/home'],
-                raise_on_error=False
-            ),
-            call(
-                ['umount', '--lazy', '/system-root/boot/efi'],
-                raise_on_error=False
-            ),
-            call(
-                ['umount', '--lazy', '/system-root/'],
-                raise_on_error=False
-            ),
-            call(['systemctl', 'reboot']),
-            call(['systemctl', '--force', 'reboot'])
-        ]
-        mock_warning.assert_called_once_with(
-            'Reboot system: [Force Reboot]'
-        )
+        with self._caplog.at_level(logging.WARNING):
+            main()
+            assert mock_Command_run.call_args_list == [
+                call(
+                    ['systemctl', 'status', '-l', '--all'],
+                    raise_on_error=False
+                ),
+                call(
+                    ['umount', '--lazy', '/system-root/home'],
+                    raise_on_error=False
+                ),
+                call(
+                    ['umount', '--lazy', '/system-root/boot/efi'],
+                    raise_on_error=False
+                ),
+                call(
+                    ['umount', '--lazy', '/system-root/'],
+                    raise_on_error=False
+                ),
+                call(['systemctl', 'reboot']),
+                call(['systemctl', '--force', 'reboot'])
+            ]
+            assert 'Reboot system: [Force Reboot]' in self._caplog.text

--- a/test/unit/units/setup_host_network_test.py
+++ b/test/unit/units/setup_host_network_test.py
@@ -11,34 +11,30 @@ from suse_migration_services.exceptions import (
 
 
 class TestSetupHostNetwork(object):
-    @patch('suse_migration_services.logger.log.error')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('os.path.exists')
     def test_main_resolv_conf_not_present(
-        self, mock_os_path_exists, mock_error
+        self, mock_os_path_exists, mock_logger_setup
     ):
         mock_os_path_exists.return_value = False
         with raises(DistMigrationNameResolverException):
             main()
-            assert mock_error.called
 
-    @patch('suse_migration_services.logger.log.error')
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.setup_host_network.Fstab')
     @patch('os.path.exists')
     @patch('shutil.copy')
     def test_main_raises_on_host_network_activation(
         self, mock_shutil_copy, mock_os_path_exists,
-        mock_Fstab, mock_Command_run, mock_info,
-        mock_error
+        mock_Fstab, mock_Command_run, mock_logger_setup
     ):
         mock_os_path_exists.return_value = True
         mock_Command_run.side_effect = Exception
         with raises(DistMigrationHostNetworkException):
             main()
-            assert mock_error.called
 
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.setup_host_network.Fstab')
     @patch('os.path.exists')
@@ -47,7 +43,7 @@ class TestSetupHostNetwork(object):
     @patch('os.path.isfile')
     def test_main(
         self, mock_isfile, mock_glob, mock_shutil_copy, mock_os_path_exists,
-        mock_Fstab, mock_Command_run, mock_info
+        mock_Fstab, mock_Command_run, mock_logger_setup
     ):
         fstab = Mock()
         mock_Fstab.return_value = fstab

--- a/test/unit/units/ssh_keys_test.py
+++ b/test/unit/units/ssh_keys_test.py
@@ -8,15 +8,13 @@ from suse_migration_services.defaults import Defaults
 
 
 class TestSSHKeys(object):
-    @patch('suse_migration_services.logger.log.error')
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('glob.glob')
     def test_migration_continues_on_error(
-        self, mock_glob_glob, mock_error
+        self, mock_glob_glob, mock_logger_setup
     ):
         mock_glob_glob.return_value = []
-        mock_error.levelno = 40
         main()  # expect pass and comment
-        assert mock_error.called
 
     @patch('suse_migration_services.command.Command.run')
     @patch('shutil.copy')
@@ -24,9 +22,9 @@ class TestSSHKeys(object):
     @patch.object(Defaults, 'get_ssh_keys_paths')
     @patch('glob.glob')
     @patch.object(Defaults, 'get_migration_ssh_file')
-    @patch('suse_migration_services.logger.log.info')
+    @patch('suse_migration_services.logger.Logger.setup')
     def test_main(
-        self, mock_info, mock_get_migration_ssh_file, mock_glob_glob,
+        self, mock_logger_setup, mock_get_migration_ssh_file, mock_glob_glob,
             mock_get_ssh_key_path, mock_get_system_sshd_config_path,
             mock_shutil_copy, mock_Command_run
     ):


### PR DESCRIPTION
The logger class contained methods never used. In addition
the logging setup was wrong and only partially working. Any
unit file represents a systemd call. This means any unit file
is an extra program call which requires the initialization
of the python logging facility. The logging itself is also
extended in a way that any external program calls from the
Command class will now be logged and written to the logfile
at call time