### PR TITLE
Clarify supported versions of SLES

### DIFF
--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -92,6 +92,11 @@ If your system is not configured for it, it is recommended that at least
 one of the users on the system has a `~/.ssh/authorized_keys` file with a
 private key accessible by the person executing the system upgrade.
 
+SLES Version Support::
+Upgrade is supported from SLES12 SP4 or SLES12 SP5 to SLES 15 SP1. It is
+possible to configure other versions of SLES as the migration target,
+but doing so is not a tested or supported use case.
+
 == Upgrade Pre-Checks
 The suse-migration-pre-checks package contains the `suse-migration-pre-checks`
 script that checks for possible incompatibilities when doing a migration.
@@ -325,7 +330,8 @@ a pointer to the respective log file.
 * Upgrade is only possible for systems that use unencrypted root file systems,
   at the OS level. Encrypting the root device using a cloud framework
   encryption mechanism happens at a different level.
-* Upgrade has been tested for SLES 12 SP4 to SLES 15
+* Upgrade has been tested for SLES 12 SP4 to SLES 15 SP1
+* Upgrade has been tested for SLES 12 SP5 to SLES 15 SP1
 * The system is primarily intended for Public Cloud instance upgrade use. The
   system also works for simple setups in a data center setting on physical
   installations. However, for any more complex configurations the off line


### PR DESCRIPTION
Update the prerequisites section to specify that SLES12 SP4 and SLES12 SP5 are the supported versions to migrate from, and that SLES15 SP1 is the supported target version of the migration.