### PR TITLE
Address RPM spec file and config.kiwi dependency issues

### DIFF
--- a/image/pubcloud/sle15/config.kiwi
+++ b/image/pubcloud/sle15/config.kiwi
@@ -37,6 +37,7 @@
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
+        <package name="suseconnect-ng"/>
         <package name="ifplugd"/>
         <package name="iputils"/>
         <package name="vim"/>
@@ -65,7 +66,6 @@
         <package name="bind-utils"/>
         <package name="util-linux"/>
         <package name="suse-migration-services"/>
-        <package name="zypper-migration-plugin"/>
         <package name="dialog"/>
         <package name="sudo"/>
         <package name="mdadm"/>

--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -38,7 +38,7 @@ Requires:         kexec-tools
 Requires:         ca-certificates
 Requires:         dialog
 Requires:         rsync
-Requires:         SUSEConnect >= 0.3.20
+Requires:         suseconnect-ng
 Requires(preun):  systemd
 Requires(postun): systemd
 BuildArch:        noarch


### PR DESCRIPTION
Update the syse-migration-services RPM spec file dependencies to use suseconnect-ng rather than the legacy SUSEConnect.  While the existing dependency specification works with zypper dependency resolution, it doesn't work with the build service package resolution mechanism and breaks the build of the SLE 15 SP1 ISO image containing the package.

Also update the config.kiwi used to build the SLE 15 SP1 ISO image to explicitly install suseconnect-ng and remove zypper-migration-plugin, which conflicts with suseconnect-ng.