### PR TITLE
Fixed reading of extra config file

### DIFF
--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -47,6 +47,12 @@ def main():
     try:
         log.info('Running migrate service')
         migration_config = MigrationConfig()
+        migration_config.update_migration_config_file()
+        log.info(
+            'Config file content:\n{content}\n'. format(
+                content=migration_config.get_migration_config_file_content()
+            )
+        )
         if migration_config.get_preserve_info():
             # set potential missing settings in env
             log.info('Update env variables')

--- a/suse_migration_services/units/reboot.py
+++ b/suse_migration_services/units/reboot.py
@@ -45,11 +45,11 @@ def main():
     Logger.setup()
     log = logging.getLogger(Defaults.get_migration_log_name())
     try:
+        migration_config = MigrationConfig()
+        migration_config.update_migration_config_file()
         log.info(
-            'Systemctl Status Information: {0}{1}'.format(
-                os.linesep, Command.run(
-                    ['systemctl', 'status', '-l', '--all'], raise_on_error=False
-                ).output
+            'Config file content:\n{content}\n'. format(
+                content=migration_config.get_migration_config_file_content()
             )
         )
         # stop console dialog log. The service holds a busy state
@@ -59,7 +59,7 @@ def main():
             ['systemctl', 'stop', 'suse-migration-console-log'],
             raise_on_error=False
         )
-        if MigrationConfig().is_debug_requested():
+        if migration_config.is_debug_requested():
             log.info('Reboot skipped due to debug flag set')
         else:
             log.info('Umounting system')
@@ -76,7 +76,7 @@ def main():
                         )
                     )
                 )
-            if not MigrationConfig().is_soft_reboot_requested():
+            if not migration_config.is_soft_reboot_requested():
                 restart_system = 'reboot'
             else:
                 restart_system = 'kexec'


### PR DESCRIPTION
The MigrationConfig() was read in only once in the mount service. However in a more flexible workflow that does not require a  mount service, the config file information would be missing. Also in case of an error in the mount service the data of the extra config file is not transported into other services that drives the cleanup.

For a more robust availability of the config information this patch adds the reading to all services that consumes it. In addition the change also prevents writing an 'all' status from systemd to the log file. This information is not relevant as the log contains information about the service runs. The data also floods the log with a lot of useless information and makes debugging more complicated