### PR TITLE
Apparmor to selinux

### DIFF
--- a/helper/service.tree
+++ b/helper/service.tree
@@ -3,6 +3,6 @@ suse-migration-mount-system -> [
     suse-migration-pre-checks,
     suse-migration-post-mount-system.service -> suse-migration-setup-host-network -> suse-migration-prepare -> [
         suse-migration-console-log,
-        suse-migration-product-setup -> suse-migration -> suse-migration-grub-setup -> suse-migration-update-bootloader -> suse-migration-regenerate-initrd -> suse-migration-kernel-load -> suse-migration-reboot
+        suse-migration-product-setup -> suse-migration -> suse-migration-apparmor-selinux -> suse-migration-grub-setup -> suse-migration-update-bootloader -> suse-migration-regenerate-initrd -> suse-migration-kernel-load -> suse-migration-reboot
     ]
 ]

--- a/image/generic/sle16/config.sh
+++ b/image/generic/sle16/config.sh
@@ -47,6 +47,7 @@ systemctl enable sshd.service
 # Activate migration services
 #--------------------------------------
 systemctl enable suse-migration-mount-system.service
+systemctl enable suse-migration-apparmor-selinux.service
 systemctl enable suse-migration-post-mount-system.service
 systemctl enable suse-migration-ssh-keys
 systemctl enable suse-migration-pre-checks.service

--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -161,6 +161,9 @@ install -D -m 644 systemd/suse-migration-ssh-keys.service \
 install -D -m 644 systemd/suse-migration-console-log.service \
     %{buildroot}%{_unitdir}/suse-migration-console-log.service
 
+install -D -m 644 systemd/systemd/suse-migration-apparmor-selinux.service \
+    %{buildroot}%{_unitdir}/systemd/suse-migration-apparmor-selinux.service
+
 install -D -m 755 tools/migrate \
     %{buildroot}%{_sbindir}/migrate
 
@@ -173,6 +176,7 @@ install -D -m 755 tools/migrate \
 
 %files
 %{_sbindir}/run_migration
+%{_bindir}/suse-migration-apparmor-selinux
 %{_bindir}/suse-migration-ssh-keys
 %{_bindir}/suse-migration-mount-system
 %{_bindir}/suse-migration-post-mount-system
@@ -197,6 +201,7 @@ install -D -m 755 tools/migrate \
 %{_unitdir}/suse-migration-container-reboot.service
 %{_unitdir}/suse-migration-container-emergency.service
 %{_unitdir}/suse-migration-console-log.service
+%{_unitdir}/suse-migration-apparmor-selinux.service
 %{_unitdir}/suse-migration-grub-setup.service
 %{_unitdir}/suse-migration-update-bootloader.service
 %{_unitdir}/suse-migration-product-setup.service

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ config = {
             'suse-migration-setup-host-network=suse_migration_services.units.setup_host_network:main',
             'suse-migration-prepare=suse_migration_services.units.prepare:main',
             'suse-migration=suse_migration_services.units.migrate:main',
+            'suse-migration-apparmor-selinux=suse_migration_services.units.apparmor_migration:main',
             'suse-migration-grub-setup=suse_migration_services.units.grub_setup:main',
             'suse-migration-update-bootloader=suse_migration_services.units.update_bootloader:main',
             'suse-migration-regenerate-initrd=suse_migration_services.units.regenerate_initrd:main',

--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -129,3 +129,9 @@ class Defaults:
     @staticmethod
     def get_zypp_gen_solver_test_case():
         return ''
+
+    @staticmethod
+    def get_grub_default_file():
+        return os.sep.join(
+                [Defaults.get_system_root_path(), '/etc/default/grub']
+        )

--- a/suse_migration_services/exceptions.py
+++ b/suse_migration_services/exceptions.py
@@ -93,6 +93,10 @@ class DistMigrationGrubConfigException(DistMigrationException):
     Exception raised if the grub update call has failed
     """
 
+class DistMigrationAppArmorMigrationException(DistMigrationException):
+    """
+    Exception raised if AppArmor migration has failed
+    """
 
 class DistMigrationKernelRebootException(DistMigrationException):
     """

--- a/suse_migration_services/units/apparmor_migration.py
+++ b/suse_migration_services/units/apparmor_migration.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2025 SUSE Linux LLC.  All rights reserved.
+#
+# This file is part of suse-migration-services.
+#
+# suse-migration-services is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# suse-migration-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
+#
+import logging
+import os
+import fileinput
+import re
+
+# project
+from suse_migration_services.command import Command
+from suse_migration_services.defaults import Defaults
+from suse_migration_services.logger import Logger
+
+from suse_migration_services.exceptions import (
+    DistMigrationAppArmorMigrationException
+)
+
+
+
+
+def main():
+    """
+    DistMigration migrate from apparmor to SELinux
+
+    Setup grub to use selinux instead of apparmor
+    """
+    Logger.setup()
+    log = logging.getLogger(Defaults.get_migration_log_name())
+    root_path = Defaults.get_system_root_path()
+
+    try:
+        log.info('Running AppArmor to SELinux migration')
+
+        log.info('Replace occurrence of security=apparmor with security=selinux in /etc/default/grub')
+
+        pattern = r"security=apparmor\b"
+        for line in fileinput.input(Defaults.get_grub_default_file(), inplace=True):
+            print(re.sub(pattern, "security=selinux", line), end='')
+    except Exception as issue:
+        message = 'Apparmor to SELinux migration failed with {0}'.format(issue)
+        log.error(message)
+        raise DistMigrationAppArmorMigrationException(message)

--- a/systemd/suse-migration-apparmor-selinux.service
+++ b/systemd/suse-migration-apparmor-selinux.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Migrate from apparmor to selinux
+After=suse-migration.service
+Requisite=suse-migration.service
+Before=suse-migration-grub-setup.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/suse-migration-apparmor-selinux
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
On SLES 16, apparmor is no longer supposed.

If package migration was succesful, change grub default configuration from apparmor to selinux on migrated host, before updating grub.cfg