### PR TITLE
Add option to skip bind mount entries in fstab

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.35
+current_version = 2.0.36
 commit = True
 tag = True
 

--- a/image/pubcloud/sle15/config.kiwi
+++ b/image/pubcloud/sle15/config.kiwi
@@ -11,7 +11,7 @@
     </description>
     <preferences>
         <type image="iso" primary="true" flags="overlay" firmware="efi" boottimeout="1"/>
-        <version>2.0.35</version>
+        <version>2.0.36</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_US</locale>
         <keytable>us</keytable>

--- a/suse_migration_services/fstab.py
+++ b/suse_migration_services/fstab.py
@@ -53,7 +53,8 @@ class Fstab:
         with open(filename) as fstab:
             for line in fstab.readlines():
                 mount_record = line.split()
-                if not mount_record or mount_record[0].startswith('#'):
+                if not mount_record or mount_record[0].startswith('#') or \
+                        mount_record[2].lower() == 'none':
                     continue
                 device = mount_record[0]
                 mountpoint = mount_record[1]

--- a/suse_migration_services/version.py
+++ b/suse_migration_services/version.py
@@ -18,4 +18,4 @@
 """
 Global version information used in suse-migration-services and the package
 """
-__VERSION__ = '2.0.35'
+__VERSION__ = '2.0.36'

--- a/test/data/fstab
+++ b/test/data/fstab
@@ -5,5 +5,6 @@ UUID=FCF7-B051                             /boot/efi  vfat  defaults        0  0
 LABEL=foo  /home      ext4  defaults        0  0
 PARTUUID=3c8bd108-01 /bar ext4 defaults 0 0
 /dev/mynode /foo ext4 defaults 0 0
+/root /testbindmount none defaults,bind 0 0
 
 # this comment line and the line above should be ignored by the parser


### PR DESCRIPTION
This PR adds a check when reading the fstab file to skip entries whose file system is none.  Per the man page of fstab, the third field fs_vfstype is set to "none" for bind or move mounts.  By checking for 'none', this allows the suse-migration-pre-checks to run correctly when a fstab has a bind mount entry. Prior to the change, if a bind mount existed, a stacktrace was generated when suse-migration-pre-checks was run.

```
EXEC: Failed with stderr: (no output on stderr), stdout: (no output on stdout)
Traceback (most recent call last):
  File "/usr/bin/suse-migration-pre-checks", line 11, in <module>
    load_entry_point('suse-migration-services==2.0.35', 'console_scripts', 'suse-migration-pre-checks')()
  File "/usr/lib/python3.4/site-packages/suse_migration_services/prechecks/pre_checks.py", line 81, in main
    check_fs.encryption(migration_system=migration_system_mode)
  File "/usr/lib/python3.4/site-packages/suse_migration_services/prechecks/fs.py", line 39, in encryption
    ["blkid", "-s", "TYPE", "-o", "value", fstab_entry.device]
  File "/usr/lib/python3.4/site-packages/suse_migration_services/command.py", line 117, in run
    command[0], error.decode(), output.decode()
suse_migration_services.exceptions.DistMigrationCommandException: blkid: stderr: (no output on stderr), stdout: (no output on stdout)
```
In addition, the version was updated.

Bump version: 2.0.35 → 2.0.36