### PR TITLE
Fix update-bootloader to run after grub-setup  bsc#1222258

### DIFF
--- a/systemd/suse-migration-update-bootloader.service
+++ b/systemd/suse-migration-update-bootloader.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Update the bootloader
-After=suse-migration-update-bootloader.service
+After=suse-migration-grub-setup.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Also checked to ensure that the sequencing for all systemd services now matches the ordering specified in helper/system.tree.