### PR TITLE
Update option settings in zypper dup mode

### DIFF
--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -74,6 +74,7 @@ def main():
                     '--auto-agree-with-licenses',
                     '--allow-vendor-change',
                     '--replacefiles',
+                    '--allow-downgrade '
                     '&>>', Defaults.get_migration_log_file()
                 ]
             )

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -133,6 +133,7 @@ class TestMigration(object):
                 '--auto-agree-with-licenses '
                 '--allow-vendor-change '
                 '--replacefiles '
+                '--allow-downgrade '
                 '&>> /system-root/var/log/distro_migration.log'
             ], raise_on_error=False
         )


### PR DESCRIPTION
When using the DMS in zypper dup mode the option
settings --allow-downgrade and --no-confirm are handy.
Even though I think with the global non-interactive
option set it should not be required to set no-confirm
in addition but the worst are questions being asked
so better add it. With allow-downgrade set the ability
to downgrade packages is given. With zypper dup the
repo setup is user defined custom set and therefore
downgrades should not be off the table