### PR TITLE
Set right root type fs

### DIFF
--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -17,6 +17,11 @@ migration_iso=$(echo /usr/share/migration-image/*-Migration.*.iso)
 root_device=$(lsblk -p -n -r -o NAME,MOUNTPOINT | grep -E "/$" | uniq | cut -f1 -d" ")
 root_uuid=$(blkid -s UUID -o value "${root_device}")
 root_type=$(blkid -s TYPE -o value "${root_device}")
+
+if [[ ${root_type} =~ ^ext[[:digit:]] ]] ; then
+   root_type="ext2"
+fi
+
 boot_options="rd.live.image root=live:CDLABEL=CDROM"
 if mdadm --detail "${root_device}" &>/dev/null; then
     boot_options="${boot_options} rd.auto"


### PR DESCRIPTION
When root type is extX, insmod is extX and it should be ext2
that way grub ext2 module supports all extX fs.

This Fixes bsc#1178737