### PR TITLE
Increase version for SLES15-Migration package

### DIFF
--- a/image/pubcloud/sle15/config.kiwi
+++ b/image/pubcloud/sle15/config.kiwi
@@ -11,7 +11,7 @@
     </description>
     <preferences>
         <type image="iso" primary="true" flags="overlay" firmware="efi" boottimeout="1"/>
-        <version>2.1.1</version>
+        <version>2.1.2</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_US</locale>
         <keytable>us</keytable>

--- a/package/suse-migration-sle15-activation-spec-template
+++ b/package/suse-migration-sle15-activation-spec-template
@@ -28,7 +28,7 @@ BuildRoot:        %{_tmppath}/%{name}-%{version}-build
 BuildArch:        noarch
 Conflicts:        suse-migration-services
 BuildRequires:    grub2
-Requires:         SLES15-Migration
+Requires:         SLES15-Migration >= 2.1.2
 
 Requires:         grub2
 Requires:         product(SLES) >= %{MinSLEVersion}


### PR DESCRIPTION
The version of the SLES15-Migration package is taken from the kiwi image description. Thus the bump of the version has happened in this file. In addition a proper version constraint to the suse-migration-sle15-activation package was added due to the latest change from commit 1dbb055bc6b97c3394d36039e7e8608bd1d7f61a which now installs the migration live ISO from the SLES15-Migration package to /migration-image and no longer to /usr/share/migration-image