### PR TITLE
Add entries to setup.py and the spec file

### DIFF
--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -155,6 +155,9 @@ install -D -m 644 systemd/suse-migration-console-log.service \
 %{_bindir}/suse-migration-grub-setup
 %{_unitdir}/suse-migration-grub-setup.service
 
+%{_bindir}/suse-migration-update-bootloader
+%{_unitdir}/suse-migration-update-bootloader.service
+
 %{_bindir}/suse-migration-product-setup
 %{_unitdir}/suse-migration-product-setup.service
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ config = {
             'suse-migration-prepare=suse_migration_services.units.prepare:main',
             'suse-migration=suse_migration_services.units.migrate:main',
             'suse-migration-grub-setup=suse_migration_services.units.grub_setup:main',
+            'suse-migration-update-bootloader=suse_migration_services.units.update_bootloader:main',
             'suse-migration-regenerate-initrd=suse_migration_services.units.regenerate_initrd:main',
             'suse-migration-kernel-load=suse_migration_services.units.kernel_load:main',
             'suse-migration-reboot=suse_migration_services.units.reboot:main',


### PR DESCRIPTION
This PR updates the setup.py and spec file to add a few more missing entries needed when adding a new service.  The update_bootloader service was added in #262 and #263 addressed one aspect of adding a new service. This PR completes the update.