### PR TITLE
Fixed loopback root setting

### DIFF
--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -14,15 +14,35 @@ else
 fi
 
 migration_iso=$(echo /usr/share/migration-image/*-Migration.*.iso)
-root_device=$(lsblk -p -n -r -o NAME,MOUNTPOINT | grep -E "/$" | uniq | cut -f1 -d" ")
-root_uuid=$(blkid -s UUID -o value "${root_device}")
-root_type=$(blkid -s TYPE -o value "${root_device}")
 
-if [[ ${root_type} =~ ^ext[[:digit:]] ]] ; then
-   root_type="ext2"
+root_device=$(
+    lsblk -p -n -r -o NAME,MOUNTPOINT | grep -E "/$" | uniq | cut -f1 -d" "
+)
+
+# check if location of migration_iso is not on the root_device
+image_fs_device=${root_device}
+index=4
+for path in "/usr/share" "/usr";do
+    if mountpoint -q ${path};then
+        image_fs_device=$(
+            lsblk -p -n -r -o NAME,MOUNTPOINT |\
+            grep -E "${path}$" | uniq | cut -f1 -d" "
+        )
+        migration_iso=/$(echo "${migration_iso}" | cut -f"${index}"- -d/)
+        break
+    fi
+    index=$((index -1))
+done
+
+image_fs_uuid=$(blkid -s UUID -o value "${image_fs_device}")
+image_fs_type=$(blkid -s TYPE -o value "${image_fs_device}")
+
+if [[ ${image_fs_type} =~ ^ext[[:digit:]] ]] ; then
+   image_fs_type="ext2"
 fi
 
 boot_options="rd.live.image root=live:CDLABEL=CDROM"
+
 if mdadm --detail "${root_device}" &>/dev/null; then
     boot_options="${boot_options} rd.auto"
 fi
@@ -38,8 +58,8 @@ if grub_file_is_not_garbage "${migration_iso}"; then
             "/@/boot/grub2/x86_64-efi"
         printf "    insmod loopback\n"
     fi
-    printf "    insmod %s\n" "${root_type}"
-    printf "    search --no-floppy --fs-uuid --set=root %s\n" "${root_uuid}"
+    printf "    insmod %s\n" "${image_fs_type}"
+    printf "    search --no-floppy --fs-uuid --set=root %s\n" "${image_fs_uuid}"
     printf "    set isofile='%s'\n" \
         "${migration_iso}"
     printf "    set linux=linux\n"


### PR DESCRIPTION
The root variable for the loopback search in grub was initialized
with the assumption that the /usr/share/ location on the system is
on the root partition. This assumption could be incorrect and the
code should be smart enough to detect this situation.
This Fixes #192