### PR TITLE
Wicked to NetworkManager migration

### DIFF
--- a/image/generic/sle16/config.sh
+++ b/image/generic/sle16/config.sh
@@ -60,6 +60,7 @@ systemctl enable suse-migration-update-bootloader.service
 systemctl enable suse-migration-product-setup.service
 systemctl enable suse-migration-regenerate-initrd.service
 systemctl enable suse-migration-kernel-load.service
+systemctl enable suse-migration-wicked-networkmanager.service
 systemctl enable suse-migration-reboot.service
 systemctl enable NetworkManager.service
 # needed for network setup migration

--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -170,6 +170,9 @@ install -D -m 644 systemd/suse-migration-console-log.service \
 install -D -m 644 systemd/suse-migration-apparmor-selinux.service \
     %{buildroot}%{_unitdir}/suse-migration-apparmor-selinux.service
 
+install -D -m 644 systemd/suse-migration-wicked-networkmanager.service \
+    %{buildroot}%{_unitdir}/suse-migration-wicked-networkmanager.service
+
 install -D -m 755 tools/migrate \
     %{buildroot}%{_sbindir}/migrate
 
@@ -195,6 +198,7 @@ install -D -m 755 tools/migrate \
 %{_bindir}/suse-migration-regenerate-initrd
 %{_bindir}/suse-migration-kernel-load
 %{_bindir}/suse-migration-reboot
+%{_bindir}/suse-migration-wicked-networkmanager
 %{_unitdir}/suse-migration-ssh-keys.service
 %{_unitdir}/suse-migration-mount-system.service
 %{_unitdir}/suse-migration-post-mount-system.service
@@ -214,6 +218,7 @@ install -D -m 755 tools/migrate \
 %{_unitdir}/suse-migration-regenerate-initrd.service
 %{_unitdir}/suse-migration-kernel-load.service
 %{_unitdir}/suse-migration-reboot.service
+%{_unitdir}/suse-migration-wicked-networkmanager.service
 
 %files -n %{pythons}-migration
 %{python_sitelib}/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ suse-migration-setup-host-network = "suse_migration_services.units.setup_host_ne
 suse-migration-prepare = "suse_migration_services.units.prepare:main"
 suse-migration = "suse_migration_services.units.migrate:main"
 suse-migration-apparmor-selinux= "suse_migration_services.units.apparmor_migration:main"
+suse-migration-wicked-networkmanager = "suse_migration_services.units.wicked_migration:main"
 suse-migration-grub-setup = "suse_migration_services.units.grub_setup:main"
 suse-migration-update-bootloader = "suse_migration_services.units.update_bootloader:main"
 suse-migration-regenerate-initrd = "suse_migration_services.units.regenerate_initrd:main"

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ config = {
             'suse-migration-prepare=suse_migration_services.units.prepare:main',
             'suse-migration=suse_migration_services.units.migrate:main',
             'suse-migration-apparmor-selinux=suse_migration_services.units.apparmor_migration:main',
+            'suse-migration-wicked-networkmanager=suse_migration_services.units.wicked_migration:main',
             'suse-migration-grub-setup=suse_migration_services.units.grub_setup:main',
             'suse-migration-update-bootloader=suse_migration_services.units.update_bootloader:main',
             'suse-migration-regenerate-initrd=suse_migration_services.units.regenerate_initrd:main',

--- a/suse_migration_services/exceptions.py
+++ b/suse_migration_services/exceptions.py
@@ -74,6 +74,11 @@ class DistMigrationHostNetworkException(DistMigrationException):
     failed for the reason reported by either mount or systemctl
     """
 
+class DistMigrationWickedMigrationException(DistMigrationException):
+    """
+    Exception raised if the wicked migration
+    failed for the reason reported by systemctl
+    """
 
 class DistMigrationZypperMetaDataException(DistMigrationException):
     """

--- a/suse_migration_services/units/wicked_migration.py
+++ b/suse_migration_services/units/wicked_migration.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 SUSE Linux LLC.  All rights reserved.
+#
+# This file is part of suse-migration-services.
+#
+# suse-migration-services is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# suse-migration-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
+#
+import logging
+import os
+
+# project
+from suse_migration_services.command import Command
+from suse_migration_services.defaults import Defaults
+from suse_migration_services.logger import Logger
+
+from suse_migration_services.exceptions import (
+    DistMigrationWickedMigrationException
+)
+
+
+
+
+def main():
+    """
+    DistMigration migrate from wicked to NetworkManager
+    """
+    Logger.setup()
+    log = logging.getLogger(Defaults.get_migration_log_name())
+    root_path = Defaults.get_system_root_path()
+
+    try:
+        log.info('Running wicked to NetworkManager migration')
+
+        log.info('Change systemd network.service symlink from wicked.service to NetworkManager')
+
+        Command.run(
+            [
+                'systemctl', '--root', root_path, 'enable',
+                '--force', 'NetworkManager.service'
+            ]
+        )
+
+        log.info('Disable wicked service completely')
+        Command.run(
+            [
+                'systemctl', '--root', root_path, 'mask',
+                'wicked.service'
+            ]
+        )
+
+    except Exception as issue:
+        message = 'wicked to NetworkManager migration failed with {0}'.format(issue)
+        log.error(message)
+        raise DistMigrationWickedMigrationException(message)

--- a/systemd/suse-migration-wicked-networkmanager.service
+++ b/systemd/suse-migration-wicked-networkmanager.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Wicked to NetworkManager migration
+After=suse-migration.service
+Requisite=suse-migration.service
+Before=suse-migration-regenerate-initrd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/suse-migration-wicked-networkmanager
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
On SLES16, wicked is no longer supported.

If packages migration was succesful, wicked systemd service is disabled and NetworkManager systemd service is enabled instead.

There is no configuration migration done here. This will be handled by another team.