### PR TITLE
Switch default target and ISO backing distro SLE 15 SP3

### DIFF
--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -28,9 +28,9 @@ endif::[]
 == Concept
 The Distribution Migration System provides an upgrade path for an
 installed SUSE Linux Enterprise system from one major version to another,
-for example, from SUSE Linux Enterprise Server 12 SP4 to SUSE Linux
-Enterprise Server 15. For a service pack upgrade from one Service Pack (SP)
-to another within a given major version release series the existing
+for example, from SUSE Linux Enterprise Server 12 SP5 to SUSE Linux
+Enterprise Server 15 SP3. For a service pack upgrade from one Service Pack
+(SP) to another within a given major version release series the existing
 Zypper migration workflow provides the supported upgrade path.
 The distribution migration system provides the ability to upgrade across
 major distributions without the need to use the next major version
@@ -100,9 +100,9 @@ data or processes. For example, DMS will function if /home is its own
 partition, but not if /var is on a separate partition from root.
 
 SLES Version Support::
-Upgrade is supported from SLES12 SP4 or SLES12 SP5 to SLES 15 SP3. It is
-possible to configure other versions of SLES as the migration target,
-but doing so is not a tested or supported use case.
+Upgrade is supported from SLES12 SP5 to SLES 15 SP3. It is possible to
+configure other versions of SLES as the migration target, but doing so
+is not a tested or supported use case.
 
 Support for SLES12 SP4 will end December 31 2023. From 2024 onward
 SLES12 SP5 is the only supported migration starting point.
@@ -370,7 +370,6 @@ the commands from the Installation Section of this document.
 * Upgrade is only possible for systems that use unencrypted root file systems,
   at the OS level. Encrypting the root device using a cloud framework
   encryption mechanism happens at a different level.
-* Upgrade has been tested for SLES 12 SP4 to SLES 15 SP3
 * Upgrade has been tested for SLES 12 SP5 to SLES 15 SP3
 * The system is primarily intended for Public Cloud instance upgrade use. The
   system also works for simple setups in a data center setting on physical
@@ -396,6 +395,6 @@ the commands from the Installation Section of this document.
   of the SLES version you started with. This cannot be changed.
 * The only supported migration path in the Public Cloud is from the
   final 2 service packs of a distribution to the first service pack of
-  the next distribution. For example from SLES 12 SP4 or SLES 12 SP5 to
-  SLES 15 SP3. The packages delivered by SUSE in the Public Cloud Module
-  implement this behavior by default.
+  the next distribution. For example from SLES 12 SP5 to SLES 15 SP3.
+  The packages delivered by SUSE in the Public Cloud Module implement
+  this behavior by default.

--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -100,7 +100,7 @@ data or processes. For example, DMS will function if /home is its own
 partition, but not if /var is on a separate partition from root.
 
 SLES Version Support::
-Upgrade is supported from SLES12 SP4 or SLES12 SP5 to SLES 15 SP1. It is
+Upgrade is supported from SLES12 SP4 or SLES12 SP5 to SLES 15 SP3. It is
 possible to configure other versions of SLES as the migration target,
 but doing so is not a tested or supported use case.
 
@@ -370,8 +370,8 @@ the commands from the Installation Section of this document.
 * Upgrade is only possible for systems that use unencrypted root file systems,
   at the OS level. Encrypting the root device using a cloud framework
   encryption mechanism happens at a different level.
-* Upgrade has been tested for SLES 12 SP4 to SLES 15 SP1
-* Upgrade has been tested for SLES 12 SP5 to SLES 15 SP1
+* Upgrade has been tested for SLES 12 SP4 to SLES 15 SP3
+* Upgrade has been tested for SLES 12 SP5 to SLES 15 SP3
 * The system is primarily intended for Public Cloud instance upgrade use. The
   system also works for simple setups in a data center setting on physical
   installations. However, for any more complex configurations the off line
@@ -397,5 +397,5 @@ the commands from the Installation Section of this document.
 * The only supported migration path in the Public Cloud is from the
   final 2 service packs of a distribution to the first service pack of
   the next distribution. For example from SLES 12 SP4 or SLES 12 SP5 to
-  SLES 15 SP1. The packages delivered by SUSE in the Public Cloud Module
+  SLES 15 SP3. The packages delivered by SUSE in the Public Cloud Module
   implement this behavior by default.

--- a/image/pubcloud/sle15/config.kiwi
+++ b/image/pubcloud/sle15/config.kiwi
@@ -23,6 +23,21 @@
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/migration" name="migration" groups="users"/>
     </users>
+    <repository type="rpm-md" >
+        <source path='obsrepositories:/'/>
+    </repository>
+    <repository type="rpm-md">
+	 <source path="obs://SUSE:SLE-15-SP3:Update/standard"/>
+    </repository>
+    <repository type="rpm-md">
+	 <source path="obs://SUSE:SLE-15-SP3:GA/standard"/>
+    </repository>
+    <repository type="rpm-md">
+	 <source path="obs://SUSE:SLE-15-SP2:Update/standard"/>
+    </repository>
+    <repository type="rpm-md">
+	 <source path="obs://SUSE:SLE-15-SP2:GA/standard"/>
+    </repository>
     <repository type="rpm-md">
         <source path="obs://SUSE:SLE-15-SP1:Update/standard"/>
     </repository>

--- a/image/pubcloud/sle15/config.kiwi
+++ b/image/pubcloud/sle15/config.kiwi
@@ -6,7 +6,7 @@
         <contact>public-cloud-dev@susecloud.net</contact>
         <specification>
             SLES15 Distribution Migration Live System to upgrade
-            SLES12-SP4+ instances to SLES15+
+            SLES12-SP5+ instances to SLES15+
         </specification>
     </description>
     <preferences>

--- a/test/data/custom-migration-config.yml
+++ b/test/data/custom-migration-config.yml
@@ -1,2 +1,2 @@
 debug: true
-migration_product: 'SLES/15.1/x86_64'
+migration_product: 'SLES/15.3/x86_64'

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -23,19 +23,19 @@ class TestDefaults(object):
             ]
         )
         os_release_result = os_release_tuple(
-            name='SLES', version='15-SP1', version_id='15.1',
-            pretty_name='SUSE Linux Enterprise Server 15 SP1',
+            name='SLES', version='15-SP3', version_id='15.3',
+            pretty_name='SUSE Linux Enterprise Server 15 SP3',
             id='sles', id_like='suse', ansi_color='0;32',
-            cpe_name='cpe:/o:suse:sles:15:sp1'
+            cpe_name='cpe:/o:suse:sles:15:sp3'
         )
         os_release_content = ('NAME="SLES"\n'
-                              'VERSION="15-SP1"\n'
-                              'VERSION_ID="15.1"\n'
-                              'PRETTY_NAME="SUSE Linux Enterprise Server 15 SP1"\n'
+                              'VERSION="15-SP3"\n'
+                              'VERSION_ID="15.3"\n'
+                              'PRETTY_NAME="SUSE Linux Enterprise Server 15 SP3"\n'
                               'ID="sles"\n'
                               'ID_LIKE="suse"\n'
                               'ANSI_COLOR="0;32"\n'
-                              'CPE_NAME="cpe:/o:suse:sles:15:sp1"')
+                              'CPE_NAME="cpe:/o:suse:sles:15:sp3"')
         with patch('builtins.open', create=True) as mock_open:
             mock_open_os_release = MagicMock(spec=io.IOBase)
 

--- a/test/unit/migration_config_test.py
+++ b/test/unit/migration_config_test.py
@@ -39,14 +39,14 @@ class TestMigrationConfig(object):
             ]
         )
         os_release_result = os_release_tuple(
-            name='SLES', version='15-SP1', version_id='15.1',
-            pretty_name='SUSE Linux Enterprise Server 15 SP1',
+            name='SLES', version='15-SP3', version_id='15.3',
+            pretty_name='SUSE Linux Enterprise Server 15 SP3',
             id='sles', id_like='suse', ansi_color='0;32',
-            cpe_name='cpe:/o:suse:sles:15:sp1'
+            cpe_name='cpe:/o:suse:sles:15:sp3'
         )
         mock_get_system_root_path.return_value = '../data'
         mock_get_os_release.return_value = os_release_result
-        assert self.config.get_migration_product() == 'SLES/15.1/x86_64'
+        assert self.config.get_migration_product() == 'SLES/15.3/x86_64'
 
     @patch.object(Defaults, 'get_os_release')
     @patch.object(SUSEBaseProduct, 'get_tag')
@@ -62,10 +62,10 @@ class TestMigrationConfig(object):
             ]
         )
         os_release_result = os_release_tuple(
-            name='SLES', version='15-SP1', version_id='15.1',
-            pretty_name='SUSE Linux Enterprise Server 15 SP1',
+            name='SLES', version='15-SP3', version_id='15.3',
+            pretty_name='SUSE Linux Enterprise Server 15 SP3',
             id='sles', id_like='suse', ansi_color='0;32',
-            cpe_name='cpe:/o:suse:sles:15:sp1'
+            cpe_name='cpe:/o:suse:sles:15:sp3'
         )
         mock_get_system_root_path.return_value = '../data'
         mock_get_os_release.return_value = os_release_result
@@ -91,16 +91,16 @@ class TestMigrationConfig(object):
             ]
         )
         os_release_result = os_release_tuple(
-            name='SLES', version='15-SP1', version_id='15.1',
-            pretty_name='SUSE Linux Enterprise Server 15 SP1',
+            name='SLES', version='15-SP3', version_id='15.3',
+            pretty_name='SUSE Linux Enterprise Server 15 SP3',
             id='sles', id_like='suse', ansi_color='0;32',
-            cpe_name='cpe:/o:suse:sles:15:sp1'
+            cpe_name='cpe:/o:suse:sles:15:sp3'
         )
         mock_get_os_release.return_value = os_release_result
         mock_get_system_root_path.return_value = '../data'
         mock_get_product_name.return_value = None
         self.config.update_migration_config_file()
-        assert self.config.get_migration_product() == 'SLES/15.1/x86_64'
+        assert self.config.get_migration_product() == 'SLES/15.3/x86_64'
         assert self.config.is_debug_requested() is True
 
     def test_is_zypper_migration_plugin_requested(self):


### PR DESCRIPTION
Update documentation to reflect new default target.

Update image build config.kiwi to build the ISO image based upon SLE 15 SP3.

Update unit tests to reflect new default target.