### PR TITLE
Respect host kernel boot options for migration

### DIFF
--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -41,11 +41,26 @@ if [[ ${image_fs_type} =~ ^ext[[:digit:]] ]] ; then
    image_fs_type="ext2"
 fi
 
+# init boot options needed for live boot
 boot_options="rd.live.image root=live:CDLABEL=CDROM"
 
+# add auto activation of devices in soft raid mode
 if mdadm --detail "${root_device}" &>/dev/null; then
     boot_options="${boot_options} rd.auto"
 fi
+
+# add relevant boot options used on the host to migrate
+for host_boot_option in $(xargs -n1 < /proc/cmdline);do
+    case "${host_boot_option}" in
+        root=*)
+            continue
+        ;;
+        quiet)
+            continue
+        ;;
+    esac
+    boot_options="${boot_options} ${host_boot_option}"
+done
 
 if grub_file_is_not_garbage "${migration_iso}"; then
     kernel="(loop)/boot/x86_64/loader/linux"

--- a/tools/run_migration
+++ b/tools/run_migration
@@ -54,10 +54,22 @@ function get_boot_options {
     # Create boot options list for kexec
     # """
     local boot_options
+    local host_boot_option
     boot_options="iso-scan/filename=$1 root=live:CDLABEL=CDROM rd.live.image"
     if mdadm --detail "$(get_system_root_device)" &>/dev/null; then
         boot_options="${boot_options} rd.auto"
     fi
+    for host_boot_option in $(xargs -n1 < /proc/cmdline);do
+        case "${host_boot_option}" in
+            root=*)
+                continue
+            ;;
+            quiet)
+                continue
+            ;;
+        esac
+        boot_options="${boot_options} ${host_boot_option}"
+    done
     echo "${boot_options}"
 }
 


### PR DESCRIPTION
The kernel boot options used on the host to migrate can be
important for the migration live environment too. For example
if net.ifnames is passed is influences the network interface
names to become predictable. As the DMS inherits configuration
data from the host e.g the network setup, it's required that
also the kernel boot parameters matches.