### PR TITLE
Add fix for cloudregister location

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,9 @@
 [bumpversion]
-current_version = 2.0.33
+current_version = 2.0.34
 commit = True
 tag = True
 
 [bumpversion:file:suse_migration_services/version.py]
 
 [bumpversion:file:image/pubcloud/sle15/config.kiwi]
+

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ Session.vim
 
 ### VSCode ##
 .vscode
+
+### Virtual envs ##
+.venv

--- a/image/pubcloud/sle15/config.kiwi
+++ b/image/pubcloud/sle15/config.kiwi
@@ -11,7 +11,7 @@
     </description>
     <preferences>
         <type image="iso" primary="true" flags="overlay" firmware="efi" boottimeout="1"/>
-        <version>2.0.33</version>
+        <version>2.0.34</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_US</locale>
         <keytable>us</keytable>

--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -50,6 +50,7 @@ Systemd services to prepare and run a distribution migration process.
 Summary:          The pre-checks code used with suse-migration-services
 Group:            System/Management
 Requires:         python3-Cerberus
+Requires:         python3-PyYAML
 Conflicts:        suse-migration-sle15-activation < 2.0.33
 
 %description -n suse-migration-pre-checks

--- a/suse_migration_services/units/mount_system.py
+++ b/suse_migration_services/units/mount_system.py
@@ -132,7 +132,7 @@ def read_system_fstab(root_path):
                 log.info('Found %s on %s ', fstab_file, block_device)
                 fstab = Fstab()
                 fstab.read(fstab_file)
-                return(fstab, lsblk_call.output)
+                return (fstab, lsblk_call.output)
             log.info('No %s found on ', block_device)
             log.info('Umount %s', root_path)
             Command.run(
@@ -140,7 +140,7 @@ def read_system_fstab(root_path):
             )
         except Exception as issue:
             log.info('Exception on mount of %s: %s', block_device, issue)
-    return(None, lsblk_call.output)
+    return (None, lsblk_call.output)
 
 
 def mount_system(root_path, fstab):

--- a/suse_migration_services/version.py
+++ b/suse_migration_services/version.py
@@ -18,4 +18,4 @@
 """
 Global version information used in suse-migration-services and the package
 """
-__VERSION__ = '2.0.33'
+__VERSION__ = '2.0.34'

--- a/test/data/etc/hosts
+++ b/test/data/etc/hosts
@@ -1,0 +1,1 @@
+1.2.3.4   smt-foo.susecloud.net smt-foo


### PR DESCRIPTION
This PR addresses an issue with the th cloud-regionsrv-client > 10.04. In that version the SMT cache files have been relocated from  /var/lib/cloudregister to /var/cache/cloudregister.  To accommodate this change, a new function has been added, get_regionsrv_client_file_location which will search both locations to find the cache files. If none are found, an exception is created as the migration would fail otherwise.

In addition, a missing dependency on the suse-migration-services-pre-checks was added in.

closes #250 