### PR TITLE
Fixed handling of busy state on system-root

### DIFF
--- a/suse_migration_services/units/reboot.py
+++ b/suse_migration_services/units/reboot.py
@@ -52,6 +52,13 @@ def main():
                 ).output
             )
         )
+        # stop console dialog log. The service holds a busy state
+        # on system-root and stands in our way in case of debug
+        # mode because it grabs the master console in/output
+        Command.run(
+            ['systemctl', 'stop', 'suse-migration-console-log'],
+            raise_on_error=False
+        )
         if MigrationConfig().is_debug_requested():
             log.info('Reboot skipped due to debug flag set')
         else:

--- a/systemd/suse-migration-console-log.service
+++ b/systemd/suse-migration-console-log.service
@@ -9,7 +9,7 @@ Conflicts=emergency.service emergency.target
 [Service]
 ExecStart=/usr/bin/dialog --tailbox /system-root/var/log/distro_migration.log 60 75
 Type=simple
-Restart=always
+Restart=on-failure
 RestartSec=2
 StandardInput=tty-force
 StandardOutput=inherit

--- a/test/unit/units/reboot_test.py
+++ b/test/unit/units/reboot_test.py
@@ -48,6 +48,10 @@ class TestKernelReboot(object):
                 raise_on_error=False
             ),
             call(
+                ['systemctl', 'stop', 'suse-migration-console-log'],
+                raise_on_error=False
+            ),
+            call(
                 ['umount', '--lazy', '/system-root/home'],
                 raise_on_error=False
             ),
@@ -80,6 +84,7 @@ class TestKernelReboot(object):
             MagicMock(),
             MagicMock(),
             MagicMock(),
+            MagicMock(),
             Exception,
             None
         ]
@@ -90,6 +95,10 @@ class TestKernelReboot(object):
             assert mock_Command_run.call_args_list == [
                 call(
                     ['systemctl', 'status', '-l', '--all'],
+                    raise_on_error=False
+                ),
+                call(
+                    ['systemctl', 'stop', 'suse-migration-console-log'],
                     raise_on_error=False
                 ),
                 call(


### PR DESCRIPTION
The console log service holds a busy state on the system-root
mount because the log file is written on the host to migrate.
At reboot time the service should be stopped to allow a clean
umount procedure prior reboot. In addition the console log
service should only restart on failure and not always