### PR TITLE
Add fixes to make updatesmtcache work correctly

### DIFF
--- a/image/pubcloud/sle15/config.kiwi
+++ b/image/pubcloud/sle15/config.kiwi
@@ -63,6 +63,10 @@
         <!-- support for migration of suse public cloud on demand images -->
         <package name="cloud-regionsrv-client"/>
         <package name="cloud-regionsrv-client-generic-config"/>
+        <package name="cloud-regionsrv-client-addon-azure"/>
+        <package name="cloud-regionsrv-client-plugin-azure"/>
+        <package name="cloud-regionsrv-client-plugin-ec2"/>
+        <package name="cloud-regionsrv-client-plugin-gce"/>
         <package name="python3-gcemetadata"/>
         <package name="python3-ec2metadata"/>
         <package name="python3-azuremetadata"/>

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -67,6 +67,10 @@ def main():
         '/etc/pki/trust/anchors/'
     ]
     cache_cloudregister_path = '/var/cache/cloudregister'
+    cloud_register_certs_path = '/var/lib/regionService/certs'
+    cloud_register_certs_bind_mount_path = \
+        root_path + cloud_register_certs_path
+
     cloud_register_metadata = ""
 
     if os.path.exists(suse_connect_setup):
@@ -187,6 +191,20 @@ def main():
                 [
                     'mount', '--bind', cloud_register_metadata,
                     cache_cloudregister_path
+                ]
+            )
+        if os.path.exists(cloud_register_certs_bind_mount_path):
+            log.info(
+                'Bind mounting {0} from {1}'.format(
+                    cloud_register_certs_path,
+                    cloud_register_certs_bind_mount_path
+                )
+            )
+            Path.create(cloud_register_certs_path)
+            Command.run(
+                [
+                    'mount', '--bind', cloud_register_certs_bind_mount_path,
+                    cloud_register_certs_path
                 ]
             )
             update_smt_cache = '/usr/sbin/updatesmtcache'

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -160,13 +160,14 @@ class TestSetupPrepare(object):
             False, False, False, True
         ]
         mock_os_path_exists.side_effect = [
-            True, True, True, True, False, True, True
+            True, True, True, True, False, True, True, True
         ]
         mock_is_registered.return_value = True
         mock_Command_run.side_effect = [
             MagicMock(),
             MagicMock(),
             Exception('no zypper log'),
+            MagicMock(),
             MagicMock(),
             MagicMock(),
             MagicMock(),
@@ -256,6 +257,12 @@ class TestSetupPrepare(object):
                 [
                     'mount', '--bind', '/system-root/var/cache/cloudregister',
                     '/var/cache/cloudregister'
+                ]
+            ),
+            call(
+                [
+                    'mount', '--bind', '/system-root/var/lib/regionService/certs',
+                    '/var/lib/regionService/certs'
                 ]
             ),
             call(


### PR DESCRIPTION
This PR add  the necessary fixes to resolve an an error when updatesmtcache is called.  The fixes include:

1) Bind mound the certs from /system-root/var/lib/regionService/certs to /var/lib/regionService/certs
2) Install the following plugin's which are used by updatesmtscache

 cloud-regionsrv-client-addon-azure
 cloud-regionsrv-client-plugin-azure
 cloud-regionsrv-client-plugin-ec2
 cloud-regionsrv-client-plugin-gce
