### PR TITLE
Use bind mount to ensure the resolv.conf is not empty

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.34
+current_version = 2.0.35
 commit = True
 tag = True
 

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -5,7 +5,8 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    #runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6, 3.8]

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 .pytest_cache
 test/unit/.coverage
 htmlcov/
+doc/build
 
 ### Vim ###
 # swap

--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -112,6 +112,20 @@ A `-f/--fix` option that will remediate the following issues:
 1. Set multiversion.kernels to the correct value and remove all
 old (not currently running) kernels.
 
+Example output from running suse-migration-pre-checks:
+
+[listing]
+Running suse-migration-pre-checks with options: fix: False
+Calling: ['blkid', '-s', 'TYPE', '-o', 'value', '/dev/disk/by-uuid/e35ee7fd-7985-4e86-ae79-32c8077e2006']
+Calling: ['blkid', '-s', 'TYPE', '-o', 'value', '/dev/disk/by-uuid/8da89821-e427-4375-8c9b-f142903e2ff8']
+Calling: ['blkid', '-s', 'TYPE', '-o', 'value', '/dev/disk/cloud/azure_resource-part1']
+Calling: ['blkid', '-s', 'TYPE', '-o', 'value', '/dev/disk/by-uuid/B04E-7E9D']
+The config option 'multiversion' in /etc/zypp/zypp.conf includes the keyword 'kernel.' The current value is set as
+'multiversion = provides:multiversion(kernel)'.
+Checking the config option 'multiversion.kernels' to see if multiple kernels are also enabled
+Calling: ['rpm', '-qa', 'kernel-default']
+
+
 == Installation
 The distribution migration system is available from the Public Cloud module.
 Therefore this module has to be enabled on the system prior to upgrade.

--- a/image/pubcloud/sle15/config.kiwi
+++ b/image/pubcloud/sle15/config.kiwi
@@ -11,7 +11,7 @@
     </description>
     <preferences>
         <type image="iso" primary="true" flags="overlay" firmware="efi" boottimeout="1"/>
-        <version>2.0.34</version>
+        <version>2.0.35</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_US</locale>
         <keytable>us</keytable>

--- a/suse_migration_services/version.py
+++ b/suse_migration_services/version.py
@@ -18,4 +18,4 @@
 """
 Global version information used in suse-migration-services and the package
 """
-__VERSION__ = '2.0.34'
+__VERSION__ = '2.0.35'


### PR DESCRIPTION
The PR changes the behavior of setup_host_network when the resolv.conf in the target system is "empty" (It does not contain any entries.)  The current behavior was to not copy the file over if it was empty.   Due to a recent change in wickedd, when the migration is started via the "Reboot" method, the target /etc/resolv.conf is reset and does not contain any entries.  (This does not happens if the /usr/sbin/run_migration is used.)  This means when the migration iso is booted,  the /system-root/etc/resolv.conf is empty and therefore any commands that require DNS and are run under `chroot /system-root` will fail. 

This change will now "bind mount" /etc/resolv.conf to /system-root/etc/resolv.conf when the `/system-root/etc/resolv.conf` is empty. 

In addition, this PR contains:
- A requested documentation update and 
- Bump version: 2.0.34 → 2.0.35

closes #253 