### PR TITLE
Use file based syscall for kexec operation

### DIFF
--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -5,6 +5,9 @@ pytest
 pytest-cov
 coverage
 
+# Rolling backport of unittest.mock for all Pythons
+mock
+
 # Python style guide checker
 flake8
 

--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -32,10 +32,16 @@ if grub_file_is_not_garbage "${migration_iso}"; then
     printf "    search --no-floppy --fs-uuid --set=root %s\n" "${root_uuid}"
     printf "    set isofile='%s'\n" \
         "${migration_iso}"
+    printf "    set linux=linux\n"
+    printf "    set initrd=initrd\n"
+    printf "    if [ \"\${grub_platform}\" = \"efi\" ]; then\n"
+    printf "        set linux=linuxefi\n"
+    printf "        set initrd=initrdefi\n"
+    printf "    fi\n"
     printf "    loopback loop (\$root)\$isofile\n"
-    printf "    linux %s iso-scan/filename=\$isofile %s\n" \
+    printf "    \$linux %s iso-scan/filename=\$isofile %s\n" \
         "${kernel}" "${boot_options}"
-    printf "    initrd %s\n" \
+    printf "    \$initrd %s\n" \
         "${initrd}"
     printf "}\n"
 

--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -28,6 +28,11 @@ if grub_file_is_not_garbage "${migration_iso}"; then
     boot_device_id="$(grub_get_device_id "${GRUB_DEVICE_BOOT}")"
     printf "menuentry '%s' %s \${menuentry_id_option} '%s' {\n" \
         "${OS}" "${CLASS}" "Migration-${boot_device_id}"
+    if btrfs subvolume show /boot/grub2/x86_64-efi &>/dev/null;then
+        printf "    btrfs-mount-subvol / /boot/grub2/x86_64-efi %s\n" \
+            "/@/boot/grub2/x86_64-efi"
+        printf "    insmod loopback\n"
+    fi
     printf "    insmod %s\n" "${root_type}"
     printf "    search --no-floppy --fs-uuid --set=root %s\n" "${root_uuid}"
     printf "    set isofile='%s'\n" \

--- a/suse_migration_services/units/kernel_load.py
+++ b/suse_migration_services/units/kernel_load.py
@@ -68,7 +68,9 @@ def main():
             ]
         )
     except Exception as issue:
-        log.error('Kernel load service raised exception: {0}', format(issue))
+        log.error(
+            'Kernel load service raised exception: {0}'.format(issue)
+        )
         raise DistMigrationKernelRebootException(
             'Failed to load kernel/initrd into memory: {0}'.format(
                 issue
@@ -94,7 +96,7 @@ def _get_cmdline(kernel_name):
         )
     with open(grub_config_file_path) as grub_config_file:
         grub_content = grub_config_file.read()
-    pattern = r'(?<=linux)[ \t]+{0}([{1}|boot/{1}].*)'.format(
+    pattern = r'(?:linux|linuxefi)[ \t]+{0}([{1}|boot/{1}].*)'.format(
         os.sep, kernel_name
     )
     cmd_line = re.findall(pattern, grub_content)[0]

--- a/suse_migration_services/units/kernel_load.py
+++ b/suse_migration_services/units/kernel_load.py
@@ -63,6 +63,7 @@ def main():
                 '--initrd', os.sep.join(
                     [kexec_boot_data, os.path.basename(target_initrd)]
                 ),
+                '--kexec-file-syscall',
                 '--command-line', _get_cmdline(os.path.basename(target_kernel))
             ]
         )

--- a/test/data/fake_grub_linux_var.cfg
+++ b/test/data/fake_grub_linux_var.cfg
@@ -1,0 +1,37 @@
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'SLES15' --class sles --class gnu-linux --class gnu --class os $menuentry_id_option 'gnulinux-simple-ec7aaf92-30ea-4c07-991a-4700177ce1b8' {
+	load_video
+	set gfxpayload=keep
+	insmod gzio
+	insmod part_msdos
+	insmod ext2
+	set root='hd0,msdos1'
+	if [ x$feature_platform_search_hint = xy ]; then
+	  search --no-floppy --fs-uuid --set=root ec7aaf92-30ea-4c07-991a-4700177ce1b8
+	else
+	  search --no-floppy --fs-uuid --set=root ec7aaf92-30ea-4c07-991a-4700177ce1b8
+	fi
+	echo    'Loading Linux 4.12.4-25.25--default ...'
+	$linux	/boot/vmlinuz-4.12.14-25.25-default root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw
+	echo    'Loading initial ramdisk ...'
+	$initrd	/boot/initrd-4.12.14-25.25-default
+}
+submenu 'Advanced options for SLES15' --hotkey=1 $menuentry_id_options 'gnulinux-advanced-ec7aaf92-30ea-4c07-991a-4700177ce1b8'
+{
+	menuentry 'SLES15, with Linux 4.12.13-25.25-default' --hotkey=2 --class sles --class gnu-linux --class gnu --class os $menuentry_id_option 'gnulinux-ec7aaf92-30ea-4c07-991a-4700177ce1b8' {
+	load_video
+	set gfxpayload=keep
+	insmod gzio
+	insmod part_msdos
+	insmod ext2
+	set root='hd0,msdos1'
+	if [ x$feature_platform_search_hint = xy ]; then
+	  search --no-floppy --fs-uuid --set=root ec7aaf92-30ea-4c07-991a-4700177ce1b8
+	else
+	  search --no-floppy --fs-uuid --set=root ec7aaf92-30ea-4c07-991a-4700177ce1b8
+	fi
+	echo    'Loading Linux 4.12.14-25.25-default ...'
+	$linux	/boot/vmlinuz-4.12.14-25.25-default root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw
+	echo    'Loading initial ramdisk ...'
+	$initrd	/boot/initrd-4.12.14-25.25-default
+}

--- a/test/data/fake_grub_linuxefi.cfg
+++ b/test/data/fake_grub_linuxefi.cfg
@@ -1,0 +1,37 @@
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'SLES15' --class sles --class gnu-linux --class gnu --class os $menuentry_id_option 'gnulinux-simple-ec7aaf92-30ea-4c07-991a-4700177ce1b8' {
+	load_video
+	set gfxpayload=keep
+	insmod gzio
+	insmod part_msdos
+	insmod ext2
+	set root='hd0,msdos1'
+	if [ x$feature_platform_search_hint = xy ]; then
+	  search --no-floppy --fs-uuid --set=root ec7aaf92-30ea-4c07-991a-4700177ce1b8
+	else
+	  search --no-floppy --fs-uuid --set=root ec7aaf92-30ea-4c07-991a-4700177ce1b8
+	fi
+	echo    'Loading Linux 4.12.4-25.25--default ...'
+	linuxefi	/boot/vmlinuz-4.12.14-25.25-default root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw
+	echo    'Loading initial ramdisk ...'
+	initrdefi	/boot/initrd-4.12.14-25.25-default
+}
+submenu 'Advanced options for SLES15' --hotkey=1 $menuentry_id_options 'gnulinux-advanced-ec7aaf92-30ea-4c07-991a-4700177ce1b8'
+{
+	menuentry 'SLES15, with Linux 4.12.13-25.25-default' --hotkey=2 --class sles --class gnu-linux --class gnu --class os $menuentry_id_option 'gnulinux-ec7aaf92-30ea-4c07-991a-4700177ce1b8' {
+	load_video
+	set gfxpayload=keep
+	insmod gzio
+	insmod part_msdos
+	insmod ext2
+	set root='hd0,msdos1'
+	if [ x$feature_platform_search_hint = xy ]; then
+	  search --no-floppy --fs-uuid --set=root ec7aaf92-30ea-4c07-991a-4700177ce1b8
+	else
+	  search --no-floppy --fs-uuid --set=root ec7aaf92-30ea-4c07-991a-4700177ce1b8
+	fi
+	echo    'Loading Linux 4.12.14-25.25-default ...'
+	linuxefi	/boot/vmlinuz-4.12.14-25.25-default root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw
+	echo    'Loading initial ramdisk ...'
+	initrdefi	/boot/initrd-4.12.14-25.25-default
+}

--- a/test/unit/units/kernel_load_test.py
+++ b/test/unit/units/kernel_load_test.py
@@ -97,6 +97,7 @@ class TestKernelLoad(object):
                     'kexec',
                     '--load', '/system-root/boot/vmlinuz',
                     '--initrd', '/var/tmp/kexec/initrd',
+                    '--kexec-file-syscall',
                     '--command-line', cmd_line
                 ]
             )
@@ -127,6 +128,7 @@ class TestKernelLoad(object):
                     'kexec',
                     '--load', '/system-root/boot/vmlinuz',
                     '--initrd', '/var/tmp/kexec/initrd',
+                    '--kexec-file-syscall',
                     '--command-line', cmd_line
                 ]
             )

--- a/test/unit/units/kernel_load_test.py
+++ b/test/unit/units/kernel_load_test.py
@@ -1,9 +1,12 @@
 import io
 import os
-from unittest.mock import (
+import logging
+from mock import (
     patch, call, MagicMock
 )
-from pytest import raises
+from pytest import (
+    raises, fixture
+)
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.units.kernel_load import (
     main, _get_cmdline
@@ -14,20 +17,69 @@ from suse_migration_services.exceptions import (
 
 
 class TestKernelLoad(object):
+    @fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('os.path.exists')
     def test_get_cmd_line_grub_cfg_not_present(
         self, mock_os_path_exists, mock_logger_setup
     ):
         mock_os_path_exists.return_value = False
-        with raises(DistMigrationKernelRebootException):
-            _get_cmdline(Defaults.get_grub_config_file())
+        with self._caplog.at_level(logging.ERROR):
+            with raises(DistMigrationKernelRebootException):
+                _get_cmdline(Defaults.get_grub_config_file())
 
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('os.path.exists')
     def test_get_cmd_line(self, mock_path_exists, mock_logger_setup):
         mock_path_exists.return_value = True
         with open('../data/fake_grub.cfg') as fake_grub:
+            fake_grub_data = fake_grub.read()
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            file_handle.read.return_value = fake_grub_data
+            grub_cmd_content = \
+                'root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 ' + \
+                'splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw'
+            result = _get_cmdline(
+                os.path.basename(Defaults.get_target_kernel())
+            )
+            mock_open.assert_called_once_with(
+                '/system-root/boot/grub2/grub.cfg'
+            )
+            assert result == grub_cmd_content
+
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('os.path.exists')
+    def test_get_cmd_line_linuxefi(self, mock_path_exists, mock_logger_setup):
+        mock_path_exists.return_value = True
+        with open('../data/fake_grub_linuxefi.cfg') as fake_grub:
+            fake_grub_data = fake_grub.read()
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            file_handle.read.return_value = fake_grub_data
+            grub_cmd_content = \
+                'root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 ' + \
+                'splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw'
+            result = _get_cmdline(
+                os.path.basename(Defaults.get_target_kernel())
+            )
+            mock_open.assert_called_once_with(
+                '/system-root/boot/grub2/grub.cfg'
+            )
+            assert result == grub_cmd_content
+
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('os.path.exists')
+    def test_get_cmd_line_linux_variable(
+        self, mock_path_exists, mock_logger_setup
+    ):
+        mock_path_exists.return_value = True
+        with open('../data/fake_grub_linux_var.cfg') as fake_grub:
             fake_grub_data = fake_grub.read()
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)
@@ -84,10 +136,11 @@ class TestKernelLoad(object):
             '../data/migration-config.yml'
         mock_Command_run.side_effect = [
             None,
-            Exception
+            Exception('error')
         ]
-        with raises(DistMigrationKernelRebootException):
-            main()
+        with self._caplog.at_level(logging.ERROR):
+            with raises(DistMigrationKernelRebootException):
+                main()
         assert mock_Command_run.call_args_list == [
             call(
                 ['mkdir', '-p', '/var/tmp/kexec']

--- a/tools/run_migration
+++ b/tools/run_migration
@@ -111,5 +111,6 @@ fi
 kexec \
     --load "${boot_dir}/linux" \
     --initrd "${boot_dir}/initrd" \
+    --kexec-file-syscall \
     --command-line "$(get_boot_options "${migration_iso}")"
 kexec --exec


### PR DESCRIPTION
To avoid permission problems on load of the kernel use
the new KEXEC_FILE_LOAD syscall instead of KEXEC_LOAD
This Fixes #174