### PR TITLE
Cracefully handle cert copy exceptions

### DIFF
--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -91,11 +91,14 @@ def main():
             if certificates:
                 Path.create(trust_anchor)
                 for cert in certificates:
-                    log.info(f'Importing certificate: {cert}')
-                    shutil.copy(
-                        os.sep.join([root_trust_anchor, cert]),
-                        trust_anchor
-                    )
+                    cert_file = os.sep.join([root_trust_anchor, cert])
+                    log.info(f'Importing certificate: {cert_file}')
+                    try:
+                        shutil.copy(cert_file, trust_anchor)
+                    except FileNotFoundError as issue:
+                        log.warning(
+                            f'Import of {cert_file!r} failed with {issue!r}'
+                        )
                 log.info('Update certificate pool')
                 Command.run(
                     ['update-ca-certificates']

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -92,6 +92,10 @@ def main():
                 Path.create(trust_anchor)
                 for cert in certificates:
                     cert_file = os.sep.join([root_trust_anchor, cert])
+                    if os.path.islink(cert_file):
+                        cert_file = os.sep.join(
+                            [root_path, os.readlink(cert_file)]
+                        )
                     log.info(f'Importing certificate: {cert_file}')
                     try:
                         shutil.copy(cert_file, trust_anchor)

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -86,13 +86,17 @@ class TestSetupPrepare(object):
     @patch('shutil.copy')
     @patch('os.listdir')
     @patch('os.path.isdir')
+    @patch('os.path.islink')
+    @patch('os.readlink')
     def test_main(
-        self, mock_path_isdir, mock_os_listdir,
+        self, mock_readlink, mock_os_path_islink,
+        mock_path_isdir, mock_os_listdir,
         mock_shutil_copy, mock_os_path_exists, mock_Path,
         mock_Fstab, mock_Command_run, mock_logger_setup,
         mock_MigrationConfig, mock_update_regionsrv_setup,
         mock_is_registered, mock_is_file
     ):
+        mock_readlink.return_value = 'link_target'
         mock_path_isdir.return_value = True
         migration_config = Mock()
         migration_config.is_zypper_migration_plugin_requested.return_value = \
@@ -101,6 +105,9 @@ class TestSetupPrepare(object):
         fstab = Mock()
         mock_Fstab.return_value = fstab
         mock_os_listdir.return_value = ['foo', 'bar']
+        mock_os_path_islink.side_effect = [
+            False, False, False, True
+        ]
         mock_os_path_exists.side_effect = [
             True, True, True, True, False, True, True
         ]
@@ -150,7 +157,7 @@ class TestSetupPrepare(object):
                 '/etc/pki/trust/anchors/'
             ),
             call(
-                '/system-root/etc/pki/trust/anchors/bar',
+                '/system-root/link_target',
                 '/etc/pki/trust/anchors/'
             )
         ]

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -118,6 +118,15 @@ class TestSetupPrepare(object):
             MagicMock(),
             MagicMock()
         ]
+        mock_shutil_copy.side_effect = [
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            FileNotFoundError('cert copy failed')
+        ]
         mock_is_file.return_value = True
         with patch('builtins.open', create=True):
             main()


### PR DESCRIPTION
If the copy process of a certificate failed this should not
cause the entire migration process to stop. This commit
handles copy errors from the cert chain and turns them into
a log message. If in the subsequent chain of tasks the
migration failed because of missing certificates we will
see that in the log and in the attempt to access the repos
which is better than the python stacktrace on an unhandled
FileNotFoundError exception. Retated to Issue #197