### PR TITLE
Add package sources for suse-migration-rpm

### DIFF
--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -14,7 +14,7 @@ else
     ) ${CLASS}"
 fi
 
-migration_iso=$(echo /usr/share/migration-image/*-Migration.*.iso)
+migration_iso=$(echo /migration-image/*-Migration.*.iso)
 
 root_device=$(
     lsblk -p -n -r -o NAME,MOUNTPOINT | grep -E "/$" | uniq | cut -f1 -d" "
@@ -74,6 +74,7 @@ if grub_file_is_not_garbage "${migration_iso}"; then
             "/@/boot/grub2/x86_64-efi"
         printf "    insmod loopback\n"
     fi
+    printf "    insmod lvm\n"
     printf "    insmod %s\n" "${image_fs_type}"
     printf "    search --no-floppy --fs-uuid --set=root %s\n" "${image_fs_uuid}"
     printf "    set isofile='%s'\n" \

--- a/image/package/suse-migration-rpm.changes
+++ b/image/package/suse-migration-rpm.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Wed Oct 30 13:21:08 UTC 2024 - Marcus Schäfer <marcus.schaefer@gmail.com>
+
+- Install migration live image to /migration-image
+
+  This change helps to run migrations on systems which stores
+  /usr/share in a special way, e.g. as LVM volume or other
+  type that cannot be read via the loopback grub or kexec
+  method
+
+-------------------------------------------------------------------
 Thu Nov 14 10:11:04 UTC 2019 - Marcus Schaefer <ms@suse.com>
 
 - Reference commit for SUSE maintenance

--- a/image/package/suse-migration-rpm.changes
+++ b/image/package/suse-migration-rpm.changes
@@ -1,0 +1,57 @@
+-------------------------------------------------------------------
+Thu Nov 14 10:11:04 UTC 2019 - Marcus Schaefer <ms@suse.com>
+
+- Reference commit for SUSE maintenance
+  
+  This submission creates a reference to bsc#1155192
+
+-------------------------------------------------------------------
+Mon Nov 11 14:29:56 UTC 2019 - Marcus Schaefer <ms@suse.com>
+
+- Add product version requirement to spec file
+  For further details see: https://github.com/SUSE/suse-migration-services/pull/143
+
+-------------------------------------------------------------------
+Tue Aug 20 12:01:26 UTC 2019 - Jesús Bermúdez Velázquez <jesusbv@suse.com>
+
+- Reference commit for SUSE maintenance
+  Fix BYOS upgrade from 12SP4-SAP to 15 (BSC#1142108) 
+
+-------------------------------------------------------------------
+Wed Aug 14 11:47:24 UTC 2019 - Jesús Bermúdez Velázquez <jesusbv@suse.com>
+
+- This submission creates a reference to bsc#1142108
+ 
+-------------------------------------------------------------------
+Wed Jul 17 09:46:13 UTC 2019 - ms@suse.com
+
+- Install run_migration from suse-migration-services package
+  that is now a build requirement. For details see:
+  https://github.com/SUSE/suse-migration-services/issues/108
+
+-------------------------------------------------------------------
+Thu May  2 13:24:04 UTC 2019 - ms@suse.com
+
+- Reference commit for SUSE maintenance
+
+  This submission creates a reference to fate#327175 and bsc#1133919
+
+-------------------------------------------------------------------
+Mon Mar  4 12:53:44 UTC 2019 - ms@suse.com
+
+- Install SLES15-Migration live image to /usr/share/migration-image
+  See https://github.com/SUSE/suse-migration-services/issues/54
+  for details 
+
+-------------------------------------------------------------------
+Fri Jan 25 10:08:59 UTC 2019 - ms@suse.com
+
+- Install SLES15-Migration live image to /boot
+
+-------------------------------------------------------------------
+Wed Nov 14 15:32:25 UTC 2018 - ms@suse.com
+
+- Post Processing package for SLES15-Migration live image.
+  This package provides metadata used at the end of an
+  appliance build to package the image results into a
+  package

--- a/image/package/suse-migration-rpm.spec
+++ b/image/package/suse-migration-rpm.spec
@@ -1,0 +1,50 @@
+#
+# spec file for package suse-migration-rpm
+#
+# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+
+Name:           suse-migration-rpm
+Version:        1.0.1
+Release:        0
+Summary:        Migration enablement package
+License:        GPL-3.0-or-later
+Group:          System/Management
+Url:            https://github.com/SUSE/suse-migration-services
+Source:         %{name}.tar.gz
+BuildRequires:  filesystem
+Requires:       suse-migration-services
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+
+%description
+OBS kiwi_post_run hook to wrap the kiwi-produced Migration live
+ISO image in an rpm package.
+
+%prep
+%setup -q -n %{name}
+
+%build
+
+%install
+mkdir -p %{buildroot}/usr/lib/build/
+install -m 644 image.spec.in %{buildroot}/usr/lib/build/
+install -m 755 kiwi_post_run %{buildroot}/usr/lib/build/
+
+%files
+%defattr(-,root,root)
+/usr/lib/build/kiwi_post_run
+/usr/lib/build/image.spec.in
+
+%changelog

--- a/image/package/suse-migration-rpm/image.spec.in
+++ b/image/package/suse-migration-rpm/image.spec.in
@@ -22,9 +22,9 @@ This package contains the Migration Live System.
 %build
 
 %install
-install -d -m 755 $RPM_BUILD_ROOT/usr/share/migration-image
+install -d -m 755 $RPM_BUILD_ROOT/migration-image
 install -d -m 755 $RPM_BUILD_ROOT/%{_sbindir}
-cp %{SOURCE0} $RPM_BUILD_ROOT/usr/share/migration-image
+cp %{SOURCE0} $RPM_BUILD_ROOT/migration-image
 cp %{_sbindir}/run_migration $RPM_BUILD_ROOT/%{_sbindir}
 
 %post
@@ -35,7 +35,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-, root, root)
-/usr/share/migration-image
+/migration-image
 %{_sbindir}/run_migration
 
 %changelog

--- a/image/package/suse-migration-rpm/image.spec.in
+++ b/image/package/suse-migration-rpm/image.spec.in
@@ -1,0 +1,41 @@
+# needsrootforbuild
+
+%global MinSLEVersion 12.3
+
+Url:            http://www.suse.com/
+Name:           __NAME__
+Summary:        Migration Live System
+Version:        __VERSION__
+Release:        __RELEASE__
+Group:          System/Management
+License:        SUSE-EULA
+Source0:        __SOURCE__
+Requires:       product(SLES) >= %{MinSLEVersion}
+Requires:       suse-migration-pre-checks
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+
+%description
+This package contains the Migration Live System.
+
+%prep
+
+%build
+
+%install
+install -d -m 755 $RPM_BUILD_ROOT/usr/share/migration-image
+install -d -m 755 $RPM_BUILD_ROOT/%{_sbindir}
+cp %{SOURCE0} $RPM_BUILD_ROOT/usr/share/migration-image
+cp %{_sbindir}/run_migration $RPM_BUILD_ROOT/%{_sbindir}
+
+%post
+/usr/bin/suse-migration-pre-checks
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-, root, root)
+/usr/share/migration-image
+%{_sbindir}/run_migration
+
+%changelog

--- a/image/package/suse-migration-rpm/kiwi_post_run
+++ b/image/package/suse-migration-rpm/kiwi_post_run
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+set -u
+
+: ${TOPDIR:=/usr/src/packages}
+
+IMAGE_DIR=$TOPDIR/KIWI
+BUILD_DIR=/usr/lib/build
+
+cd $IMAGE_DIR
+
+ARCH=$(rpm --eval '%{_arch}')
+IMAGE=$(echo *.iso)
+NAME=$(echo $IMAGE | cut -f1 -d.)
+VERSION=$(echo $IMAGE | cut -f3 -d-)
+RELEASE=$(echo $IMAGE | cut -f4 -d- | sed -e "s@Build@@" | cut -f1 -d.)
+
+if [ -z "$IMAGE" ]; then
+    echo "Couldn't find anything in $IMAGE_DIR matching *.iso"
+    echo "Will skip containment rpm wrapping steps."
+    exit 0
+fi
+
+echo "Attempting to wrap $IMAGE in a containment rpm ..."
+
+echo "name $NAME"
+echo "version $VERSION"
+echo "release $RELEASE"
+
+sed -e "s/__NAME__/$NAME/g" \
+    -e "s/__VERSION__/$VERSION/g" \
+    -e "s/__RELEASE__/$RELEASE/g" \
+    -e "s/__SOURCE__/$IMAGE/g" \
+    < $BUILD_DIR/image.spec.in \
+    > $BUILD_DIR/image.spec
+
+# Local builds have the file already in place, that's not true on IBS
+if [ ! -f $TOPDIR/SOURCES/$IMAGE ]; then
+  ln $IMAGE $TOPDIR/SOURCES
+fi
+
+# Make sure /usr/src/packages/* dirs exist
+if [ ! -f $TOPDIR/BUILD ]; then
+  echo "Create BUILD dir"
+  mkdir -p $TOPDIR/BUILD
+fi
+
+if [ ! -f $TOPDIR/SRPMS ]; then
+  echo "Create SRPMS dir"
+  mkdir -p $TOPDIR/SRPMS
+fi
+
+if [ ! -f $TOPDIR/RPMS/$ARCH ]; then
+  echo "Create SRPMS dir"
+  mkdir -p $TOPDIR/RPMS/$ARCH
+fi
+
+rpmbuild -ba $BUILD_DIR/image.spec
+
+# required for the BS to find the rpm, because it is
+# a "non-standard result file for KIWI"
+mkdir -p $TOPDIR/OTHER
+mv $TOPDIR/RPMS/$ARCH/$NAME-$VERSION-$RELEASE.$ARCH.rpm $TOPDIR/OTHER/

--- a/tools/run_migration
+++ b/tools/run_migration
@@ -39,7 +39,7 @@ function get_migration_image {
     # """
     # Search for migration ISO file
     # """
-    echo /usr/share/migration-image/*-Migration.*.iso
+    echo /migration-image/*-Migration.*.iso
 }
 
 function get_system_root_device {


### PR DESCRIPTION
The suse-migration-rpm package contains an OBS hook script which turns the migration live ISO image into a package named according to the name of the image name attribute. In our case: SLES15-Migration. The sources of this package was not maintained in any git repository but are tightly coupled to the live image build which resides here. Thus and to complete the source gap we have for the DMS this commit adds the sources for the meta package here