### PR TITLE
Fixed mount of root for detected disk

### DIFF
--- a/test/unit/fstab_test.py
+++ b/test/unit/fstab_test.py
@@ -36,31 +36,36 @@ class TestFstab(object):
                 fstype='ext4',
                 mountpoint='/',
                 device='/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2',
-                options='acl,user_xattr'
+                options='acl,user_xattr',
+                eligible_for_mount=False
             ),
             self.fstab.fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/bar',
                 device='/dev/disk/by-partuuid/3c8bd108-01',
-                options='defaults'
+                options='defaults',
+                eligible_for_mount=True
             ),
             self.fstab.fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/home',
                 device='/dev/disk/by-label/foo',
-                options='defaults'
+                options='defaults',
+                eligible_for_mount=True
             ),
             self.fstab.fstab_entry_type(
                 fstype='vfat',
                 mountpoint='/boot/efi',
                 device='/dev/disk/by-uuid/FCF7-B051',
-                options='defaults'
+                options='defaults',
+                eligible_for_mount=True
             ),
             self.fstab.fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/home/stack',
                 device='/dev/homeboy',
-                options='defaults'
+                options='defaults',
+                eligible_for_mount=True
             )
         ]
 
@@ -70,37 +75,43 @@ class TestFstab(object):
                 fstype='ext4',
                 mountpoint='/',
                 device='/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2',
-                options='acl,user_xattr'
+                options='acl,user_xattr',
+                eligible_for_mount=False
             ),
             self.fstab.fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/bar',
                 device='/dev/disk/by-partuuid/3c8bd108-01',
-                options='defaults'
+                options='defaults',
+                eligible_for_mount=True
             ),
             self.fstab.fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/foo',
                 device='/dev/mynode',
-                options='defaults'
+                options='defaults',
+                eligible_for_mount=True
             ),
             self.fstab.fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/home',
                 device='/dev/disk/by-label/foo',
-                options='defaults'
+                options='defaults',
+                eligible_for_mount=True
             ),
             self.fstab.fstab_entry_type(
                 fstype='vfat',
                 mountpoint='/boot/efi',
                 device='/dev/disk/by-uuid/FCF7-B051',
-                options='defaults'
+                options='defaults',
+                eligible_for_mount=True
             ),
             self.fstab.fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/home/stack',
                 device='/dev/homeboy',
-                options='defaults'
+                options='defaults',
+                eligible_for_mount=True
             )
         ]
 
@@ -112,7 +123,8 @@ class TestFstab(object):
                 fstype='none',
                 mountpoint='/foo',
                 device='/dev/sda',
-                options='defaults'
+                options='defaults',
+                eligible_for_mount=True
             )
         ]
 


### PR DESCRIPTION
The former implementation looped through a list of block
devices, mounted them, looked for the fstab file, reads it
and umounted the device again. In a next step we mounted
all entries from that fstab file as listed. The problem
with this approach is that the mount of the root device
already happened and we did it again. As this is not needed
it should also not create a problem. But it does create
a problem in multipath environments. With the absence of
the multipath setup in the live migration system only one
of the multipath devices can be mounted. This device was
found by our loop approach but is not necessarily the
right choice when mounting the device as referenced from
the fstab file without multipath running. Therefore this
commit makes sure the root device is mounted only once
and only through our best guess loop and not by the entry
in the fstab file.