### PR TITLE
Install migration live image to /migration-image

### DIFF
--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -14,7 +14,7 @@ else
     ) ${CLASS}"
 fi
 
-migration_iso=$(echo /usr/share/migration-image/*-Migration.*.iso)
+migration_iso=$(echo /migration-image/*-Migration.*.iso)
 
 root_device=$(
     lsblk -p -n -r -o NAME,MOUNTPOINT | grep -E "/$" | uniq | cut -f1 -d" "

--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -74,6 +74,7 @@ if grub_file_is_not_garbage "${migration_iso}"; then
             "/@/boot/grub2/x86_64-efi"
         printf "    insmod loopback\n"
     fi
+    printf "    insmod lvm\n"
     printf "    insmod %s\n" "${image_fs_type}"
     printf "    search --no-floppy --fs-uuid --set=root %s\n" "${image_fs_uuid}"
     printf "    set isofile='%s'\n" \

--- a/image/package/suse-migration-rpm.changes
+++ b/image/package/suse-migration-rpm.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Wed Oct 30 13:21:08 UTC 2024 - Marcus Schäfer <marcus.schaefer@gmail.com>
+
+- Install migration live image to /migration-image
+
+  This change helps to run migrations on systems which stores
+  /usr/share in a special way, e.g. as LVM volume or other
+  type that cannot be read via the loopback grub or kexec
+  method
+
+-------------------------------------------------------------------
 Thu Nov 14 10:11:04 UTC 2019 - Marcus Schaefer <ms@suse.com>
 
 - Reference commit for SUSE maintenance

--- a/image/package/suse-migration-rpm/image.spec.in
+++ b/image/package/suse-migration-rpm/image.spec.in
@@ -22,9 +22,9 @@ This package contains the Migration Live System.
 %build
 
 %install
-install -d -m 755 $RPM_BUILD_ROOT/usr/share/migration-image
+install -d -m 755 $RPM_BUILD_ROOT/migration-image
 install -d -m 755 $RPM_BUILD_ROOT/%{_sbindir}
-cp %{SOURCE0} $RPM_BUILD_ROOT/usr/share/migration-image
+cp %{SOURCE0} $RPM_BUILD_ROOT/migration-image
 cp %{_sbindir}/run_migration $RPM_BUILD_ROOT/%{_sbindir}
 
 %post
@@ -35,7 +35,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-, root, root)
-/usr/share/migration-image
+/migration-image
 %{_sbindir}/run_migration
 
 %changelog

--- a/tools/run_migration
+++ b/tools/run_migration
@@ -39,7 +39,7 @@ function get_migration_image {
     # """
     # Search for migration ISO file
     # """
-    echo /usr/share/migration-image/*-Migration.*.iso
+    echo /migration-image/*-Migration.*.iso
 }
 
 function get_system_root_device {


### PR DESCRIPTION
This change helps to run migrations on systems which stores /usr/share in a special way, e.g. as LVM volume or other type that cannot be read via the loopback grub or kexec method. This Fixes #277