### PR TITLE
Fixing variablelists that caused validation errors

### DIFF
--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -124,6 +124,7 @@ old (not currently running) kernels.
 Example output from running suse-migration-pre-checks:
 
 [listing]
+----
 Running suse-migration-pre-checks with options: fix: False
 Calling: ['blkid', '-s', 'TYPE', '-o', 'value', '/dev/disk/by-uuid/e35ee7fd-7985-4e86-ae79-32c8077e2006']
 Calling: ['blkid', '-s', 'TYPE', '-o', 'value', '/dev/disk/by-uuid/8da89821-e427-4375-8c9b-f142903e2ff8']
@@ -133,7 +134,7 @@ The config option 'multiversion' in /etc/zypp/zypp.conf includes the keyword 'ke
 'multiversion = provides:multiversion(kernel)'.
 Checking the config option 'multiversion.kernels' to see if multiple kernels are also enabled
 Calling: ['rpm', '-qa', 'kernel-default']
-
+----
 
 == Installation
 The distribution migration system is available from the Public Cloud module.
@@ -154,7 +155,9 @@ package.
 Option 1 - Trigger via run_migration::
 +
 [listing]
+----
 tux > sudo zypper in SLES15-Migration
+----
 +
 The `run_migration` uses `kexec` to boot into the kernel delivered with the
 upgrade image delivered by the SLES15-Migration package. Once this system
@@ -169,12 +172,16 @@ https://www.suse.com/support/kb/doc/?id=000019733
 And set the "soft_reboot" customization option:
 +
 [listing]
+----
 echo "soft_reboot: false" >> /etc/sle-migration-service.yml
+----
 
 Option 2 - Trigger via reboot::
 +
 [listing]
+----
 tux > sudo zypper in SLES15-Migration suse-migration-sle15-activation
+----
 +
 Starting the migration via reboot after installing the
 suse-migration-sle15-activation package covers the Xen use case but does
@@ -193,7 +200,9 @@ upgrade process. Prior to the start of the upgrade process, create the
 following file if a change of the default behavior is needed:
 
 [listing]
+----
 tux > ssh INSTANCE_USER@IP_OF_INSTANCE 'touch /etc/sle-migration-service.yml'
+----
 
 The custom config file supports the following settings:
 
@@ -203,7 +212,9 @@ or for which the repository server has no upgrade path, it's required to
 switch off the use of the migration workflow.
 +
 [listing]
+----
 use_zypper_migration: true|false
+----
 +
 [NOTE]
 The use of the migration workflow is the default behavior. If the migration
@@ -225,7 +236,9 @@ The product must be specified with the triplet name/version/arch found
 in '/etc/products.d/baseproduct' of the target product, for example:
 +
 [listing]
+----
 migration_product: 'SLES/15.1/x86_64'
+----
 +
 would set the product target to SLES-15-SP1
 +
@@ -245,6 +258,7 @@ rule set effective, while the files in the static section are copied with no
 further action.
 +
 [listing]
+----
 preserve:
   rules:
     - /etc/udev/rules.d/a.rules
@@ -252,6 +266,7 @@ preserve:
   static:
     - /etc/sysconfig/proxy
     - /path/to/be/preserved/file
+----
 +
 [NOTE]
 udev rules that require custom drivers will not have the desired effect
@@ -265,7 +280,9 @@ steps and rebooting due to a failed upgrade, allowing the issue to
 be debugged.
 +
 [listing]
+----
 debug: true|false
+----
 
 Configure Reboot Method::
 By default, the migration system uses `kexec` to boot back into the host
@@ -273,20 +290,26 @@ system once migration is complete.  If this is in any way problematic,
 a regular `reboot` can be requested by setting `soft_reboot: false`.
 +
 [listing]
+----
 soft_reboot: true|false
+----
 
 Enable verbosity for zypper migration::
 If enabled, it will run the zypper migration plugin with increased verbosity.
 +
 [listing]
+----
 verbose_migration: true|false
+----
 
 Enable the fix option for pre_checks::
 If enabled (default), the run_pre_checks systemd process will use the `--fix`
 option to automatically remediate applicable issues before the migration is started. 
 +
 [listing]
+----
 pre_checks_fix: true|false
+----
 
 Configure Make initrd Method::
 The live system may not contain all necessary tools to create an initrd that
@@ -297,7 +320,9 @@ independent initrd can be created by setting
 `build_host_independent_initrd: True`.
 +
 [listing]
+----
 build_host_independent_initrd: true|false
+----
 
 == Run the Migration
 Migration can be triggered either via run_migration or via reboot.
@@ -307,7 +332,9 @@ After the install of the `SLES15-Migration` package, start the migration
 process by calling the following command:
 +
 [listing]
+----
 tux > sudo run_migration
+----
 
 Option 2 - Running Migration via reboot::
 +
@@ -315,7 +342,9 @@ Option 2 - Running Migration via reboot::
 If using the `reboot` method to start migration, reboot the system:
 +
 [listing]
+----
 tux > sudo reboot
+----
 
 After Migration has been triggered via either method::
 +
@@ -324,7 +353,9 @@ After the upgrade has started, the only way to access the system during the
 upgrade process is via ssh with a user called `migration`:
 +
 [listing]
+----
 tux > sudo ssh migration@IP_OF_INSTANCE
+----
 +
 [NOTE]
 There is no need to provide any other information or key. The known SSH

--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -152,30 +152,30 @@ process is via reboot after installing the suse-migration-sle15-activation
 package.
 
 Option 1 - Trigger via run_migration::
-
++
 [listing]
 tux > sudo zypper in SLES15-Migration
-
++
 The `run_migration` uses `kexec` to boot into the kernel delivered with the
 upgrade image delivered by the SLES15-Migration package. Once this system
 is live after the `kexec` the distribution migration process is automatically
 started. However, `kexec` is not supported and does not function in certain
 conditions. The `run_migration` utility does not work in Xen based
 environments.
-
++
 If kexec causes a kernel panic this can cause the system to hang and the 
 distribution migration to fail. In that case refer to this TID:
 https://www.suse.com/support/kb/doc/?id=000019733
 And set the "soft_reboot" customization option:
-
++
 [listing]
 echo "soft_reboot: false" >> /etc/sle-migration-service.yml
 
 Option 2 - Trigger via reboot::
-
++
 [listing]
 tux > sudo zypper in SLES15-Migration suse-migration-sle15-activation
-
++
 Starting the migration via reboot after installing the
 suse-migration-sle15-activation package covers the Xen use case but does
 not work in cases where there is no direct access to the root file system
@@ -201,10 +201,10 @@ Control Zypper Installation Mode::
 If the upgrade process is used on systems that are not registered
 or for which the repository server has no upgrade path, it's required to
 switch off the use of the migration workflow.
-
++
 [listing]
 use_zypper_migration: true|false
-
++
 [NOTE]
 The use of the migration workflow is the default behavior. If the migration
 workflow is not used, the setup of the repositories must be performed
@@ -215,20 +215,20 @@ Migration product target::
 The default product target will be the 15-SP1 release corresponding to the
 current product. The migration_product setting can be used to change the
 product target. 
-
++
 [NOTE]
 Changing the product target from the 15-SP1 release is not officially
 supported
-
++
 If migration_product is set, the migration will use that product as a target.
 The product must be specified with the triplet name/version/arch found
 in '/etc/products.d/baseproduct' of the target product, for example:
-
++
 [listing]
 migration_product: 'SLES/15.1/x86_64'
-
++
 would set the product target to SLES-15-SP1
-
++
 [NOTE]
 The default target, if `migration_product` is not set, is the version
 available in the migration path from zypper-migration.
@@ -237,13 +237,13 @@ Preserve System Data::
 Preserve custom data file(s) e.g. udev rules from the system
 to be migrated into the upgrade live system and make sure
 they will become effective.
-
++
 Under preserve section, there are two subsections: rules and static.
 The difference between 'rules' and 'static' sections is that files preserved as
 udev rules will also make the DMS to reload udev and its rules to make the new
 rule set effective, while the files in the static section are copied with no
 further action.
-
++
 [listing]
 preserve:
   rules:
@@ -252,8 +252,7 @@ preserve:
   static:
     - /etc/sysconfig/proxy
     - /path/to/be/preserved/file
-
-
++
 [NOTE]
 udev rules that require custom drivers will not have the desired effect
 as the migration system will not include these drivers and therefore
@@ -264,7 +263,7 @@ Enable Debug Mode::
 If enabled, prevents the upgrade system from rewinding the setup
 steps and rebooting due to a failed upgrade, allowing the issue to
 be debugged.
-
++
 [listing]
 debug: true|false
 
@@ -272,20 +271,20 @@ Configure Reboot Method::
 By default, the migration system uses `kexec` to boot back into the host
 system once migration is complete.  If this is in any way problematic,
 a regular `reboot` can be requested by setting `soft_reboot: false`.
-
++
 [listing]
 soft_reboot: true|false
 
 Enable verbosity for zypper migration::
 If enabled, it will run the zypper migration plugin with increased verbosity.
-
++
 [listing]
 verbose_migration: true|false
 
 Enable the fix option for pre_checks::
 If enabled (default), the run_pre_checks systemd process will use the `--fix`
 option to automatically remediate applicable issues before the migration is started. 
-
++
 [listing]
 pre_checks_fix: true|false
 
@@ -296,7 +295,7 @@ initrd will create an initrd in a way that contains the tools and
 modules available on the system being upgraded. If this is needed, a host
 independent initrd can be created by setting
 `build_host_independent_initrd: True`.
-
++
 [listing]
 build_host_independent_initrd: true|false
 
@@ -306,25 +305,27 @@ Migration can be triggered either via run_migration or via reboot.
 Option 1 - Running Migration via run_migration::
 After the install of the `SLES15-Migration` package, start the migration
 process by calling the following command:
-
++
 [listing]
 tux > sudo run_migration
 
 Option 2 - Running Migration via reboot::
++
 [NOTE]
 If using the `reboot` method to start migration, reboot the system:
-
++
 [listing]
 tux > sudo reboot
 
 After Migration has been triggered via either method::
++
 [NOTE]
 After the upgrade has started, the only way to access the system during the
 upgrade process is via ssh with a user called `migration`:
-
++
 [listing]
 tux > sudo ssh migration@IP_OF_INSTANCE
-
++
 [NOTE]
 There is no need to provide any other information or key. The known SSH
 keys on the system to be upgraded have been imported into the upgrade system.


### PR DESCRIPTION
Complex list elements consisting of more than one block may not contain empty lines, you need to concatenate the blocks with a single "+" on a line. Did that for the variablelists, which otherwise caused an error when building html/pdf.

Also added block markeres to the listings which solved the problem of a superflous "+" in the output for me.