### PR TITLE
Added update of regionserverclnt for Azure

### DIFF
--- a/image/pubcloud/sle15/config.kiwi
+++ b/image/pubcloud/sle15/config.kiwi
@@ -53,6 +53,7 @@
         <package name="timezone"/>
         <package name="dracut-kiwi-live"/>
         <package name="bind-utils"/>
+        <package name="util-linux"/>
         <package name="suse-migration-services"/>
         <package name="zypper-migration-plugin"/>
         <package name="dialog"/>

--- a/test/data/regionserverclnt-azure.cfg
+++ b/test/data/regionserverclnt-azure.cfg
@@ -1,0 +1,8 @@
+[server]
+api = regionInfo
+
+[instance]
+dataprovider = /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml
+instanceargs = msftazure
+httpsonly = true
+


### PR DESCRIPTION
In case of the Azure cloud the auto detection code for the root
disk device does not work when running the distribution migration
live system. Therefore it's required to pass in the correct
information as option to azuremetadata. This is related to
bsc#1173654