### PR TITLE
Fix suse-migration-pre-checks package requires

### DIFF
--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -74,6 +74,7 @@ Group:            System/Management
 Requires:         %{pythons}-migration
 Requires:         %{pythons}-Cerberus
 Requires:         %{pythons}-PyYAML
+Requires:         %{pythons}-setuptools
 Conflicts:        suse-migration-sle15-activation < 2.0.33
 Conflicts:        suse-migration-sle16-activation < 2.0.33
 


### PR DESCRIPTION
We are using the entry point mechanics which requires setuptools for older python versions.