### PR TITLE
Fix kernel check when there is no entry for 'multiversion ='

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.34
+current_version = 2.0.35
 commit = True
 tag = True
 

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -5,7 +5,8 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    #runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6, 3.8]

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 .pytest_cache
 test/unit/.coverage
 htmlcov/
+doc/build
 
 ### Vim ###
 # swap

--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -112,6 +112,20 @@ A `-f/--fix` option that will remediate the following issues:
 1. Set multiversion.kernels to the correct value and remove all
 old (not currently running) kernels.
 
+Example output from running suse-migration-pre-checks:
+
+[listing]
+Running suse-migration-pre-checks with options: fix: False
+Calling: ['blkid', '-s', 'TYPE', '-o', 'value', '/dev/disk/by-uuid/e35ee7fd-7985-4e86-ae79-32c8077e2006']
+Calling: ['blkid', '-s', 'TYPE', '-o', 'value', '/dev/disk/by-uuid/8da89821-e427-4375-8c9b-f142903e2ff8']
+Calling: ['blkid', '-s', 'TYPE', '-o', 'value', '/dev/disk/cloud/azure_resource-part1']
+Calling: ['blkid', '-s', 'TYPE', '-o', 'value', '/dev/disk/by-uuid/B04E-7E9D']
+The config option 'multiversion' in /etc/zypp/zypp.conf includes the keyword 'kernel.' The current value is set as
+'multiversion = provides:multiversion(kernel)'.
+Checking the config option 'multiversion.kernels' to see if multiple kernels are also enabled
+Calling: ['rpm', '-qa', 'kernel-default']
+
+
 == Installation
 The distribution migration system is available from the Public Cloud module.
 Therefore this module has to be enabled on the system prior to upgrade.

--- a/image/pubcloud/sle15/config.kiwi
+++ b/image/pubcloud/sle15/config.kiwi
@@ -11,7 +11,7 @@
     </description>
     <preferences>
         <type image="iso" primary="true" flags="overlay" firmware="efi" boottimeout="1"/>
-        <version>2.0.34</version>
+        <version>2.0.35</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_US</locale>
         <keytable>us</keytable>

--- a/suse_migration_services/prechecks/kernels.py
+++ b/suse_migration_services/prechecks/kernels.py
@@ -55,7 +55,11 @@ def multiversion_settings(fix, migration_system, log):
 
     kernel_multi_version_enabled = config.get('main', 'multiversion', fallback=None)
 
-    if 'kernel' in kernel_multi_version_enabled:
+    if not kernel_multi_version_enabled:
+        log.info("Could not find the config option 'multiversion' in "
+                 "/etc/zypp/zypp.conf. Skipping check for "
+                 "'multiversion.kernels'")
+    elif 'kernel' in kernel_multi_version_enabled:
         kernel_multi_version_settings = config.get('main', 'multiversion.kernels', fallback=None)
 
         log.info("The config option 'multiversion' in /etc/zypp/zypp.conf "
@@ -63,7 +67,6 @@ def multiversion_settings(fix, migration_system, log):
                  "as \n'multiversion = %s'.\nChecking the config option "
                  "'multiversion.kernels' to see if multiple kernels are "
                  "also enabled", kernel_multi_version_enabled)
-
         if not kernel_multi_version_settings:
             log.warning('Missing multiversion.kernels setting in zypp.conf. '
                         'Please ensure it is set as:\n'

--- a/suse_migration_services/version.py
+++ b/suse_migration_services/version.py
@@ -18,4 +18,4 @@
 """
 Global version information used in suse-migration-services and the package
 """
-__VERSION__ = '2.0.34'
+__VERSION__ = '2.0.35'

--- a/test/unit/pre_checks_test.py
+++ b/test/unit/pre_checks_test.py
@@ -295,6 +295,35 @@ class TestPreChecks():
     @patch('configparser.ConfigParser.get')
     @patch('suse_migration_services.command.Command.run')
     @patch('os.readlink')
+    def test_missing_multiversion_in_zypp_config(
+        self, mock_os_readlink, mock_command_run,
+        mock_configparser_get, mock_log
+    ):
+        """ Test for missing setting in /etc/zypp/zypp.conf"""
+
+        mock_os_readlink.return_value = 'vmlinuz-4.12.14-122.113-default'
+
+        rpm_command = Mock()
+        rpm_command.returncode = 0
+        rpm_command.output = 'kernel-default-4.12.14-122.113.1.x86_64'
+
+        mock_command_run.side_effect = [rpm_command]
+
+        mock_configparser_get.side_effect = \
+            [None]
+
+        warning_message_multipe_kernels = \
+            "Could not find the config option 'multiversion' in " \
+            "/etc/zypp/zypp.conf. Skipping check for " \
+            "'multiversion.kernels'"
+
+        with self._caplog.at_level(logging.INFO):
+            check_kernels.multiversion_and_multiple_kernels()
+            assert warning_message_multipe_kernels in self._caplog.text
+
+    @patch('configparser.ConfigParser.get')
+    @patch('suse_migration_services.command.Command.run')
+    @patch('os.readlink')
     def test_update_zypp_conf_exception_raised(
         self, mock_os_readlink, mock_command_run,
         mock_configparser_get, mock_log


### PR DESCRIPTION
This PR fixes an issue when  the following lines in /etc/zypp/zypp.conf are commented out a stack trace was created. 

#multiversion = provides:multiversion(kernel)
#multiversion.kernels = latest,running

With this change an appropriate warning message is logged and stacktrace do not occur.

Closes #255 

