### PR TITLE
Prevent use of shutil.copytree

### DIFF
--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -90,10 +90,12 @@ def main():
             certificates = os.listdir(root_trust_anchor)
             if certificates:
                 Path.create(trust_anchor)
-                log.info(f'Importing certificates: {", ".join(certificates)}')
-                shutil.copytree(
-                    root_trust_anchor, trust_anchor, dirs_exist_ok=True
-                )
+                for cert in certificates:
+                    log.info(f'Importing certificate: {cert}')
+                    shutil.copy(
+                        os.sep.join([root_trust_anchor, cert]),
+                        trust_anchor
+                    )
                 log.info('Update certificate pool')
                 Command.run(
                     ['update-ca-certificates']

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -84,11 +84,10 @@ class TestSetupPrepare(object):
     @patch('suse_migration_services.units.prepare.Path')
     @patch('os.path.exists')
     @patch('shutil.copy')
-    @patch('shutil.copytree')
     @patch('os.listdir')
     @patch('os.path.isdir')
     def test_main(
-        self, mock_path_isdir, mock_os_listdir, mock_shutil_copy_tree,
+        self, mock_path_isdir, mock_os_listdir,
         mock_shutil_copy, mock_os_path_exists, mock_Path,
         mock_Fstab, mock_Command_run, mock_logger_setup,
         mock_MigrationConfig, mock_update_regionsrv_setup,
@@ -128,18 +127,22 @@ class TestSetupPrepare(object):
                 '/system-root/etc/regionserverclnt.cfg',
                 '/etc/regionserverclnt.cfg'
             ),
-            call('/system-root/etc/hosts', '/etc/hosts')
-        ]
-        assert mock_shutil_copy_tree.call_args_list == [
+            call('/system-root/etc/hosts', '/etc/hosts'),
             call(
-                '/system-root/usr/share/pki/trust/anchors',
-                '/usr/share/pki/trust/anchors/',
-                dirs_exist_ok=True
+                '/system-root/usr/share/pki/trust/anchors/foo',
+                '/usr/share/pki/trust/anchors/'
             ),
             call(
-                '/system-root/etc/pki/trust/anchors',
-                '/etc/pki/trust/anchors/',
-                dirs_exist_ok=True
+                '/system-root/usr/share/pki/trust/anchors/bar',
+                '/usr/share/pki/trust/anchors/'
+            ),
+            call(
+                '/system-root/etc/pki/trust/anchors/foo',
+                '/etc/pki/trust/anchors/'
+            ),
+            call(
+                '/system-root/etc/pki/trust/anchors/bar',
+                '/etc/pki/trust/anchors/'
             )
         ]
         mock_Path.call_args_list == [


### PR DESCRIPTION
The versions of copytree comes with a different set of
features depending on the used python interpreter. The
former implementation used an option which did not exist
on python in SLE15. To keep us safe from further surprises
I moved back to the simple but stable shutil.copy method.
We can come up with a refactoring PR when needed but not
combined with the fix for the certificates as this was the
original intention of the change