### PR TITLE
Add option to create a solver test case

### DIFF
--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -3,13 +3,13 @@
 [#art-suse-migration-services]
 
 = Using the SUSE Distribution Migration System
-Marcus Schäfer; Jesús Velázquez; Keith Berger
+Marcus Schäfer; Jesús Velázquez; Keith Berger; Robert Schweikert
 
 :toc:
 :icons: font
 :numbered:
 
-:Authors: Marcus Schäfer, Jesús Bermúdez Velázquez, Keith Berger
+:Authors: Marcus Schäfer, Jesús Bermúdez Velázquez, Keith Berger, Robert Schweikert
 :Latest_Version: 1.2.0
 :Contributors:
 :Repo: https://github.com/SUSE/suse-migration-services[suse-migration-services]
@@ -312,7 +312,8 @@ verbose_migration: true|false
 
 Enable the fix option for pre_checks::
 If enabled (default), the run_pre_checks systemd process will use the `--fix`
-option to automatically remediate applicable issues before the migration is started. 
+option to automatically remediate applicable issues before the migration
+is started. 
 +
 [listing]
 ----
@@ -330,6 +331,18 @@ independent initrd can be created by setting
 [listing]
 ----
 build_host_independent_initrd: true|false
+----
+
+Configure Dependency Solver Test Case Generation::
+It is possible that during the migration packages get installed that were not
+on the system previously and are pulled in because of dependencies. This
+setting will setup the migration such that a solver test case is generated.
+The information form the test case can then be used to understand why a
+given package was installed.
++
+[listing]
+----
+debug_solver: true|false
 ----
 
 == Run the Migration

--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -125,3 +125,7 @@ class Defaults:
     @staticmethod
     def get_zypp_config_path():
         return '/etc/zypp/zypp.conf'
+
+    @staticmethod
+    def get_zypp_gen_solver_test_case():
+        return ''

--- a/suse_migration_services/migration_config.py
+++ b/suse_migration_services/migration_config.py
@@ -148,6 +148,9 @@ class MigrationConfig:
     def is_verbosity_requested(self):
         return self.config_data.get('verbose_migration', False)
 
+    def is_zypp_solver_test_case_requested(self):
+        return self.config_data.get('debug_solver', False)
+
     def _write_config_file(self):
         with open(self.migration_config_file, 'w') as config:
             yaml.dump(self.config_data, config, default_flow_style=False)

--- a/suse_migration_services/schema.py
+++ b/suse_migration_services/schema.py
@@ -42,5 +42,9 @@ schema = {
     'pre_checks_fix': {
         'required': False,
         'type': 'boolean'
+    },
+    'debug_solver': {
+        'required': False,
+        'type': 'boolean'
     }
 }

--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -59,12 +59,18 @@ def main():
             log.info('Update env variables')
             update_env(migration_config.get_preserve_info())
             log_env(log)
-        verbose_migration = '--verbose' if migration_config.is_verbosity_requested() else '--no-verbose'
+        verbose_migration = '--no-verbose'
+        if migration_config.is_verbosity_requested():
+            verbose_migration = '--verbose'
+        solver_case = Defaults.get_zypp_gen_solver_test_case()
+        if migration_config.is_zypp_solver_test_case_requested():
+            solver_case = '--debug-solver'
         if migration_config.is_zypper_migration_plugin_requested():
             bash_command = ' '.join(
                 [
                     'zypper', 'migration',
                     verbose_migration,
+                    solver_case,
                     '--non-interactive',
                     '--gpg-auto-import-keys',
                     '--no-selfupdate',

--- a/test/data/migration-config-solver-case.yml
+++ b/test/data/migration-config-solver-case.yml
@@ -1,0 +1,7 @@
+debug_solver: true
+preserve:
+  rules:
+     - /etc/udev/rules.d/a.rules
+     - /etc/udev/rules.d/b.rules
+  static:
+    - /etc/sysconfig/proxy

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -24,6 +24,9 @@ class TestMigration(object):
         mock_get_migration_config_file.return_value = \
             '../data/migration-config-zypper-dup.yml'
         self.migration_config_dup = MigrationConfig()
+        mock_get_migration_config_file.return_value = \
+            '../data/migration-config-solver-case.yml'
+        self.migration_config_solver_case = MigrationConfig()
 
     @patch.object(Defaults, 'get_migration_config_file')
     def setup_method(self, cls, mock_get_migration_config_file):
@@ -142,6 +145,7 @@ class TestMigration(object):
                 'bash', '-c',
                 'zypper migration '
                 '--no-verbose '
+                ' '
                 '--non-interactive '
                 '--gpg-auto-import-keys '
                 '--no-selfupdate '
@@ -174,6 +178,40 @@ class TestMigration(object):
                 'bash', '-c',
                 'zypper migration '
                 '--verbose '
+                ' '
+                '--non-interactive '
+                '--gpg-auto-import-keys '
+                '--no-selfupdate '
+                '--auto-agree-with-licenses '
+                '--allow-vendor-change '
+                '--strict-errors-dist-migration '
+                '--replacefiles '
+                '--product SLES/15/x86_64 '
+                '--root /system-root '
+                '&>> /system-root/var/log/distro_migration.log'
+            ]
+        )
+
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.command.Command.run')
+    @patch('suse_migration_services.units.migrate.log_env')
+    @patch('suse_migration_services.units.migrate.update_env')
+    @patch.object(MigrationConfig, 'get_migration_product')
+    @patch('suse_migration_services.units.migrate.MigrationConfig')
+    def test_main_zypper_migration_plugin_solver_case(
+        self, mock_MigrationConfig, mock_get_system_root_path,
+        mock_update_env, mock_log_env, mock_Command_run, mock_logger_setup
+    ):
+        mock_MigrationConfig.return_value = self.migration_config_solver_case
+        mock_get_system_root_path.return_value = 'SLES/15/x86_64'
+        with patch('builtins.open', create=True):
+            main()
+        mock_Command_run.assert_called_once_with(
+            [
+                'bash', '-c',
+                'zypper migration '
+                '--no-verbose '
+                '--debug-solver '
                 '--non-interactive '
                 '--gpg-auto-import-keys '
                 '--no-selfupdate '


### PR DESCRIPTION
During the migration we may run into a situation where a package shows up on the migrated system and we need to understand why this happened. Creating a solver test case allows us to debug such issues.