### PR TITLE
Add high availablity extension check

### DIFF
--- a/suse_migration_services/prechecks/ha.py
+++ b/suse_migration_services/prechecks/ha.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2025 SUSE Linux LLC.  All rights reserved.
+#
+# This file is part of suse-migration-services.
+#
+# suse-migration-services is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# suse-migration-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
+#
+"""Call prechecks for HA provided by crmsh"""
+import logging
+import os
+import subprocess
+
+from suse_migration_services.defaults import Defaults
+
+
+log = logging.getLogger(Defaults.get_migration_log_name())
+
+
+def check_ha(migration_system=False):
+    if migration_system:
+        log.info('Skipped checks for high availablity extension in migration system.')
+        return
+    if not _corosync_conf_exists():
+        log.info('corosync.conf not found. Skipped checks for high availablity extension.')
+        return
+    if not _is_crmsh_capable_to_check():
+        log.warning('crmsh version is too old. Skipped checks for high availablity extension.')
+        return
+    subprocess.run(['crm', 'cluster', 'health', 'sles16', '--local'])
+
+
+def _corosync_conf_exists():
+    return os.access('/etc/corosync/corosync.conf', os.F_OK)
+
+
+def _is_crmsh_capable_to_check():
+    try:
+        result = subprocess.run(
+            ['crm', 'help', 'cluster', 'health'],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        return False
+    except Exception as e:
+        log.error('Failed to call crmsh: %s', e)
+        return False
+    return result.returncode == 0 and 'sles16' in result.stdout.decode(errors='replace')

--- a/suse_migration_services/prechecks/pre_checks.py
+++ b/suse_migration_services/prechecks/pre_checks.py
@@ -24,6 +24,7 @@ from suse_migration_services.defaults import Defaults
 from suse_migration_services.logger import Logger
 from suse_migration_services.migration_config import MigrationConfig
 
+import suse_migration_services.prechecks.ha as check_ha
 import suse_migration_services.prechecks.repos as check_repos
 import suse_migration_services.prechecks.fs as check_fs
 import suse_migration_services.prechecks.kernels as check_multi_kernels
@@ -112,4 +113,8 @@ def main():
     check_scc.migration(
         migration_system=migration_system_mode
     )
+    log.info('Done')
+
+    log.info('--> Checking high availability extension...')
+    check_ha.check_ha()
     log.info('Done')

--- a/test/unit/pre_checks_test.py
+++ b/test/unit/pre_checks_test.py
@@ -2,6 +2,7 @@ import io
 import argparse
 import logging
 import os
+import subprocess
 from unittest.mock import (
     patch, call, Mock, MagicMock
 )
@@ -13,6 +14,7 @@ import suse_migration_services.prechecks.repos as check_repos
 import suse_migration_services.prechecks.fs as check_fs
 import suse_migration_services.prechecks.kernels as check_kernels
 import suse_migration_services.prechecks.scc as check_scc
+import suse_migration_services.prechecks.ha as check_ha
 import suse_migration_services.prechecks.pre_checks as check_pre_checks
 from suse_migration_services.exceptions import DistMigrationCommandException
 from suse_migration_services.defaults import Defaults
@@ -705,3 +707,78 @@ class TestPreChecks():
         with self._caplog.at_level(logging.ERROR):
             check_pre_checks.main()
             assert 'pre-checks requires root permissions' in self._caplog.text
+
+    @patch('subprocess.run')
+    @patch('os.access')
+    def test_check_ha_in_migration_system(
+        self,
+        mock_os_access, mock_subprocess_run,
+        mock_os_getuid, mock_log,
+    ):
+        mock_os_access.return_value = False
+        with self._caplog.at_level(logging.INFO):
+            check_ha.check_ha(migration_system=True)
+            assert 'Skipped checks for high availablity extension' in self._caplog.text
+        mock_os_access.assert_not_called()
+        mock_subprocess_run.assert_not_called()
+
+    @patch('subprocess.run')
+    @patch('os.access')
+    def test_check_ha_not_intialzied(
+        self,
+        mock_os_access, mock_subprocess_run,
+        mock_os_getuid, mock_log,
+    ):
+        mock_os_access.return_value = False
+        with self._caplog.at_level(logging.INFO):
+            check_ha.check_ha(migration_system=False)
+            assert 'Skipped checks for high availablity extension' in self._caplog.text
+        mock_subprocess_run.assert_not_called()
+
+    @patch('subprocess.run')
+    @patch('os.access')
+    def test_check_ha_not_installed(
+        self,
+        mock_os_access, mock_subprocess_run,
+        mock_os_getuid, mock_log,
+    ):
+        mock_os_access.return_value = True
+        mock_subprocess_run.side_effect = FileNotFoundError()
+        with self._caplog.at_level(logging.INFO):
+            check_ha.check_ha(migration_system=False)
+            assert 'Skipped checks for high availablity extension' in self._caplog.text
+        mock_subprocess_run.assert_called_once()
+
+    @patch('subprocess.run')
+    @patch('os.access')
+    def test_check_ha_unexpected_exception_when_calling_crmsh(
+        self,
+        mock_os_access, mock_subprocess_run,
+        mock_os_getuid, mock_log,
+    ):
+        mock_os_access.return_value = True
+        mock_subprocess_run.side_effect = PermissionError()
+        with self._caplog.at_level(logging.WARNING):
+            check_ha.check_ha(migration_system=False)
+            assert 'Skipped checks for high availablity extension' in self._caplog.text
+        mock_subprocess_run.assert_called_once()
+
+    @patch('subprocess.run')
+    @patch('os.access')
+    def test_check_ha(
+        self,
+        mock_os_access, mock_subprocess_run,
+        mock_os_getuid, mock_log,
+    ):
+        mock_os_access.return_value = True
+        mock_subprocess_run.return_value = Mock(returncode=0, stdout=b'crm cluster health hawk2|sles16')
+        with self._caplog.at_level(logging.INFO):
+            check_ha.check_ha(migration_system=False)
+            assert 'Skipped checks for high availablity extension.' not in self._caplog.text
+        mock_subprocess_run.assert_has_calls([
+            call(
+                ['crm', 'help', 'cluster', 'health'],
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            ),
+            call(['crm', 'cluster', 'health', 'sles16', '--local']),
+        ])


### PR DESCRIPTION
Add a check to call ha checks provided by crmsh. If ha cluster config files exist and crmsh is installed and up to date, this module calls crmsh as a subprocess to run the checks. The result is printed to stdout directly by crmsh.

close #329