### PR TITLE
Add product migration check

### DIFF
--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -118,6 +118,7 @@ These incompatibilities include:
 1. Encrypted file systems
 2. Invalid repository types
 3. multiversion.kernels enabled and multiple kernels installed
+4. Unsupported upgrade path with enabled products
 
 This script is run during the install of SLES15-Migration. It can
 also be run anytime using
@@ -130,21 +131,6 @@ A `-f/--fix` option that will remediate the following issues:
 
 1. Set multiversion.kernels to the correct value and remove all
 old (not currently running) kernels.
-
-Example output from running suse-migration-pre-checks:
-
-[listing]
-----
-Running suse-migration-pre-checks with options: fix: False
-Calling: ['blkid', '-s', 'TYPE', '-o', 'value', '/dev/disk/by-uuid/e35ee7fd-7985-4e86-ae79-32c8077e2006']
-Calling: ['blkid', '-s', 'TYPE', '-o', 'value', '/dev/disk/by-uuid/8da89821-e427-4375-8c9b-f142903e2ff8']
-Calling: ['blkid', '-s', 'TYPE', '-o', 'value', '/dev/disk/cloud/azure_resource-part1']
-Calling: ['blkid', '-s', 'TYPE', '-o', 'value', '/dev/disk/by-uuid/B04E-7E9D']
-The config option 'multiversion' in /etc/zypp/zypp.conf includes the keyword 'kernel.' The current value is set as
-'multiversion = provides:multiversion(kernel)'.
-Checking the config option 'multiversion.kernels' to see if multiple kernels are also enabled
-Calling: ['rpm', '-qa', 'kernel-default']
-----
 
 == Installation
 The distribution migration system is available from the Public Cloud module.

--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -71,6 +71,8 @@ Python based implementation for suse major code stream upgrade system
 %package          -n suse-migration-pre-checks
 Summary:          The pre-checks code used with the python migration module
 Group:            System/Management
+Requires:         %{pythons}-lxml
+Requires:         %{pythons}-requests
 Requires:         %{pythons}-migration
 Requires:         %{pythons}-Cerberus
 Requires:         %{pythons}-PyYAML

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.9"
 PyYAML = ">=5.4.0"
+lxml = "*"
+requests = "*"
 Cerberus = ">=1.3.0"
 
 [tool.poetry.scripts]
@@ -78,6 +80,7 @@ pytest-xdist = "*"
 # type checking
 mypy = ">=0.971"
 types-PyYAML = "*"
+types-requests = "*"
 
 [tool.poetry.group.style]
 [tool.poetry.group.style.dependencies]

--- a/suse_migration_services/prechecks/pre_checks.py
+++ b/suse_migration_services/prechecks/pre_checks.py
@@ -24,9 +24,10 @@ from suse_migration_services.defaults import Defaults
 from suse_migration_services.logger import Logger
 from suse_migration_services.migration_config import MigrationConfig
 
-import suse_migration_services.prechecks.repos as check_repos  # type: ignore
-import suse_migration_services.prechecks.fs as check_fs  # type: ignore
-import suse_migration_services.prechecks.kernels as check_multi_kernels  # type: ignore
+import suse_migration_services.prechecks.repos as check_repos
+import suse_migration_services.prechecks.fs as check_fs
+import suse_migration_services.prechecks.kernels as check_multi_kernels
+import suse_migration_services.prechecks.scc as check_scc
 
 
 def main():
@@ -38,45 +39,77 @@ def main():
       - filesystems in fstab are using LUKS encryption
       - Multiple kernels are installed on the system and multiversion.kernels
         in /etc/zypp/zypp.conf is not set to 'running, latest'
+      - for registered systems, check if migration path exists
+        by sending a request to the SCC migrations API
     """
+    cli_parser = argparse.ArgumentParser(
+        prog='suse-migration-pre-checks',
+        description='Check for existing conditions '
+        'that will cause a migration to fail'
+    )
+
+    cli_parser.add_argument(
+        '-f', '--fix',
+        action='store_true',
+        help='Perform fixes to remediate potential issues that may cause '
+        'the migration to fail. For example, remove extra superseeded '
+        'kernels and set "multiversion.kernels = running,latest". '
+        'Additional details can be found in the Distribution Migration '
+        'System documentation.'
+    )
+
+    args = cli_parser.parse_args()
+
+    if os.geteuid() != 0:
+        logging.error('pre-checks requires root permissions')
+        return
 
     Logger.setup()
     log = logging.getLogger(Defaults.get_migration_log_name())
 
-    cli_parser = argparse.ArgumentParser(
-        prog='suse-migration-pre-checks',
-        description='Check for existing conditions that will cause a migration to fail'
+    log.info(
+        'Running suse-migration-pre-checks with options: fix: {}'.format(
+            args.fix
+        )
     )
-
-    cli_parser.add_argument(
-        '-f',
-        '--fix',
-        action='store_true',
-        help="Perform fixes to remediate potential issues that may cause "
-             "the migration to fail. For example, remove extra superseeded "
-             "kernels and set 'multiversion.kernels = running,latest'. "
-             "Additional details can be found in the Distribution Migration "
-             "System documentation."
-    )
-
-    args = cli_parser.parse_args()
-    log.info('Running suse-migration-pre-checks '
-             'with options: fix: %s',
-             args.fix)
     migration_system_mode = False
     dms_env_var = os.environ.get('SUSE_MIGRATION_PRE_CHECKS_MODE', None)
 
     if dms_env_var == 'migration_system_iso_image':
-        log.info("Using migration_system mode")
+        log.info('Using migration_system mode')
         migration_system_mode = True
 
-    if args.fix and migration_system_mode and not MigrationConfig().is_pre_checks_fix_requested():
-        log.info("The distribution migration system configuration value "
-                 "'pre_checks_fix' is set to 'False'. Overriding the 'fix' "
-                 "option and not applying pre-check fixes during the "
-                 "migration.")
+    pre_checks_fix_requested = MigrationConfig().is_pre_checks_fix_requested()
+    if args.fix and migration_system_mode and not pre_checks_fix_requested:
+        log.info(
+            'The distribution migration system configuration value '
+            '"pre_checks_fix" is set to: False. Overriding the --fix '
+            'option and not applying pre-check fixes during the migration.'
+        )
         args.fix = False
 
-    check_repos.remote_repos(migration_system=migration_system_mode)
-    check_fs.encryption(migration_system=migration_system_mode)
-    check_multi_kernels.multiversion_and_multiple_kernels(fix=args.fix, migration_system=migration_system_mode)
+    log.info('Checking harmful migration conditions')
+
+    log.info('--> Checking for local private repos...')
+    check_repos.remote_repos(
+        migration_system=migration_system_mode
+    )
+    log.info('Done')
+
+    log.info('--> Checking for encrypted rootfs...')
+    check_fs.encryption(
+        migration_system=migration_system_mode
+    )
+    log.info('Done')
+
+    log.info('--> Checking for latest kernel in multiversion kernel system...')
+    check_multi_kernels.multiversion_and_multiple_kernels(
+        fix=args.fix, migration_system=migration_system_mode
+    )
+    log.info('Done')
+
+    log.info('--> Checking upgrade path against registration server...')
+    check_scc.migration(
+        migration_system=migration_system_mode
+    )
+    log.info('Done')

--- a/suse_migration_services/prechecks/scc.py
+++ b/suse_migration_services/prechecks/scc.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2025 SUSE LLC.  All rights reserved.
+#
+# This file is part of suse-migration-services.
+#
+# suse-migration-services is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# suse-migration-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>#
+from lxml import etree
+import platform
+import requests
+import yaml
+import logging
+import os
+import glob
+
+from suse_migration_services.command import Command
+from suse_migration_services.defaults import Defaults
+
+log = logging.getLogger(Defaults.get_migration_log_name())
+
+
+def migration(migration_system=False):
+    """
+    Send API call to ask the registration server for an upgrade path
+    and report any error this request might come back with
+    """
+    if migration_system:
+        # This check must not be called inside of the
+        # migration system live iso or container image.
+        # It will only be useful on the system to migrate
+        # at install time of the Migration package or on
+        # manual user invocation of suse-migration-pre-checks
+        # prior the actual migration.
+        return
+
+    installed_products = get_installed_products()
+    installed_products['target_base_product'] = get_migration_target()
+
+    if installed_products.get('installed_products') and \
+       installed_products.get('target_base_product'):
+        registration_server = get_registration_server_url()
+        registration_credentials = get_scc_credentials()
+        if registration_server and registration_credentials:
+            request_migration_offer(
+                installed_products,
+                registration_credentials,
+                registration_server
+            )
+            return
+    log.info('System not registered, skipped')
+
+
+def request_migration_offer(
+    installed_products, registration_credentials, registration_server
+):
+    data = {
+        'installed_products':
+            installed_products['installed_products'],
+        'target_base_product':
+            installed_products['target_base_product']
+    }
+    headers = {
+        'accept': 'application/json',
+        'Content-Type': 'application/json'
+    }
+    response = None
+    try:
+        uri = '{}/connect/systems/products/offline_migrations'.format(
+            registration_server
+        )
+        user = registration_credentials['username']
+        secret = registration_credentials['password']
+        response = requests.post(
+            uri, json=data, auth=(user, secret), headers=headers
+        )
+        offline_migrations = response.json()
+        result_error = offline_migrations.get('error')
+        if result_error:
+            log.error(result_error)
+    except Exception as issue:
+        log.error(
+            'Post request to {} failed with {}'.format(
+                registration_server,
+                response.text if response else issue
+            )
+        )
+
+
+def get_scc_credentials():
+    scc_credentials = '/etc/zypp/credentials.d/SCCcredentials'
+    result = {}
+    if os.path.isfile(scc_credentials):
+        try:
+            with open(scc_credentials, 'r') as config:
+                for line in config.read().splitlines():
+                    if line.startswith('username'):
+                        result['username'] = line.split('=')[1]
+                    if line.startswith('password'):
+                        result['password'] = line.split('=')[1]
+        except Exception as issue:
+            message = 'Loading {0} failed: {1}: {2}'.format(
+                scc_credentials, type(issue).__name__, issue
+            )
+            log.error(message)
+    return result
+
+
+def get_registration_server_url():
+    suseconnect_config = '/etc/SUSEConnect'
+    if os.path.isfile(suseconnect_config):
+        try:
+            with open(suseconnect_config, 'r') as config:
+                scc_data = yaml.safe_load(config) or {}
+                return scc_data.get('url')
+        except Exception as issue:
+            message = 'Loading {0} failed: {1}: {2}'.format(
+                suseconnect_config, type(issue).__name__, issue
+            )
+            log.error(message)
+
+
+def get_migration_target():
+    migration_config = '/etc/sle-migration-service.yml'
+    config_data = {}
+    if os.path.isfile(migration_config):
+        try:
+            with open(migration_config, 'r') as config:
+                config_data = yaml.safe_load(config) or {}
+        except Exception as issue:
+            message = 'Loading {0} failed: {1}: {2}'.format(
+                migration_config, type(issue).__name__, issue
+            )
+            log.error(message)
+            return {}
+
+    migration_product = config_data.get('migration_product')
+    if migration_product:
+        product = migration_product.split('/')
+        return {
+            'identifier': product[0],
+            'version': product[1],
+            'arch': product[2]
+        }
+    sles15_migration = Command.run(
+        ['rpm', '-q', 'SLES15-Migration'], raise_on_error=False
+    )
+    if sles15_migration.returncode == 0:
+        # return default migration target
+        return {
+            'identifier': 'SLES',
+            'version': '15.3',
+            'arch': platform.machine()
+        }
+    return {}
+
+
+def get_installed_products():
+    installed_products = {
+        'installed_products': []
+    }
+    for prod_file in glob.glob('/etc/products.d/*.prod'):
+        product_tree = etree.parse(prod_file)
+        installed_products['installed_products'].append(
+            {
+                'identifier': product_tree.find('name').text,
+                'version': product_tree.find('version').text,
+                'arch': product_tree.find('arch').text
+            }
+        )
+    return installed_products

--- a/test/data/SLES.prod
+++ b/test/data/SLES.prod
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<product schemeversion="0">
+  <vendor>SUSE</vendor>
+  <name>SLES</name>
+  <version>12.5</version>
+  <baseversion>12</baseversion>
+  <patchlevel>5</patchlevel>
+  <release>0</release>
+  <endoflife>2024-10-31</endoflife>
+  <arch>x86_64</arch>
+  <cpeid>cpe:/o:suse:sles:12:sp5</cpeid>
+  <productline>sles</productline>
+  <codestream>
+    <name>SUSE Linux Enterprise Server 12</name>
+    <endoflife>2030-10-31</endoflife>
+  </codestream>
+  <register>
+      <target>sle-12-x86_64</target>
+    <updates>
+      <repository repoid="obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER:12-SP5:x86_64/update" />
+      <repository repoid="obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER:12-SP5:x86_64/update_debug" />
+      <repository repoid="obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER-INSTALLER:12-SP5:x86_64/update" />
+    </updates>
+  </register>
+  <upgrades/>
+  <updaterepokey>A43242DKD</updaterepokey>
+  <summary>SUSE Linux Enterprise Server 12 SP5</summary>
+  <shortsummary>SLES12-SP5</shortsummary>
+  <description>SUSE Linux Enterprise offers a comprehensive
+        suite of products built on a single code base.
+        The platform addresses business needs from
+        the smallest thin-client devices to the world's
+        most powerful high-performance computing
+        and mainframe servers. SUSE Linux Enterprise
+        offers common management tools and technology
+        certifications across the platform, and
+        each product is enterprise-class.</description>
+  <linguas>
+    <language>cs</language>
+    <language>da</language>
+    <language>de</language>
+    <language>en</language>
+    <language>en_GB</language>
+    <language>en_US</language>
+    <language>es</language>
+    <language>fi</language>
+    <language>fr</language>
+    <language>hu</language>
+    <language>it</language>
+    <language>ja</language>
+    <language>nb</language>
+    <language>nl</language>
+    <language>pl</language>
+    <language>pt</language>
+    <language>pt_BR</language>
+    <language>ru</language>
+    <language>sv</language>
+    <language>zh</language>
+    <language>zh_CN</language>
+    <language>zh_TW</language>
+  </linguas>
+  <urls>
+    <url name="releasenotes">https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12-SP5/release-notes-sles.rpm</url>
+  </urls>
+  <buildconfig>
+    <producttheme>SLES</producttheme>
+  </buildconfig>
+  <installconfig>
+    <defaultlang>en_US</defaultlang>
+    <datadir>suse</datadir>
+    <descriptiondir>suse/setup/descr</descriptiondir>
+    <releasepackage name="sles-release" flag="EQ" version="12.5" release="9.5.2"/>
+    <distribution>SUSE_SLE</distribution>
+  </installconfig>
+  <runtimeconfig/>
+  <productdependency relationship="provides" name="SUSE_SLE" baseversion="12" patchlevel="5" flag="EQ"/>
+  <productdependency relationship="provides" name="SUSE_SLE-SP5" baseversion="12" patchlevel="5" flag="EQ"/>
+</product>
+

--- a/test/unit/pre_checks_test.py
+++ b/test/unit/pre_checks_test.py
@@ -1,25 +1,26 @@
-"""Unit tests for pre-checks"""
+import io
 import argparse
 import logging
 import os
 from unittest.mock import (
-    patch, call, Mock
+    patch, call, Mock, MagicMock
 )
 from pytest import fixture
 
-
+from suse_migration_services.command import Command
 from suse_migration_services.fstab import Fstab
 import suse_migration_services.prechecks.repos as check_repos
 import suse_migration_services.prechecks.fs as check_fs
 import suse_migration_services.prechecks.kernels as check_kernels
+import suse_migration_services.prechecks.scc as check_scc
 import suse_migration_services.prechecks.pre_checks as check_pre_checks
 from suse_migration_services.exceptions import DistMigrationCommandException
 from suse_migration_services.defaults import Defaults
 
 
 @patch('suse_migration_services.logger.Logger.setup')
+@patch('os.geteuid')
 class TestPreChecks():
-    """Class for holding pre-checks tests"""
     @fixture(autouse=True)
     def inject_fixtures(self, caplog):
         """Setup capture for mock"""
@@ -28,14 +29,18 @@ class TestPreChecks():
     @patch('suse_migration_services.prechecks.repos.remote_repos')
     @patch('suse_migration_services.prechecks.fs.encryption')
     @patch('suse_migration_services.prechecks.kernels.multiversion_and_multiple_kernels')
-    @patch.dict(os.environ, {"SUSE_MIGRATION_PRE_CHECKS_MODE": "foo"}, clear=True)
-    @patch('argparse.ArgumentParser.parse_args',
-           return_value=argparse.Namespace(fix=False))
+    @patch.dict(
+        os.environ, {"SUSE_MIGRATION_PRE_CHECKS_MODE": "foo"}, clear=True
+    )
+    @patch(
+        'argparse.ArgumentParser.parse_args',
+        return_value=argparse.Namespace(fix=False)
+    )
     def test_main(
         self, mock_arg_parse, mock_kernels,
-        mock_fs, mock_repos, mock_log
+        mock_fs, mock_repos, mock_os_geteuid, mock_log
     ):
-        """Test calling main()"""
+        mock_os_geteuid.return_value = 0
         with self._caplog.at_level(logging.INFO):
             check_pre_checks.main()
             assert "Running suse-migration-pre-checks" in self._caplog.text
@@ -43,14 +48,24 @@ class TestPreChecks():
     @patch('suse_migration_services.prechecks.repos.remote_repos')
     @patch('suse_migration_services.prechecks.fs.encryption')
     @patch('suse_migration_services.prechecks.kernels.multiversion_and_multiple_kernels')
-    @patch.dict(os.environ, {"SUSE_MIGRATION_PRE_CHECKS_MODE": "migration_system_iso_image"}, clear=True)
-    @patch('argparse.ArgumentParser.parse_args',
-           return_value=argparse.Namespace(fix=True))
+    @patch.dict(
+        os.environ,
+        {
+            "SUSE_MIGRATION_PRE_CHECKS_MODE": "migration_system_iso_image"
+        }, clear=True
+    )
+    @patch(
+        'argparse.ArgumentParser.parse_args',
+        return_value=argparse.Namespace(fix=True)
+    )
     def test_main_with_fix_and_migration_system_mode(
         self, mock_arg_parse, mock_kernels, mock_fs,
-        mock_repos, mock_log
+        mock_repos, mock_os_geteuid, mock_log
     ):
-        """Test calling main() when using fix and migration_system"""
+        """
+        Test calling main() when using fix and migration_system
+        """
+        mock_os_geteuid.return_value = 0
         with self._caplog.at_level(logging.INFO):
             check_pre_checks.main()
             assert "fix: True" in self._caplog.text
@@ -63,9 +78,11 @@ class TestPreChecks():
     @patch('suse_migration_services.prechecks.fs.Fstab')
     def test_fs_and_repos(
         self, mock_fstab, mock_command_run, mock_configparser_items,
-        mock_os_exists, mock_os_listdir, mock_log
+        mock_os_exists, mock_os_listdir, mock_os_geteuid, mock_log
     ):
-        """Test fs and repo modules"""
+        """
+        Test fs and repo modules
+        """
         def luks(device):
             command = Mock()
             command.returncode = 0
@@ -81,19 +98,44 @@ class TestPreChecks():
         mock_fstab.return_value = fstab_mock
         mock_command_run.side_effect = luks
         mock_os_exists.return_value = True
-        mock_os_listdir.return_value = ['no_remote.repo', 'super_repo.repo', 'another.repo']
-        repo_no_foo = 'hd:/?device=/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2'
-        repo_no_bar = 'hd:/?device=/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea4'
+        mock_os_listdir.return_value = [
+            'no_remote.repo', 'super_repo.repo', 'another.repo'
+        ]
+        repo_no_foo = \
+            'hd:/?device=/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2'
+        repo_no_bar = \
+            'hd:/?device=/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea4'
         mock_configparser_items.side_effect = [
-            [('name', 'Foo'), ('enabled', '1'), ('autorefresh', '0'), ('baseurl', 'https://download.foo.com/foo/repo/'), ('type', 'rpm-md')],
-            [('name', 'No_Foo'), ('enabled', '1'), ('autorefresh', '0'), ('baseurl', f"{repo_no_foo}"), ('path', '/'), ('keeppackages', '0')],
-            [('name', 'No_Bar'), ('enabled', '1'), ('autorefresh', '0'), ('baseurl', f"{repo_no_bar}"), ('path', '/'), ('keeppackages', '0')]
+            [
+                ('name', 'Foo'),
+                ('enabled', '1'),
+                ('autorefresh', '0'),
+                ('baseurl', 'https://download.foo.com/foo/repo/'),
+                ('type', 'rpm-md')
+            ],
+            [
+                ('name', 'No_Foo'),
+                ('enabled', '1'),
+                ('autorefresh', '0'),
+                ('baseurl', f"{repo_no_foo}"),
+                ('path', '/'),
+                ('keeppackages', '0')
+            ],
+            [
+                ('name', 'No_Bar'),
+                ('enabled', '1'),
+                ('autorefresh', '0'),
+                ('baseurl', f"{repo_no_bar}"),
+                ('path', '/'),
+                ('keeppackages', '0')
+            ]
         ]
         warning_message_remote_repos = \
-            'The following repositories may cause the migration to fail, as they ' \
-            'may not be available during the migration'
+            'The following repositories may cause the migration ' \
+            'to fail, as they may not be available during the migration'
         warning_message_show_repos = \
-            'To see all the repositories and their urls, you can run "zypper repos --url"'
+            'To see all the repositories and their urls, you can ' \
+            'run "zypper repos --url"'
 
         with self._caplog.at_level(logging.WARNING):
             check_repos.remote_repos()
@@ -108,9 +150,11 @@ class TestPreChecks():
     @patch('suse_migration_services.prechecks.fs.Fstab')
     def test_fs_and_repos_with_migration_system(
         self, mock_fstab, mock_command_run, mock_configparser_items,
-        mock_os_exists, mock_os_listdir, mock_log
+        mock_os_exists, mock_os_listdir, mock_os_geteuid, mock_log
     ):
-        """Test fs and repo modules"""
+        """
+        Test fs and repo modules
+        """
         def luks(device):
             command = Mock()
             command.returncode = 0
@@ -126,19 +170,44 @@ class TestPreChecks():
         mock_fstab.return_value = fstab_mock
         mock_command_run.side_effect = luks
         mock_os_exists.return_value = True
-        mock_os_listdir.return_value = ['no_remote.repo', 'super_repo.repo', 'another.repo']
-        repo_no_foo = 'hd:/?device=/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2'
-        repo_no_bar = 'hd:/?device=/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea4'
+        mock_os_listdir.return_value = [
+            'no_remote.repo', 'super_repo.repo', 'another.repo'
+        ]
+        repo_no_foo = \
+            'hd:/?device=/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2'
+        repo_no_bar = \
+            'hd:/?device=/dev/disk/by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea4'
         mock_configparser_items.side_effect = [
-            [('name', 'Foo'), ('enabled', '1'), ('autorefresh', '0'), ('baseurl', 'https://download.foo.com/foo/repo/'), ('type', 'rpm-md')],
-            [('name', 'No_Foo'), ('enabled', '1'), ('autorefresh', '0'), ('baseurl', f"{repo_no_foo}"), ('path', '/'), ('keeppackages', '0')],
-            [('name', 'No_Bar'), ('enabled', '1'), ('autorefresh', '0'), ('baseurl', f"{repo_no_bar}"), ('path', '/'), ('keeppackages', '0')]
+            [
+                ('name', 'Foo'),
+                ('enabled', '1'),
+                ('autorefresh', '0'),
+                ('baseurl', 'https://download.foo.com/foo/repo/'),
+                ('type', 'rpm-md')
+            ],
+            [
+                ('name', 'No_Foo'),
+                ('enabled', '1'),
+                ('autorefresh', '0'),
+                ('baseurl', f"{repo_no_foo}"),
+                ('path', '/'),
+                ('keeppackages', '0')
+            ],
+            [
+                ('name', 'No_Bar'),
+                ('enabled', '1'),
+                ('autorefresh', '0'),
+                ('baseurl', f"{repo_no_bar}"),
+                ('path', '/'),
+                ('keeppackages', '0')
+            ]
         ]
         warning_message_remote_repos = \
-            'The following repositories may cause the migration to fail, as they ' \
-            'may not be available during the migration'
+            'The following repositories may cause the migration to ' \
+            'fail, as they may not be available during the migration'
         warning_message_show_repos = \
-            'To see all the repositories and their urls, you can run "zypper repos --url"'
+            'To see all the repositories and their urls, you can ' \
+            'run "zypper repos --url"'
 
         with self._caplog.at_level(logging.WARNING):
             check_repos.remote_repos(True)
@@ -148,8 +217,12 @@ class TestPreChecks():
 
     @patch('os.listdir')
     @patch('os.path.exists')
-    def test_empty_repos(self, mock_os_exists, mock_os_listdir, mock_log):
-        """Test for empty repos"""
+    def test_empty_repos(
+        self, mock_os_exists, mock_os_listdir, mock_os_geteuid, mock_log
+    ):
+        """
+        Test for empty repos
+        """
         mock_os_exists.return_value = True
         mock_os_listdir.return_value = []
         check_repos.remote_repos()
@@ -159,21 +232,24 @@ class TestPreChecks():
     @patch('os.readlink')
     def test_multiple_kernels_default(
         self, mock_os_readlink, mock_command_run,
-        mock_configparser_items, mock_log
+        mock_configparser_items, mock_os_geteuid, mock_log
     ):
-        """ Test for multiple kernel-default packages installed"""
-
+        """
+        Test for multiple kernel-default packages installed
+        """
         mock_os_readlink.return_value = 'vmlinuz-4.12.14-122.113-default'
 
         rpm_command = Mock()
         rpm_command.returncode = 0
         rpm_command.output = \
-            'kernel-default-4.12.14-122.106.1.x86_64\nkernel-default-4.12.14-122.113.1.x86_64'
+            'kernel-default-4.12.14-122.106.1.x86_64\n' \
+            'kernel-default-4.12.14-122.113.1.x86_64'
 
         mock_command_run.side_effect = [rpm_command]
 
-        mock_configparser_items.side_effect = ('multiversion.kernels', 'latest,running')
-
+        mock_configparser_items.side_effect = (
+            'multiversion.kernels', 'latest,running'
+        )
         warning_message_multipe_kernels = \
             'Multiple kernels have been detected on the system:'
 
@@ -186,21 +262,24 @@ class TestPreChecks():
     @patch('os.readlink')
     def test_multiple_kernels_azure(
         self, mock_os_readlink, mock_command_run,
-        mock_configparser_items, mock_log
+        mock_configparser_items, mock_os_geteuid, mock_log
     ):
-        """ Test for multiple kernel-azure packages installed"""
-
+        """
+        Test for multiple kernel-azure packages installed
+        """
         mock_os_readlink.return_value = 'vmlinuz-4.12.14-16.91-azure'
 
         rpm_command = Mock()
         rpm_command.returncode = 0
         rpm_command.output = \
-            'kernel-azure-4.12.14-16.85.1.x86_64\nkernel-azure-4.12.14-16.91.1.x86_64'
+            'kernel-azure-4.12.14-16.85.1.x86_64\n' \
+            'kernel-azure-4.12.14-16.91.1.x86_64'
 
         mock_command_run.side_effect = [rpm_command]
 
-        mock_configparser_items.side_effect = ('multiversion.kernels', 'latest,running')
-
+        mock_configparser_items.side_effect = (
+            'multiversion.kernels', 'latest,running'
+        )
         warning_message_multipe_kernels = \
             'Please remove all kernels other than the currrent running kernel:'
 
@@ -213,16 +292,18 @@ class TestPreChecks():
     @patch('os.readlink')
     def test_multiple_kernels_azure_with_fix(
         self, mock_os_readlink, mock_command_run,
-        mock_configparser_items, mock_log
+        mock_configparser_items, mock_os_geteuid, mock_log
     ):
-        """ Test for multiple kernel-azure packages installed"""
-
+        """
+        Test for multiple kernel-azure packages installed
+        """
         mock_os_readlink.return_value = 'vmlinuz-4.12.14-16.91-azure'
 
         rpm_command = Mock()
         rpm_command.returncode = 0
         rpm_command.output = \
-            'kernel-azure-4.12.14-16.85.1.x86_64\nkernel-azure-4.12.14-16.91.1.x86_64'
+            'kernel-azure-4.12.14-16.85.1.x86_64\n' \
+            'kernel-azure-4.12.14-16.91.1.x86_64'
 
         command = Mock()
         command.returncode = 0
@@ -243,10 +324,11 @@ class TestPreChecks():
     @patch('os.readlink')
     def test_incorrect_multiversion_kernels_in_zypp_config(
         self, mock_os_readlink, mock_command_run,
-        mock_configparser_get, mock_log
+        mock_configparser_get, mock_os_geteuid, mock_log
     ):
-        """ Test for incorrect setting in /etc/zypp/zypp.conf"""
-
+        """
+        Test for incorrect setting in /etc/zypp/zypp.conf
+        """
         mock_os_readlink.return_value = 'vmlinuz-4.12.14-122.113-default'
 
         rpm_command = Mock()
@@ -270,10 +352,11 @@ class TestPreChecks():
     @patch('os.readlink')
     def test_missing_multiversion_kernels_in_zypp_config(
         self, mock_os_readlink, mock_command_run,
-        mock_configparser_get, mock_log
+        mock_configparser_get, mock_os_geteuid, mock_log
     ):
-        """ Test for missing setting in /etc/zypp/zypp.conf"""
-
+        """
+        Test for missing setting in /etc/zypp/zypp.conf
+        """
         mock_os_readlink.return_value = 'vmlinuz-4.12.14-122.113-default'
 
         rpm_command = Mock()
@@ -297,10 +380,11 @@ class TestPreChecks():
     @patch('os.readlink')
     def test_missing_multiversion_in_zypp_config(
         self, mock_os_readlink, mock_command_run,
-        mock_configparser_get, mock_log
+        mock_configparser_get, mock_os_geteuid, mock_log
     ):
-        """ Test for missing setting in /etc/zypp/zypp.conf"""
-
+        """
+        Test for missing setting in /etc/zypp/zypp.conf
+        """
         mock_os_readlink.return_value = 'vmlinuz-4.12.14-122.113-default'
 
         rpm_command = Mock()
@@ -326,10 +410,11 @@ class TestPreChecks():
     @patch('os.readlink')
     def test_update_zypp_conf_exception_raised(
         self, mock_os_readlink, mock_command_run,
-        mock_configparser_get, mock_log
+        mock_configparser_get, mock_os_geteuid, mock_log
     ):
-        """ Test for error updating /etc/zypp/zypp.conf"""
-
+        """
+        Test for error updating /etc/zypp/zypp.conf
+        """
         mock_os_readlink.return_value = 'vmlinuz-4.12.14-122.113-default'
 
         rpm_command = Mock()
@@ -337,35 +422,39 @@ class TestPreChecks():
         rpm_command.output = \
             'kernel-default-4.12.14-122.113.1.x86_64'
 
-        mock_command_run.side_effect = [DistMigrationCommandException('Run failure'), rpm_command, ]
-
+        mock_command_run.side_effect = [
+            DistMigrationCommandException('Run failure'), rpm_command
+        ]
         mock_configparser_get.side_effect = \
             ['provides:multiversion(kernel)', 'latest,running,latest-1']
 
         with self._caplog.at_level(logging.WARNING):
             check_kernels.multiversion_and_multiple_kernels(True)
-            assert 'ERROR: Unable to update /etc/zypp/zypp.conf' in self._caplog.text
+            assert 'ERROR: Unable to update /etc/zypp/zypp.conf' in \
+                self._caplog.text
 
     @patch('configparser.ConfigParser.get')
     @patch('suse_migration_services.command.Command.run')
     @patch('os.readlink')
     def test_rpm_remove_exception_raised(
         self, mock_os_readlink, mock_command_run,
-        mock_configparser_get, mock_log
+        mock_configparser_get, mock_os_geteuid, mock_log
     ):
-        """ Test for missing setting in /etc/zypp/zypp.conf"""
-
+        """
+        Test for missing setting in /etc/zypp/zypp.conf
+        """
         mock_os_readlink.return_value = 'vmlinuz-4.12.14-122.113-default'
 
         rpm_command = Mock()
         rpm_command.returncode = 0
         rpm_command.output = \
-            'kernel-default-4.12.14-122.106.1.x86_64\nkernel-default-4.12.14-122.113.1.x86_64'
+            'kernel-default-4.12.14-122.106.1.x86_64\n' \
+            'kernel-default-4.12.14-122.113.1.x86_64'
 
-        mock_command_run.side_effect = [rpm_command, DistMigrationCommandException('Run failure')]
-
+        mock_command_run.side_effect = [
+            rpm_command, DistMigrationCommandException('Run failure')
+        ]
         mock_configparser_get.return_value = 'foo'
-
         with self._caplog.at_level(logging.WARNING):
             check_kernels.multiversion_and_multiple_kernels(True)
             assert 'ERROR: Unable to remove old kernel(s)' in self._caplog.text
@@ -375,21 +464,21 @@ class TestPreChecks():
     @patch('os.readlink')
     def test_correct_rpm_commands_when_using_target(
         self, mock_os_readlink, mock_command_run,
-        mock_configparser_get, mock_log
+        mock_configparser_get, mock_os_geteuid, mock_log
     ):
-        """ Test for missing setting in /etc/zypp/zypp.conf"""
-
+        """
+        Test for missing setting in /etc/zypp/zypp.conf
+        """
         mock_os_readlink.return_value = 'vmlinuz-4.12.14-122.113-default'
 
         rpm_command = Mock()
         rpm_command.returncode = 0
         rpm_command.output = \
-            'kernel-default-4.12.14-122.106.1.x86_64\nkernel-default-4.12.14-122.113.1.x86_64'
+            'kernel-default-4.12.14-122.106.1.x86_64\n' \
+            'kernel-default-4.12.14-122.113.1.x86_64'
 
         mock_command_run.side_effect = [rpm_command, rpm_command]
-
         mock_configparser_get.return_value = 'foo'
-
         check_kernels.multiversion_and_multiple_kernels(True, True)
         assert mock_command_run.call_args_list == [
             call(
@@ -417,10 +506,11 @@ class TestPreChecks():
     @patch('os.readlink')
     def test_correct_rpm_command_when_using_target_with_azure(
         self, mock_os_readlink, mock_command_run,
-        mock_configparser_get, mock_log
+        mock_configparser_get, mock_os_geteuid, mock_log
     ):
-        """ Test for missing setting in /etc/zypp/zypp.conf"""
-
+        """
+        Test for missing setting in /etc/zypp/zypp.conf
+        """
         mock_os_readlink.return_value = 'vmlinuz-4.12.14-16.91-azure'
 
         rpm_command = Mock()
@@ -446,24 +536,172 @@ class TestPreChecks():
         ]
 
     @patch.object(Defaults, 'get_migration_config_file')
+    @patch('suse_migration_services.prechecks.scc.migration')
     @patch('suse_migration_services.prechecks.repos.remote_repos')
     @patch('suse_migration_services.prechecks.fs.encryption')
     @patch('suse_migration_services.prechecks.kernels.multiversion_and_multiple_kernels')
-    @patch.dict(os.environ, {"SUSE_MIGRATION_PRE_CHECKS_MODE": "migration_system_iso_image"}, clear=True)
-    @patch('argparse.ArgumentParser.parse_args',
-           return_value=argparse.Namespace(fix=True))
+    @patch.dict(
+        os.environ, {
+            "SUSE_MIGRATION_PRE_CHECKS_MODE": "migration_system_iso_image"
+        }, clear=True
+    )
+    @patch(
+        'argparse.ArgumentParser.parse_args',
+        return_value=argparse.Namespace(fix=True)
+    )
     def test_pre_checks_false(
         self, mock_argparse, mock_kernels, mock_fs,
-        mock_repos, mock_get_migration_config_file,
-        mock_log
+        mock_repos, mock_scc_migration, mock_get_migration_config_file,
+        mock_os_geteuid, mock_log
     ):
-        """ Test for missing setting in /etc/zypp/zypp.conf"""
-
+        """
+        Test for missing setting in /etc/zypp/zypp.conf
+        """
+        mock_os_geteuid.return_value = 0
         mock_get_migration_config_file.return_value = \
             '../data/migration-config-pre-checks.yml'
 
-        info_message = "Overriding the 'fix' option"
-
+        info_message = "Overriding the --fix option"
         with self._caplog.at_level(logging.INFO):
             check_pre_checks.main()
             assert info_message in self._caplog.text
+
+    @patch('yaml.safe_load')
+    @patch('glob.glob')
+    @patch('os.path.isfile')
+    @patch('requests.post')
+    @patch.object(Command, 'run')
+    @patch.object(Defaults, 'get_migration_config_file')
+    def test_check_scc_migration(
+        self, mock_get_migration_config_file,
+        mock_Command_run, mock_requests_post,
+        mock_os_path_isfile, mock_glob, mock_yaml_safe_load,
+        mock_os_geteuid, mock_log
+    ):
+        response = Mock()
+        response.json.return_value = {
+            'type': 'error',
+            'error': 'Some error'
+        }
+        mock_glob.return_value = ['../data/SLES.prod']
+        mock_os_path_isfile.return_value = True
+        mock_requests_post.return_value = response
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open_credentials = MagicMock(spec=io.IOBase)
+            mock_open_suseconnect = MagicMock(spec=io.IOBase)
+            mock_open_migration_config = MagicMock(spec=io.IOBase)
+
+            def safe_load_suseconnect_exception(handle):
+                if handle == file_handle_suseconnect:
+                    raise Exception('IO Error')
+                elif handle == file_handle_migration_config:
+                    return {'migration_product': 'SLES/15.3/x86_64'}
+
+            def safe_load_migration_config_exception(handle):
+                if handle == file_handle_suseconnect:
+                    return {'url': 'https://smt-ec2.susecloud.net'}
+                elif handle == file_handle_migration_config:
+                    raise Exception('IO Error')
+
+            def safe_load(handle):
+                if handle == file_handle_suseconnect:
+                    return {'url': 'https://smt-ec2.susecloud.net'}
+                elif handle == file_handle_migration_config:
+                    return {'migration_product': 'SLES/15.3/x86_64'}
+
+            def open_file(filename, mode=None):
+                if filename == '/etc/zypp/credentials.d/SCCcredentials':
+                    return mock_open_credentials.return_value
+                elif filename == '/etc/SUSEConnect':
+                    return mock_open_suseconnect.return_value
+                elif filename == '/etc/sle-migration-service.yml':
+                    return mock_open_migration_config.return_value
+
+            mock_open.side_effect = open_file
+
+            file_handle_credentials = \
+                mock_open_credentials.return_value.__enter__.return_value
+            file_handle_suseconnect = \
+                mock_open_suseconnect.return_value.__enter__.return_value
+            file_handle_migration_config = \
+                mock_open_migration_config.return_value.__enter__.return_value
+
+            mock_yaml_safe_load.side_effect = safe_load
+
+            file_handle_credentials.read.return_value = \
+                'username=SCC_xxx\npassword=xxx\n'
+
+            with self._caplog.at_level(logging.ERROR):
+                check_scc.migration()
+                mock_requests_post.assert_called_once_with(
+                    'https://smt-ec2.susecloud.net/'
+                    'connect/systems/products/offline_migrations',
+                    json={
+                        'installed_products': [
+                            {
+                                'identifier': 'SLES',
+                                'version': '12.5',
+                                'arch': 'x86_64'
+                            }
+                        ],
+                        'target_base_product': {
+                            'identifier': 'SLES',
+                            'version': '15.3',
+                            'arch': 'x86_64'
+                        }
+                    },
+                    auth=('SCC_xxx', 'xxx'),
+                    headers={
+                        'accept': 'application/json',
+                        'Content-Type': 'application/json'
+                    }
+                )
+                assert 'Some error' in self._caplog.text
+
+            # Test exception on requests.post
+            mock_requests_post.side_effect = Exception('Some error')
+            check_scc.migration()
+            assert 'Post request to https://smt-ec2.susecloud.net '
+            'failed with Some error' in self._caplog.text
+            mock_requests_post.reset_mock()
+
+            # Test exception on get_migration_target
+            mock_yaml_safe_load.side_effect = \
+                safe_load_migration_config_exception
+            check_scc.migration()
+            assert not mock_requests_post.called
+
+            # Test exception on get_registration_server_url
+            mock_yaml_safe_load.side_effect = \
+                safe_load_suseconnect_exception
+            check_scc.migration()
+            assert not mock_requests_post.called
+
+            # Test exception on get_scc_credentials
+            mock_yaml_safe_load.side_effect = safe_load
+            file_handle_credentials.read.side_effect = Exception('IO error')
+            check_scc.migration()
+            assert not mock_requests_post.called
+
+    @patch('platform.machine')
+    @patch('os.path.isfile')
+    @patch.object(Command, 'run')
+    def test_check_scc_migration_default_target(
+        self, mock_Command_run, mock_os_path_isfile,
+        mock_platform_machine, mock_os_geteuid, mock_log
+    ):
+        mock_platform_machine.return_value = 'x86_64'
+        sles15_migration = Mock()
+        sles15_migration.returncode = 0
+        mock_Command_run.return_value = sles15_migration
+        mock_os_path_isfile.return_value = False
+        assert check_scc.get_migration_target() == {
+            'identifier': 'SLES',
+            'version': '15.3',
+            'arch': 'x86_64'
+        }
+
+    def test_privileges(self, mock_os_geteuid, mock_log):
+        with self._caplog.at_level(logging.ERROR):
+            check_pre_checks.main()
+            assert 'pre-checks requires root permissions' in self._caplog.text


### PR DESCRIPTION
Add check which sends an API call to the registration server migrations API to ask for the possible upgrade path. This is acually the same call done by the zypper migration plugin but prior the actual migration starts. The request can only be issued if product and credentials data as well as the registration server URL could be found on the system to migrate. If the required information to issue the request cannot be found, the check is skipped. In case the regsitration server responds with an error, the pre-check prints this information such that the user knows about the issue prior starting the migration. The error information sent from the registration server could also include instructions how to fix the situation such that a migration can succeed. For example on LTSS registered systems the request will respond with an error message that products with activated LTSS cannot be migrated and how to call SUSEConnect to disable LTSS such that a migration will become possible.