### PR TITLE
Mount only os entries

### DIFF
--- a/test/data/fstab
+++ b/test/data/fstab
@@ -3,6 +3,7 @@ UUID=daa5a8c3-5c72-4343-a1d4-bb74ec4e586e  swap       swap  defaults        0  0
 UUID=FCF7-B051                             /boot/efi  vfat  defaults        0  0
 LABEL=foo  /home      ext4  defaults        0  0
 PARTUUID=3c8bd108-01 /bar ext4 defaults 0 0
+UUID=00d53ca7-11a4-4455-848e-ee52b1173518  /dif/disk  ext4  acl,user_xattr  0  1
 /dev/mynode /foo ext4 defaults 0 0
 
-# this comment line and the line above should be ignored by the parser
+# this comment line and the previous two lines above should be ignored by the parser

--- a/test/unit/fstab_test.py
+++ b/test/unit/fstab_test.py
@@ -2,7 +2,7 @@ import io
 import logging
 from pytest import fixture
 from unittest.mock import (
-    MagicMock, patch, call
+    MagicMock, patch, call, Mock
 )
 from suse_migration_services.fstab import Fstab
 
@@ -12,15 +12,53 @@ class TestFstab(object):
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
+    @patch('suse_migration_services.command.Command.run')
     @patch('os.path.exists')
-    def setup(self, mock_os_path_exists):
+    def setup(self, mock_os_path_exists, mock_Command_run):
         mock_os_path_exists.return_value = True
+
+        def is_on_root_entries(command):
+            command_on_root = Mock()
+            command_on_root.returncode = 0
+            skip_uuid = '/dev/disk/by-uuid/00d53ca7-11a4-4455-848e-ee52b1173518'
+
+            if skip_uuid in command:
+                command_on_root.output = 'sdb'
+            else:
+                command_on_root.output = 'sda'
+
+            return command_on_root
+
+        mock_Command_run.side_effect = is_on_root_entries
         self.fstab = Fstab()
         self.fstab.read('../data/fstab')
+        print(self.fstab.root_disk)
 
+    @patch('os.path.realpath')
+    @patch('suse_migration_services.fstab.Fstab._is_on_root')
+    @patch('suse_migration_services.fstab.Fstab._get_root_disk')
+    @patch('suse_migration_services.command.Command.run')
     @patch('os.path.exists')
-    def test_read_with_skipped_entries(self, mock_os_path_exists):
+    def test_read_with_skipped_entries(
+        self, mock_os_path_exists, mock_Command_run,
+        mock_get_root_disk, mock_is_on_root, mock_os_realpath
+    ):
         mock_os_path_exists.return_value = False
+        mock_get_root_disk.return_value = 'sda'
+
+        def is_on_root_entries(entry):
+            skip_uuid = '00d53ca7-11a4-4455-848e-ee52b1173518'
+
+            if skip_uuid in entry:
+                return False
+
+            return True
+
+        def real_path(device):
+            return device
+
+        mock_is_on_root.side_effect = is_on_root_entries
+        mock_os_realpath.side_effect = real_path
         fstab = Fstab()
         with self._caplog.at_level(logging.WARNING):
             fstab.read('../data/fstab')
@@ -31,77 +69,117 @@ class TestFstab(object):
                 fstype='ext4',
                 mountpoint='/',
                 device='/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2',
-                options='acl,user_xattr'
+                options='acl,user_xattr',
+                unix_device='/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2'
             ),
             self.fstab.fstab_entry_type(
                 fstype='vfat',
                 mountpoint='/boot/efi',
                 device='/dev/disk/by-uuid/FCF7-B051',
-                options='defaults'
+                options='defaults',
+                unix_device='/dev/disk/by-uuid/FCF7-B051'
             ),
             self.fstab.fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/home',
                 device='/dev/disk/by-label/foo',
-                options='defaults'
+                options='defaults',
+                unix_device='/dev/disk/by-label/foo'
             ),
             self.fstab.fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/bar',
                 device='/dev/disk/by-partuuid/3c8bd108-01',
-                options='defaults'
+                options='defaults',
+                unix_device='/dev/disk/by-partuuid/3c8bd108-01'
             )
         ]
 
-    def test_get_devices(self):
+    @patch('os.path.realpath')
+    @patch('suse_migration_services.fstab.Fstab._is_on_root')
+    def test_get_devices(self, mock_is_on_root, mock_os_realpath):
+        def is_on_root_entries(entry):
+            skip_uuid = '00d53ca7-11a4-4455-848e-ee52b1173518'
+
+            if skip_uuid in entry:
+                return False
+
+            return True
+
+        def real_path(device):
+            return device
+
+        mock_is_on_root.side_effect = is_on_root_entries
+        mock_os_realpath.side_effect = real_path
         assert self.fstab.get_devices() == [
             self.fstab.fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/',
                 device='/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2',
-                options='acl,user_xattr'
+                options='acl,user_xattr',
+                unix_device='/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2'
             ),
             self.fstab.fstab_entry_type(
                 fstype='vfat',
                 mountpoint='/boot/efi',
                 device='/dev/disk/by-uuid/FCF7-B051',
-                options='defaults'
+                options='defaults',
+                unix_device='/dev/disk/by-uuid/FCF7-B051'
             ),
             self.fstab.fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/home',
                 device='/dev/disk/by-label/foo',
-                options='defaults'
+                options='defaults',
+                unix_device='/dev/disk/by-label/foo'
             ),
             self.fstab.fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/bar',
                 device='/dev/disk/by-partuuid/3c8bd108-01',
-                options='defaults'
+                options='defaults',
+                unix_device='/dev/disk/by-partuuid/3c8bd108-01'
             ),
             self.fstab.fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/foo',
                 device='/dev/mynode',
-                options='defaults'
+                options='defaults',
+                unix_device='/dev/mynode'
             )
         ]
 
-    def test_add_entry(self):
+    @patch('suse_migration_services.fstab.Fstab._is_on_root')
+    @patch('os.path.realpath')
+    def test_add_entry(self, mock_os_realpath, mock_is_on_root):
         fstab = Fstab()
+        mock_os_realpath.return_value = '/dev/sda'
+        mock_is_on_root.return_value = True
         fstab.add_entry('/dev/sda', '/foo')
         assert fstab.get_devices() == [
             fstab.fstab_entry_type(
                 fstype='none',
                 mountpoint='/foo',
                 device='/dev/sda',
-                options='defaults'
+                options='defaults',
+                unix_device='/dev/sda'
             )
         ]
 
-    def test_export(self):
+    @patch('suse_migration_services.fstab.Fstab._is_on_root')
+    def test_export(self, mock_is_on_root):
         fstab = Fstab()
         fstab.add_entry('/dev/sda', '/foo')
+
+        def is_on_root_entries(device):
+            skip_uuid = '/dev/disk/by-uuid/00d53ca7-11a4-4455-848e-ee52b1173518'
+
+            if skip_uuid in device:
+                return False
+
+            return True
+
+        mock_is_on_root.side_effect = is_on_root_entries
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)
             fstab.export('filename')
@@ -110,5 +188,5 @@ class TestFstab(object):
                 'filename', 'w'
             )
             assert file_handle.write.call_args_list == [
-                call('/dev/sda /foo none defaults 0 0\n')
+                call('/dev/sda /foo none defaults 0 0 /dev/sda\n')
             ]

--- a/test/unit/units/reboot_test.py
+++ b/test/unit/units/reboot_test.py
@@ -26,13 +26,16 @@ class TestKernelReboot(object):
             main()
             assert 'Reboot skipped due to debug flag set' in self._caplog.text
 
+    @patch('suse_migration_services.fstab.Fstab._is_on_root')
+    @patch('suse_migration_services.fstab.Fstab._get_root_disk')
     @patch.object(Defaults, 'get_migration_config_file')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.reboot.Fstab')
     def test_main_kexec_reboot(
         self, mock_Fstab, mock_Command_run,
-        mock_logger_setup, mock_get_migration_config_file
+        mock_logger_setup, mock_get_migration_config_file,
+        mock_get_root_disk, mock_is_on_root
     ):
         fstab = Fstab()
         fstab_mock = Mock()
@@ -41,6 +44,8 @@ class TestKernelReboot(object):
         mock_Fstab.return_value = fstab_mock
         mock_get_migration_config_file.return_value = \
             '../data/migration-config.yml'
+        mock_get_root_disk.return_value = 'sda3 /'
+        mock_is_on_root.return_value = True
         main()
         assert mock_Command_run.call_args_list == [
             call(
@@ -62,13 +67,15 @@ class TestKernelReboot(object):
             call(['systemctl', 'kexec'])
         ]
 
+    @patch('suse_migration_services.fstab.Fstab._is_on_root')
+    @patch('suse_migration_services.fstab.Fstab._get_root_disk')
     @patch.object(Defaults, 'get_migration_config_file')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.reboot.Fstab')
     def test_main_force_reboot(
         self, mock_Fstab, mock_Command_run, mock_logger_setup,
-        mock_get_migration_config_file
+        mock_get_migration_config_file, mock_get_root_disk, mock_is_on_root
     ):
         fstab = Fstab()
         fstab_mock = Mock()
@@ -85,6 +92,8 @@ class TestKernelReboot(object):
         ]
         mock_get_migration_config_file.return_value = \
             '../data/migration-config-hard-reboot.yml'
+        mock_get_root_disk.return_value = 'sda3 /'
+        mock_is_on_root.return_value = True
         with self._caplog.at_level(logging.WARNING):
             main()
             assert mock_Command_run.call_args_list == [


### PR DESCRIPTION
Before, mount service mounted everything on
/etc/fstab, now that service takes into account
the entries that matches the disk that holds the
fstab file.

This Fixes #165