### PR TITLE
Add missing metadata for docs.suse.com

### DIFF
--- a/doc/DC-distribution-migration-system
+++ b/doc/DC-distribution-migration-system
@@ -11,4 +11,4 @@ ADOC_TYPE=article
 #ADOC_IMG_DIR=adoc/images
 
 DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/doc/DC-distribution-migration-system
+++ b/doc/DC-distribution-migration-system
@@ -10,4 +10,5 @@ ADOC_POST=yes
 ADOC_TYPE=article
 #ADOC_IMG_DIR=adoc/images
 
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"

--- a/doc/adoc/user_guide-docinfo.xml
+++ b/doc/adoc/user_guide-docinfo.xml
@@ -1,0 +1,6 @@
+<dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+    <dm:bugtracker>
+        <dm:url>https://github.com/SUSE/suse-migration-services/issues/new</dm:url>
+	<dm:editurl>https://github.com/SUSE/suse-migration-services/edit/master/doc/adoc/user_guide.adoc</dm:editurl>
+    </dm:bugtracker>
+</dm:docmanager>

--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -1,3 +1,5 @@
+:docinfo:
+
 = Using the SUSE Distribution Migration System
 Marcus Schäfer; Jesús Velázquez; Keith Berger
 


### PR DESCRIPTION
# Situation

The document at https://documentation.suse.com/suse-distribution-migration-system/15/single-html/distribution-migration-system/ is publicly available, but misses "Edit source" and "Report bug" links.

The SLE documentation contains some metadata which is used to create these links.


# Solution

This change adds metadata to create "Report bug" links for each title. This is how it looks like when you hover the mouse:

![Screenshot_20230601_160748](https://github.com/SUSE/suse-migration-services/assets/1312925/b989d300-6dc2-466b-aadf-afb6c7477954)


This is how it looks, @amach4. 