### PR TITLE
Fix and cleanup update_bootloader service

### DIFF
--- a/test/unit/units/update_bootloader_test.py
+++ b/test/unit/units/update_bootloader_test.py
@@ -1,121 +1,45 @@
-""" Tests for update_bootloader"""
-import logging
-
 from unittest.mock import (
     patch, call
 )
-from pytest import (
-    raises, fixture
-)
-from suse_migration_services.units.update_bootloader import (
-    main,
-    install_shim_package,
-    install_secure_bootloader,
-    update_bootloader_config
-)
-from suse_migration_services.exceptions import (
-    DistMigrationCommandException
-)
+from pytest import fixture
+from suse_migration_services.units.update_bootloader import main
 
 
 @patch('suse_migration_services.logger.Logger.setup')
-@patch('os.path.exists')
-class TestUpdateBootloader():
+class TestUpdateBootloader:
     @fixture(autouse=True)
     def inject_fixtures(self, caplog):
-        """Setup capture log"""
         self._caplog = caplog
 
     @patch('suse_migration_services.command.Command.run')
-    def test_install_shim_package_raises(
-        self,
-        mock_Command_run,
-        mock_os_path_exists,
-        mock_logger_setup
-    ):
-        """ Test exception raised when running update_bootloader"""
-
-        mock_Command_run.side_effect = [
-            Exception('error')
-        ]
-        with self._caplog.at_level(logging.ERROR):
-            with raises(DistMigrationCommandException):
-                install_shim_package('/system-root')
-        assert mock_Command_run.call_args_list == [
-            call(
-                [
-                    'chroot',
-                    '/system-root',
-                    'zypper',
-                    'in',
-                    'shim'
-                ]
-            )
-        ]
-
-    @patch('suse_migration_services.command.Command.run')
-    def test_install_secure_bootloader_raises_on_update_bootloader(
-        self,
-        mock_Command_run,
-        mock_os_path_exists,
-        mock_logger_setup
-    ):
-        """ Test exception raised when running dracut_bind_mounts()"""
-        mock_Command_run.side_effect = [
-            Exception('error')
-        ]
-        with self._caplog.at_level(logging.ERROR):
-            with raises(DistMigrationCommandException):
-                install_secure_bootloader('/system-root')
-
-    @patch('suse_migration_services.command.Command.run')
-    def test_update_bootloader_config_raise_on_update_bootloader(
-        self,
-        mock_Command_run,
-        mock_os_path_exists,
-        mock_logger_setup
-    ):
-        """ Test exception raised when running dracut_bind_mounts()"""
-        mock_Command_run.side_effect = [
-            Exception('error')
-        ]
-        with self._caplog.at_level(logging.ERROR):
-            with raises(DistMigrationCommandException):
-                update_bootloader_config('/system-root')
-
-    @patch('suse_migration_services.command.Command.run')
-    def test_main(
-        self,
-        mock_Command_run,
-        mock_os_path_exists,
-        mock_logger_setup
-    ):
-        """ Test running update_bootloader"""
+    def test_main(self, mock_Command_run, mock_logger_setup):
         main()
         assert mock_Command_run.call_args_list == [
             call(
                 [
-                    'chroot',
-                    '/system-root',
-                    'zypper',
-                    'in',
-                    'shim'
+                    'bash', '-c',
+                    'zypper --no-cd --non-interactive --gpg-auto-import-keys '
+                    '--root /system-root '
+                    'in '
+                    '--auto-agree-with-licenses '
+                    '--allow-vendor-change '
+                    '--download in-advance '
+                    '--replacefiles '
+                    '--allow-downgrade '
+                    'shim '
+                    '&>> /system-root/var/log/distro_migration.log'
                 ]
             ),
             call(
                 [
-                    'chroot',
-                    '/system-root',
-                    'shim-install',
-                    '--removable'
+                    'chroot', '/system-root',
+                    'shim-install', '--removable'
                 ]
             ),
             call(
                 [
-                    'chroot',
-                    '/system-root',
-                    '/sbin/update-bootloader',
-                    '--reinit'
+                    'chroot', '/system-root',
+                    '/sbin/update-bootloader', '--reinit'
                 ]
             )
         ]


### PR DESCRIPTION
The service tries to install the shim package by a chroot call into the upgraded system. This is not going to work for several reasons. First and foremost the call is interactive and was missing several zypper options to allow this to be done non-interactive. Second zypper from the DMS host should be called in the same way as it was done during the actual migrate service for consistency and stability reasons. When zypper has worked during the migrate service it's likely to work for subsequent calls too. In addition to the actual zypper call I reduced the code at several stages. There is no need to catch an exception from Command.run to raise the same exception (DistMigrationCommandException) that would be done by Command.run itself. Also the command interface logs the executed command. There is no reason to log the same information again. This reduces the implementation by a number of superfluous code and test code.