### PR TITLE
ensure /run is available in chroot

### DIFF
--- a/suse_migration_services/units/mount_system.py
+++ b/suse_migration_services/units/mount_system.py
@@ -179,6 +179,10 @@ def mount_system(root_path, fstab):
             system_mount.add_entry(
                 mount_type, mount_point
             )
+        log.info('Bind mount /run inside chroot {0}'.format(root_path))
+        Command.run(
+            ['mount', '-o', 'bind','/run', os.sep.join([root_path,'run'])]
+        )
     except Exception as issue:
         log.error(
             'Mounting system for upgrade failed with {0}'.format(issue)


### PR DESCRIPTION
Some symlinks on migrated host can point to temporary files in /run (for instance /etc/resolv.conf, by default on SLE15, points to /run/netconfig/resolv.conf). 

We must ensure /run is available when running chrooted application on migrated host.