### PR TITLE
Add an option to create a 'fat' initrd

### DIFF
--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -227,6 +227,17 @@ If enabled, it will run the zypper migration plugin with increased verbosity.
 [listing]
 verbose_migration: true|false
 
+Configure Make initrd Method::
+The live system may not contain all necessary tools to create an initrd that
+meets the need of the system being upgraded. Building a host independent
+initrd will create an initrd in a way that contains the tools and
+modules available on the system being upgraded. If this is needed, a host
+independent initrd can be created by setting
+`build_host_independent_initrd: True`.
+
+[listing]
+build_host_independent_initrd: true|false
+
 == Run the Migration
 After the install of the `SLES15-Migration` package, start the migration
 by calling the following command:

--- a/helper/service.tree
+++ b/helper/service.tree
@@ -2,6 +2,6 @@ suse-migration-mount-system -> [
     suse-migration-ssh-keys,
     suse-migration-post-mount-system.service -> suse-migration-setup-host-network -> suse-migration-prepare -> [
         suse-migration-console-log,
-        suse-migration-product-setup -> suse-migration -> suse-migration-grub-setup -> suse-migration-kernel-load -> suse-migration-reboot
+        suse-migration-product-setup -> suse-migration -> suse-migration-grub-setup -> suse-migration-regenerate-initrd -> suse-migration-kernel-load ->suse-migration-reboot
     ]
 ]

--- a/image/pubcloud/sle15/config.sh
+++ b/image/pubcloud/sle15/config.sh
@@ -68,6 +68,7 @@ suseInsertService suse-migration
 suseInsertService suse-migration-console-log
 suseInsertService suse-migration-grub-setup
 suseInsertService suse-migration-product-setup
+suseInsertService suse-migration-regenerate-initrd
 suseInsertService suse-migration-kernel-load
 suseInsertService suse-migration-reboot
 

--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -81,6 +81,9 @@ install -D -m 644 systemd/suse-migration-grub-setup.service \
 install -D -m 644 systemd/suse-migration-product-setup.service \
     %{buildroot}%{_unitdir}/suse-migration-product-setup.service
 
+install -D -m 644 systemd/suse-migration-regenerate-initrd.service \
+    %{buildroot}%{_unitdir}/suse-migration-regenerate-initrd.service
+
 install -D -m 644 systemd/suse-migration-kernel-load.service \
     %{buildroot}%{_unitdir}/suse-migration-kernel-load.service
 
@@ -130,6 +133,9 @@ install -D -m 644 systemd/suse-migration-console-log.service \
 
 %{_bindir}/suse-migration-product-setup
 %{_unitdir}/suse-migration-product-setup.service
+
+%{_bindir}/suse-migration-regenerate-initrd
+%{_unitdir}/suse-migration-regenerate-initrd.service
 
 %{_bindir}/suse-migration-kernel-load
 %{_unitdir}/suse-migration-kernel-load.service

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ config = {
             'suse-migration-prepare=suse_migration_services.units.prepare:main',
             'suse-migration=suse_migration_services.units.migrate:main',
             'suse-migration-grub-setup=suse_migration_services.units.grub_setup:main',
+            'suse-migration-regenerate-initrd=suse_migration_services.units.regenerate_initrd:main',
             'suse-migration-kernel-load=suse_migration_services.units.kernel_load:main',
             'suse-migration-reboot=suse_migration_services.units.reboot:main',
             'suse-migration-product-setup=suse_migration_services.units.product_setup:main',

--- a/suse_migration_services/migration_config.py
+++ b/suse_migration_services/migration_config.py
@@ -136,6 +136,9 @@ class MigrationConfig:
     def is_soft_reboot_requested(self):
         return self.config_data.get('soft_reboot', True)
 
+    def is_host_independent_initd_requested(self):
+        return self.config_data.get('build_host_independent_initrd', False)
+
     def get_migration_config_file_content(self):
         return yaml.dump(self.config_data, default_flow_style=False)
 

--- a/suse_migration_services/schema.py
+++ b/suse_migration_services/schema.py
@@ -34,5 +34,9 @@ schema = {
     'verbose_migration': {
         'required': False,
         'type': 'boolean'
+    },
+    'build_host_independent_initrd': {
+        'required': False,
+        'type': 'boolean'
     }
 }

--- a/suse_migration_services/units/regenerate_initrd.py
+++ b/suse_migration_services/units/regenerate_initrd.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2022 SUSE Linux LLC.  All rights reserved.
+#
+# This file is part of suse-migration-services.
+#
+# suse-migration-services is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# suse-migration-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
+#
+"""systemd service to build a host independant initrd"""
+import logging
+
+# project
+from suse_migration_services.command import Command
+from suse_migration_services.defaults import Defaults
+from suse_migration_services.logger import Logger
+from suse_migration_services.migration_config import MigrationConfig
+
+from suse_migration_services.exceptions import (
+    DistMigrationCommandException
+)
+
+
+def main():
+    """
+    DistMigration create a new initrd with added modules
+
+    Run dracut to build a new initrd that includes multipath modules
+    """
+    Logger.setup()
+    log = logging.getLogger(Defaults.get_migration_log_name())
+
+    if MigrationConfig().is_host_independent_initd_requested():
+        log.info('Creating a new host independent initrd')
+        root_path = Defaults.get_system_root_path()
+
+        dracut_bind_mounts(root_path)
+        run_dracut(root_path)
+
+
+def dracut_bind_mounts(root_path,):
+    """Function to do bind mounts needed before running dracut"""
+
+    log = logging.getLogger(Defaults.get_migration_log_name())
+
+    BIND_DIRS = ['/dev', '/proc', '/sys']
+
+    for bind_dir in BIND_DIRS:
+        try:
+            log.info(
+                'Running mount --bind {0} {1}'.format(bind_dir, root_path + bind_dir)
+            )
+            Command.run(
+                [
+                    'mount',
+                    '--bind',
+                    bind_dir,
+                    root_path + bind_dir
+                ]
+            )
+        except Exception as issue:
+            log.error(
+                'Unable to mount: {0}'.format(issue)
+            )
+            raise DistMigrationCommandException(
+                'Unable to mount: {0}'.format(
+                    issue
+                )
+            ) from issue
+
+
+def run_dracut(root_path):
+    """Function run dracut"""
+
+    log = logging.getLogger(Defaults.get_migration_log_name())
+
+    try:
+        log.info(
+            'Running chroot {0} dracut --no-kernel --no-host-only --no-hostonly-cmdline'
+            '--regenerate-all --logfile /tmp/host_independent_initrd.log -f'.format(root_path)
+        )
+        Command.run(
+            [
+                'chroot',
+                root_path,
+                'dracut',
+                '--no-kernel',
+                '--no-host-only',
+                '--no-hostonly-cmdline',
+                '--regenerate-all',
+                '--logfile',
+                '/tmp/host_independent_initrd.log',
+                '-f'
+            ]
+        )
+        Command.run(
+            [
+                'chroot',
+                root_path,
+                'cat',
+                '/tmp/host_independent_initrd.log',
+                '>> /var/log/distro_migration.log'
+            ]
+        )
+        Command.run(
+            [
+                'chroot',
+                root_path,
+                'rm',
+                '/tmp/host_independent_initrd.log'
+            ]
+        )
+    except Exception as issue:
+        log.error(
+            'Unable to create new initrd with dracut: {0}'.format(issue)
+        )
+        raise DistMigrationCommandException(
+            'Failed to create new initrd: {0}'.format(
+                issue
+            )
+        ) from issue

--- a/systemd/suse-migration-kernel-load.service
+++ b/systemd/suse-migration-kernel-load.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Load the migrated system kernel/initrd
-After=suse-migration-grub-setup.service
+After=suse-migration-regenerate-initrd.service
 
 [Service]
 Type=oneshot

--- a/systemd/suse-migration-regenerate-initrd.service
+++ b/systemd/suse-migration-regenerate-initrd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Regenerate the initrd to add multipath
+After=suse-migration-grub-setup.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/suse-migration-regenerate-initrd
+
+[Install]
+WantedBy=multi-user.target

--- a/test/data/migration-config-initrd.yml
+++ b/test/data/migration-config-initrd.yml
@@ -1,0 +1,1 @@
+build_host_independent_initrd: true

--- a/test/unit/migration_config_test.py
+++ b/test/unit/migration_config_test.py
@@ -109,6 +109,9 @@ class TestMigrationConfig(object):
     def test_is_debug_requested(self):
         assert self.config.is_debug_requested() is False
 
+    def test_is_host_independent_initd_requested(self):
+        assert self.config.is_host_independent_initd_requested() is False
+
     @patch('yaml.dump')
     def test_write_config_file(self, mock_yaml_dump):
         with patch('builtins.open', create=True) as mock_open:

--- a/test/unit/units/regenerate_initrd_test.py
+++ b/test/unit/units/regenerate_initrd_test.py
@@ -1,0 +1,170 @@
+""" Tests for regenerate_initrd"""
+import logging
+
+from mock import (
+    patch, call
+)
+from pytest import (
+    raises, fixture
+)
+from suse_migration_services.defaults import Defaults
+from suse_migration_services.units.regenerate_initrd import (
+    main, dracut_bind_mounts
+)
+from suse_migration_services.exceptions import (
+    DistMigrationCommandException
+)
+
+
+@patch('suse_migration_services.logger.Logger.setup')
+@patch('os.path.exists')
+class TestRegenInitrd():
+    @fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        """Setup capture log"""
+        self._caplog = caplog
+
+    @patch.object(Defaults, 'get_migration_config_file')
+    @patch('suse_migration_services.command.Command.run')
+    def test_main_raises_on_regen_initrd(
+        self, mock_Command_run, mock_get_migration_config_file,
+        mock_os_path_exists, mock_logger_setup
+    ):
+        """ Test exception raised when running regenerate_initrd"""
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config-initrd.yml'
+        mock_Command_run.side_effect = [
+            None,
+            None,
+            None,
+            Exception('error')
+        ]
+        with self._caplog.at_level(logging.ERROR):
+            with raises(DistMigrationCommandException):
+                main()
+        assert mock_Command_run.call_args_list == [
+            call(
+                [
+                    'mount',
+                    '--bind',
+                    '/dev',
+                    '/system-root/dev',
+                ]
+            ),
+            call(
+                [
+                    'mount',
+                    '--bind',
+                    '/proc',
+                    '/system-root/proc',
+                ]
+            ),
+            call(
+                [
+                    'mount',
+                    '--bind',
+                    '/sys',
+                    '/system-root/sys',
+                ]
+            ),
+            call(
+                [
+                    'chroot',
+                    '/system-root',
+                    'dracut',
+                    '--no-kernel',
+                    '--no-host-only',
+                    '--no-hostonly-cmdline',
+                    '--regenerate-all',
+                    '--logfile',
+                    '/tmp/host_independent_initrd.log',
+                    '-f'
+                ]
+            )
+        ]
+
+    @patch.object(Defaults, 'get_migration_config_file')
+    @patch('suse_migration_services.command.Command.run')
+    def test_dracut_bind_mounts_raises_on_regen_initrd(
+        self, mock_Command_run, mock_get_migration_config_file,
+        mock_os_path_exists, mock_logger_setup
+    ):
+        """ Test exception raised when running dracut_bind_mounts()"""
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config-initrd.yml'
+        mock_Command_run.side_effect = [
+            Exception('error'),
+            Exception('error'),
+            Exception('error')
+        ]
+        with self._caplog.at_level(logging.ERROR):
+            with raises(DistMigrationCommandException):
+                dracut_bind_mounts('/system-root')
+
+    @patch.object(Defaults, 'get_migration_config_file')
+    @patch('suse_migration_services.command.Command.run')
+    def test_main(
+        self, mock_Command_run, mock_get_migration_config_file,
+        mock_os_path_exists, mock_logger_setup
+    ):
+        """ Test running regenerate_initrd"""
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config-initrd.yml'
+        main()
+        assert mock_Command_run.call_args_list == [
+            call(
+                [
+                    'mount',
+                    '--bind',
+                    '/dev',
+                    '/system-root/dev',
+                ]
+            ),
+            call(
+                [
+                    'mount',
+                    '--bind',
+                    '/proc',
+                    '/system-root/proc',
+                ]
+            ),
+            call(
+                [
+                    'mount',
+                    '--bind',
+                    '/sys',
+                    '/system-root/sys',
+                ]
+            ),
+            call(
+                [
+                    'chroot',
+                    '/system-root',
+                    'dracut',
+                    '--no-kernel',
+                    '--no-host-only',
+                    '--no-hostonly-cmdline',
+                    '--regenerate-all',
+                    '--logfile',
+                    '/tmp/host_independent_initrd.log',
+                    '-f'
+                ]
+            ),
+            call(
+                [
+                    'chroot',
+                    '/system-root',
+                    'cat',
+                    '/tmp/host_independent_initrd.log',
+                    '>> /var/log/distro_migration.log'
+                ]
+            ),
+            call(
+                [
+                    'chroot',
+                    '/system-root',
+                    'rm',
+                    '/tmp/host_independent_initrd.log'
+                ]
+            )
+        ]


### PR DESCRIPTION
This change adds a new systemd service, regenerate-initrd that is
responsible for running the dracut command to build a "fat" initrd
when the config setting 'build_host_independent_initrd' is enabled. 

This service is configured to run before the kernel-load service
and allows a new initrd to be created after the migration is complete
and before the final system reboot is performed.

The dracut command that is executed is:

```
chroot  root_path dracut --no-kernel --no-host-only --no-hostonly-cmdline --regenerate-all --logfile  /var/log/YaST2/mkinitrd.log -f
```
