### PR TITLE
Added sort by path order for fstab handling

### DIFF
--- a/test/data/fstab
+++ b/test/data/fstab
@@ -1,6 +1,7 @@
 UUID=bd604632-663b-4d4c-b5b0-8d8686267ea2  /          ext4  acl,user_xattr  0  1
 UUID=daa5a8c3-5c72-4343-a1d4-bb74ec4e586e  swap       swap  defaults        0  0
 UUID=FCF7-B051                             /boot/efi  vfat  defaults        0  0
+/dev/homeboy /home/stack ext4  defaults        0  0
 LABEL=foo  /home      ext4  defaults        0  0
 PARTUUID=3c8bd108-01 /bar ext4 defaults 0 0
 /dev/mynode /foo ext4 defaults 0 0

--- a/test/unit/fstab_test.py
+++ b/test/unit/fstab_test.py
@@ -39,9 +39,9 @@ class TestFstab(object):
                 options='acl,user_xattr'
             ),
             self.fstab.fstab_entry_type(
-                fstype='vfat',
-                mountpoint='/boot/efi',
-                device='/dev/disk/by-uuid/FCF7-B051',
+                fstype='ext4',
+                mountpoint='/bar',
+                device='/dev/disk/by-partuuid/3c8bd108-01',
                 options='defaults'
             ),
             self.fstab.fstab_entry_type(
@@ -51,9 +51,15 @@ class TestFstab(object):
                 options='defaults'
             ),
             self.fstab.fstab_entry_type(
+                fstype='vfat',
+                mountpoint='/boot/efi',
+                device='/dev/disk/by-uuid/FCF7-B051',
+                options='defaults'
+            ),
+            self.fstab.fstab_entry_type(
                 fstype='ext4',
-                mountpoint='/bar',
-                device='/dev/disk/by-partuuid/3c8bd108-01',
+                mountpoint='/home/stack',
+                device='/dev/homeboy',
                 options='defaults'
             )
         ]
@@ -67,18 +73,6 @@ class TestFstab(object):
                 options='acl,user_xattr'
             ),
             self.fstab.fstab_entry_type(
-                fstype='vfat',
-                mountpoint='/boot/efi',
-                device='/dev/disk/by-uuid/FCF7-B051',
-                options='defaults'
-            ),
-            self.fstab.fstab_entry_type(
-                fstype='ext4',
-                mountpoint='/home',
-                device='/dev/disk/by-label/foo',
-                options='defaults'
-            ),
-            self.fstab.fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/bar',
                 device='/dev/disk/by-partuuid/3c8bd108-01',
@@ -88,6 +82,24 @@ class TestFstab(object):
                 fstype='ext4',
                 mountpoint='/foo',
                 device='/dev/mynode',
+                options='defaults'
+            ),
+            self.fstab.fstab_entry_type(
+                fstype='ext4',
+                mountpoint='/home',
+                device='/dev/disk/by-label/foo',
+                options='defaults'
+            ),
+            self.fstab.fstab_entry_type(
+                fstype='vfat',
+                mountpoint='/boot/efi',
+                device='/dev/disk/by-uuid/FCF7-B051',
+                options='defaults'
+            ),
+            self.fstab.fstab_entry_type(
+                fstype='ext4',
+                mountpoint='/home/stack',
+                device='/dev/homeboy',
                 options='defaults'
             )
         ]

--- a/test/unit/units/mount_system_test.py
+++ b/test/unit/units/mount_system_test.py
@@ -65,19 +65,25 @@ class TestMountSystem(object):
                 Defaults.get_system_root_path(), fstab
             )
         assert mock_Command_run.call_args_list == [
-            call([
-                'mount', '-o', 'acl,user_xattr',
-                '/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2',
-                '/system-root/'
-            ]),
-            call([
-                'mount', '-o', 'defaults',
-                '/dev/disk/by-uuid/FCF7-B051', '/system-root/boot/efi'
-            ]),
-            call([
-                'mount', '-o', 'defaults',
-                '/dev/disk/by-label/foo', '/system-root/home'
-            ])
+            call(
+                [
+                    'mount', '-o', 'acl,user_xattr',
+                    '/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2',
+                    '/system-root/'
+                ]
+            ),
+            call(
+                [
+                    'mount', '-o', 'defaults',
+                    '/dev/disk/by-partuuid/3c8bd108-01', '/system-root/bar'
+                ]
+            ),
+            call(
+                [
+                    'mount', '-o', 'defaults',
+                    '/dev/disk/by-label/foo', '/system-root/home'
+                ]
+            )
         ]
 
     @patch('yaml.safe_load')
@@ -140,27 +146,14 @@ class TestMountSystem(object):
                     ['mount', '/dev/sda1', '/system-root'], raise_on_error=False
                 ),
                 call(
-                    ['umount', '/system-root'], raise_on_error=False),
+                    ['umount', '/system-root'], raise_on_error=False
+                ),
                 call(
                     [
                         'mount', '-o', 'acl,user_xattr',
                         '/dev/disk/by-uuid/'
                         'bd604632-663b-4d4c-b5b0-8d8686267ea2',
                         '/system-root/'
-                    ]
-                ),
-                call(
-                    [
-                        'mount', '-o', 'defaults',
-                        '/dev/disk/by-uuid/FCF7-B051',
-                        '/system-root/boot/efi'
-                    ]
-                ),
-                call(
-                    [
-                        'mount', '-o', 'defaults',
-                        '/dev/disk/by-label/foo',
-                        '/system-root/home'
                     ]
                 ),
                 call(
@@ -175,6 +168,27 @@ class TestMountSystem(object):
                         'mount', '-o', 'defaults',
                         '/dev/mynode',
                         '/system-root/foo'
+                    ]
+                ),
+                call(
+                    [
+                        'mount', '-o', 'defaults',
+                        '/dev/disk/by-label/foo',
+                        '/system-root/home'
+                    ]
+                ),
+                call(
+                    [
+                        'mount', '-o', 'defaults',
+                        '/dev/disk/by-uuid/FCF7-B051',
+                        '/system-root/boot/efi'
+                    ]
+                ),
+                call(
+                    [
+                        'mount', '-o', 'defaults',
+                        '/dev/homeboy',
+                        '/system-root/home/stack'
                     ]
                 ),
                 call(
@@ -194,16 +208,6 @@ class TestMountSystem(object):
                     'ext4'
                 ),
                 call(
-                    '/dev/disk/by-uuid/FCF7-B051',
-                    '/system-root/boot/efi',
-                    'vfat',
-                ),
-                call(
-                    '/dev/disk/by-label/foo',
-                    '/system-root/home',
-                    'ext4'
-                ),
-                call(
                     '/dev/disk/by-partuuid/3c8bd108-01',
                     '/system-root/bar',
                     'ext4'
@@ -211,6 +215,21 @@ class TestMountSystem(object):
                 call(
                     '/dev/mynode',
                     '/system-root/foo',
+                    'ext4'
+                ),
+                call(
+                    '/dev/disk/by-label/foo',
+                    '/system-root/home',
+                    'ext4'
+                ),
+                call(
+                    '/dev/disk/by-uuid/FCF7-B051',
+                    '/system-root/boot/efi',
+                    'vfat',
+                ),
+                call(
+                    '/dev/homeboy',
+                    '/system-root/home/stack',
                     'ext4'
                 ),
                 call(

--- a/test/unit/units/reboot_test.py
+++ b/test/unit/units/reboot_test.py
@@ -60,11 +60,11 @@ class TestKernelReboot(object):
                 raise_on_error=False
             ),
             call(
-                ['umount', '--lazy', '/system-root/home'],
+                ['umount', '--lazy', '/system-root/boot/efi'],
                 raise_on_error=False
             ),
             call(
-                ['umount', '--lazy', '/system-root/boot/efi'],
+                ['umount', '--lazy', '/system-root/home'],
                 raise_on_error=False
             ),
             call(
@@ -117,11 +117,11 @@ class TestKernelReboot(object):
                     raise_on_error=False
                 ),
                 call(
-                    ['umount', '--lazy', '/system-root/home'],
+                    ['umount', '--lazy', '/system-root/boot/efi'],
                     raise_on_error=False
                 ),
                 call(
-                    ['umount', '--lazy', '/system-root/boot/efi'],
+                    ['umount', '--lazy', '/system-root/home'],
                     raise_on_error=False
                 ),
                 call(


### PR DESCRIPTION
Don't trust the order of entries in the fstab to be correct.
Instead add a canonical path order to the fstab entries
when processed by the distribution migration system.
This Fixes #188 and Fixes bsc#1182520