### PR TITLE
Bind mount the configured certs location bsc#1219004

### DIFF
--- a/test/data/regionserverclnt-certlocation.cfg
+++ b/test/data/regionserverclnt-certlocation.cfg
@@ -1,0 +1,2 @@
+[server]
+certLocation = /usr/lib/regionService/certs

--- a/test/data/regionserverclnt-nocertlocation.cfg
+++ b/test/data/regionserverclnt-nocertlocation.cfg
@@ -1,0 +1,2 @@
+[server]
+dummy = value

--- a/test/data/regionserverclnt-oldcertlocation.cfg
+++ b/test/data/regionserverclnt-oldcertlocation.cfg
@@ -1,0 +1,2 @@
+[server]
+certLocation = /var/lib/regionService/certs


### PR DESCRIPTION
When the migration is running ensure that the correct certs directory is bind mounted from the /system-root into the ISO boot's runtime environment, by retrieving the configured server.certlocation setting from the /system-root/etc/regionserverclnt.cfg file.

Add unit tests for new get_regionsrv_certs_path() function and tweak some existing tests, that depend upon mocking calls to builtin.open(), so that they mock any calls to get_regionsrv_certs_path() so as to avoid triggering additional open() calls that would break those tests.