### PR TITLE
Avoid multiple mount attempts

### DIFF
--- a/test/unit/units/mount_system_test.py
+++ b/test/unit/units/mount_system_test.py
@@ -236,7 +236,7 @@ class TestMountSystem(object):
                     'devtmpfs', '/system-root/dev'
                 ),
                 call(
-                    '/proc', '/system-root/proc'
+                    'proc', '/system-root/proc'
                 ),
                 call(
                     'sysfs', '/system-root/sys'


### PR DESCRIPTION
- Fstab could contain one of the mount points
  DMS mount explicitly, ending up in an exception.
  To avoid this, DMS does not mount the explicit
  mount points if they are in fstab.

This Fixes #191 and bcs#1184278