### PR TITLE
Mount only existent devices

### DIFF
--- a/suse_migration_services/fstab.py
+++ b/suse_migration_services/fstab.py
@@ -69,21 +69,23 @@ class Fstab:
                         )
                     else:
                         device_path = device
-                        if not os.path.exists(device_path):
-                            log.warning(
-                                'Device path {0} not found and skipped'.format(
-                                    device_path
-                                )
+
+                    if os.path.exists(device_path):
+                        self.fstab.append(
+                            self.fstab_entry_type(
+                                fstype=fstype,
+                                mountpoint=mountpoint,
+                                device=device_path,
+                                options=options
                             )
-                            continue
-                    self.fstab.append(
-                        self.fstab_entry_type(
-                            fstype=fstype,
-                            mountpoint=mountpoint,
-                            device=device_path,
-                            options=options
                         )
-                    )
+                    else:
+                        log.warning(
+                            'Device path {0} not found and skipped'.format(
+                                device_path
+                            )
+                        )
+                        continue
 
     def add_entry(self, device, mountpoint, fstype=None, options=None):
         self.fstab.append(

--- a/test/unit/fstab_test.py
+++ b/test/unit/fstab_test.py
@@ -20,7 +20,12 @@ class TestFstab(object):
 
     @patch('os.path.exists')
     def test_read_with_skipped_entries(self, mock_os_path_exists):
-        mock_os_path_exists.return_value = False
+        def skip_device(device):
+            if '/dev/mynode' in device:
+                return False
+            return True
+
+        mock_os_path_exists.side_effect = skip_device
         fstab = Fstab()
         with self._caplog.at_level(logging.WARNING):
             fstab.read('../data/fstab')

--- a/test/unit/units/mount_system_test.py
+++ b/test/unit/units/mount_system_test.py
@@ -40,16 +40,23 @@ class TestMountSystem(object):
         with raises(DistMigrationSystemNotFoundException):
             main()
 
+    @patch('os.path.exists')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     def test_mount_system_raises(
-        self, mock_Command_run, mock_logger_setup,
+        self, mock_Command_run, mock_logger_setup, mock_os_path_exists
     ):
+        def skip_device(device):
+            if '/dev/mynode' in device:
+                return False
+            return True
+
         def command_calls(command):
             # mock error on mounting home, testing reverse umount
             if '/system-root/home' in command:
                 raise Exception
 
+        mock_os_path_exists.side_effect = skip_device
         mock_Command_run.side_effect = command_calls
         with raises(DistMigrationSystemMountException):
             fstab = Fstab()

--- a/test/unit/units/reboot_test.py
+++ b/test/unit/units/reboot_test.py
@@ -26,14 +26,22 @@ class TestKernelReboot(object):
             main()
             assert 'Reboot skipped due to debug flag set' in self._caplog.text
 
+    @patch('os.path.exists')
     @patch.object(Defaults, 'get_migration_config_file')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.reboot.Fstab')
     def test_main_kexec_reboot(
         self, mock_Fstab, mock_Command_run,
-        mock_logger_setup, mock_get_migration_config_file
+        mock_logger_setup, mock_get_migration_config_file,
+        mock_os_path_exists
     ):
+        def skip_device(device):
+            if '/dev/mynode' in device:
+                return False
+            return True
+
+        mock_os_path_exists.side_effect = skip_device
         fstab = Fstab()
         fstab_mock = Mock()
         fstab_mock.read.return_value = fstab.read('../data/system-root.fstab')
@@ -66,14 +74,21 @@ class TestKernelReboot(object):
             call(['systemctl', 'kexec'])
         ]
 
+    @patch('os.path.exists')
     @patch.object(Defaults, 'get_migration_config_file')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.reboot.Fstab')
     def test_main_force_reboot(
         self, mock_Fstab, mock_Command_run, mock_logger_setup,
-        mock_get_migration_config_file
+        mock_get_migration_config_file, mock_os_path_exists
     ):
+        def skip_device(device):
+            if '/dev/mynode' in device:
+                return False
+            return True
+
+        mock_os_path_exists.side_effect = skip_device
         fstab = Fstab()
         fstab_mock = Mock()
         fstab_mock.read.return_value = fstab.read('../data/system-root.fstab')


### PR DESCRIPTION
Before, mount service mounted everything on
/etc/fstab, now that service takes into account
the entries that have an existent path.

This Fixes #165