### PR TITLE
Fixed umount inconsistency

### DIFF
--- a/suse_migration_services/units/mount_system.py
+++ b/suse_migration_services/units/mount_system.py
@@ -187,8 +187,6 @@ def mount_system(root_path, fstab):
         log.error(
             'Mounting system for upgrade failed with {0}'.format(issue)
         )
-        for entry in reversed(system_mount.get_devices()):
-            Command.run(['umount', entry.mountpoint])
         raise DistMigrationSystemMountException(
             'Mounting system for upgrade failed with {0}'.format(issue)
         )

--- a/test/unit/units/mount_system_test.py
+++ b/test/unit/units/mount_system_test.py
@@ -52,7 +52,7 @@ class TestMountSystem(object):
             return True
 
         def command_calls(command):
-            # mock error on mounting home, testing reverse umount
+            # mock error on mounting home
             if '/system-root/home' in command:
                 raise Exception
 
@@ -77,9 +77,7 @@ class TestMountSystem(object):
             call([
                 'mount', '-o', 'defaults',
                 '/dev/disk/by-label/foo', '/system-root/home'
-            ]),
-            call(['umount', '/system-root/boot/efi']),
-            call(['umount', '/system-root/'])
+            ])
         ]
 
     @patch('yaml.safe_load')


### PR DESCRIPTION
There is the mount-system service which mounts the system taking fstab into account. If it fails for some reason it also umounts all parts of the system. However in the sequence of the error condition there is also the grub-setup service which uninstalls the migration package and restores the grub config such that the subsequent boot process does no longer boot into the migration system. With the error condition from above the grub-setup service has no chance to perform its jobs because all of system-root has been umounted already. This commit makes sure that mount-service only registers the mount paths but does not umount them in case of a failure. This allows grub-setup to do its job and also allows the reboot service to umount registered devices prior reboot.

This is related to bsc#1182520