### PR TITLE
use requisite for systemd units

### DIFF
--- a/systemd/suse-migration-grub-setup.service
+++ b/systemd/suse-migration-grub-setup.service
@@ -1,10 +1,12 @@
 [Unit]
 Description=Recreate grub configuration file from migrated version
 After=suse-migration.service
+Requisite=suse-migration.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/suse-migration-grub-setup
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/suse-migration-kernel-load.service
+++ b/systemd/suse-migration-kernel-load.service
@@ -1,10 +1,12 @@
 [Unit]
 Description=Load the migrated system kernel/initrd
 After=suse-migration-regenerate-initrd.service
+Requisite=suse-migration.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/suse-migration-kernel-load
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/suse-migration-mount-system.service
+++ b/systemd/suse-migration-mount-system.service
@@ -4,6 +4,7 @@ Description=Mount System To Upgrade
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/suse-migration-mount-system
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/suse-migration-post-mount-system.service
+++ b/systemd/suse-migration-post-mount-system.service
@@ -1,11 +1,12 @@
 [Unit]
 Description=Preserve Data After System Mount
 After=suse-migration-mount-system.service
-Requires=suse-migration-mount-system.service
+Requisite=suse-migration-mount-system.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/suse-migration-post-mount-system
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/suse-migration-pre-checks.service
+++ b/systemd/suse-migration-pre-checks.service
@@ -1,12 +1,13 @@
 [Unit]
 Description=Run suse-migration-pre-checks before starting the migration
 After=suse-migration-mount-system.service suse-migration-ssh-keys.service
-Requires=suse-migration-mount-system.service suse-migration-ssh-keys.service
+Requisite=suse-migration-mount-system.service suse-migration-ssh-keys.service
 
 [Service]
 Type=oneshot
 Environment="SUSE_MIGRATION_PRE_CHECKS_MODE=migration_system_iso_image"
 ExecStart=/usr/bin/suse-migration-pre-checks --fix
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/suse-migration-prepare.service
+++ b/systemd/suse-migration-prepare.service
@@ -1,12 +1,14 @@
 [Unit]
 Description=Prepare For Migration
-After=suse-migration-setup-host-network.service
-Requires=suse-migration-mount-system.service suse-migration-setup-host-network.service network-online.target
+After=suse-migration-setup-host-network.service network-online.target
+Requisite=suse-migration-mount-system.service suse-migration-setup-host-network.service
+Requires=network-online.target
 
 [Service]
 Type=oneshot
 EnvironmentFile=-/etc/sysconfig/proxy
 ExecStart=/usr/bin/suse-migration-prepare
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/suse-migration-product-setup.service
+++ b/systemd/suse-migration-product-setup.service
@@ -6,6 +6,7 @@ Requires=suse-migration-prepare.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/suse-migration-product-setup
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/suse-migration-regenerate-initrd.service
+++ b/systemd/suse-migration-regenerate-initrd.service
@@ -1,10 +1,12 @@
 [Unit]
 Description=Regenerate the initrd to add multipath
 After=suse-migration-grub-setup.service
+Requisite=suse-migration-grub-setup.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/suse-migration-regenerate-initrd
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/suse-migration-setup-host-network.service
+++ b/systemd/suse-migration-setup-host-network.service
@@ -7,6 +7,7 @@ After=network.target
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/suse-migration-setup-host-network
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/suse-migration-ssh-keys.service
+++ b/systemd/suse-migration-ssh-keys.service
@@ -6,6 +6,7 @@ Requires=suse-migration-mount-system.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/suse-migration-ssh-keys
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/suse-migration-update-bootloader.service
+++ b/systemd/suse-migration-update-bootloader.service
@@ -1,10 +1,12 @@
 [Unit]
 Description=Update the bootloader
 After=suse-migration-grub-setup.service
+Requisite=suse-migration-grub-setup.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/suse-migration-update-bootloader
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/suse-migration.service
+++ b/systemd/suse-migration.service
@@ -1,11 +1,12 @@
 [Unit]
 Description=Run Zypper Migration
 After=suse-migration-product-setup.service
-Requires=suse-migration-product-setup.service
+Requisite=suse-migration-product-setup.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/suse-migration
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
ensure some migration tasks are only executed if previous one were succesfull