### PR TITLE
Update kiwi config files to match current build versions

### DIFF
--- a/image/pubcloud/sle15/config.kiwi
+++ b/image/pubcloud/sle15/config.kiwi
@@ -23,8 +23,17 @@
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/migration" name="migration" groups="users"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15-SP1:Update/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15-SP1:GA/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15:Update/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15:GA/standard"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/image/pubcloud/sle15/config.sh
+++ b/image/pubcloud/sle15/config.sh
@@ -3,9 +3,10 @@
 # FILE          : config.sh
 #----------------
 # PROJECT       : KIWI - Image System
-# COPYRIGHT     : (c) 2020 SUSE Software Solutions Germany GmbH
+# COPYRIGHT     : (c) 2023 SUSE Software Solutions Germany GmbH
 #               :
-# AUTHOR        : Marcus Schaefer <ms@suse.de>
+# AUTHORS       : Marcus Schaefer <ms@suse.de>
+#               : Keith Berger <kberger@suse.com>
 #               :
 # BELONGS TO    : Operating System images
 #               :


### PR DESCRIPTION
This PR updates the kiwi image file to use the correct set of repositories. Prior it was using 

```
    <repository type="rpm-md" >
        <source path='obsrepositories:/'/>
```
but this does not match the current version used in the buildserver.