### PR TITLE
Address nose tests deprecation issues

### DIFF
--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -8,7 +8,7 @@ from suse_migration_services.defaults import Defaults
 
 
 class TestDefaults(object):
-    def setup(self):
+    def setup_method(self):
         self.defaults = Defaults()
 
     def test_get_migration_config_file(self):


### PR DESCRIPTION
The Python 3.8 CI testing is failing with an error because we haven't addressed the nose tests support deprecation by renaming the setup() method to setup_method().