### PR TITLE
Debug lvm issue

### DIFF
--- a/image/pubcloud/sle15/config.kiwi
+++ b/image/pubcloud/sle15/config.kiwi
@@ -50,6 +50,7 @@
         <package name="which"/>
         <package name="shim" arch="x86_64"/>
         <package name="kernel-default"/>
+        <package name="kernel-firmware"/>
         <package name="timezone"/>
         <package name="dracut-kiwi-live"/>
         <package name="bind-utils"/>


### PR DESCRIPTION
Added kernel-firmware to support bare metal better
    
For the DMS to boot on bare metal system we should install the kernel-firmware package. If not present certain systems like HP with Mellanox driver fails to boot. This is related to bsc#1182520
