### PR TITLE
Use download-in-advance mode for zypper dup

### DIFF
--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -73,6 +73,7 @@ def main():
                     'dup',
                     '--auto-agree-with-licenses',
                     '--allow-vendor-change',
+                    '--download', 'in-advance',
                     '--replacefiles',
                     '--allow-downgrade '
                     '&>>', Defaults.get_migration_log_file()

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -132,6 +132,7 @@ class TestMigration(object):
                 'dup '
                 '--auto-agree-with-licenses '
                 '--allow-vendor-change '
+                '--download in-advance '
                 '--replacefiles '
                 '--allow-downgrade '
                 '&>> /system-root/var/log/distro_migration.log'


### PR DESCRIPTION
If the DMS was configured to use 'zypper dup' we should
download packages in advance for more stability. The reason
is that zypper dup always starts with deleting packages and
then continues with installing packages. If at install time
a package cannot be downloaded for some reason the zypper
process ends and leaves the system in an inconsistent state