### PR TITLE
update spec template file to include update_bootloader service

### DIFF
--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -89,6 +89,9 @@ install -D -m 644 systemd/suse-migration.service \
 install -D -m 644 systemd/suse-migration-grub-setup.service \
     %{buildroot}%{_unitdir}/suse-migration-grub-setup.service
 
+install -D -m 644 systemd/suse-migration-update-bootloader.service \
+    %{buildroot}%{_unitdir}/suse-migration-update-bootloader.service
+
 install -D -m 644 systemd/suse-migration-product-setup.service \
     %{buildroot}%{_unitdir}/suse-migration-product-setup.service
 


### PR DESCRIPTION
This commit adds an entry to the suse-migration-services-spec-template file to install the new update_bootloader service. This was inadvertently omitted in #262 