### PR TITLE
Relax on the shim-install call

### DIFF
--- a/suse_migration_services/units/update_bootloader.py
+++ b/suse_migration_services/units/update_bootloader.py
@@ -70,10 +70,15 @@ def install_shim_package(root_path):
 
 def install_secure_bootloader(root_path):
     """
-    Perform shim-install from inside the upgraded system
+    Perform shim-install from inside the upgraded system.
+    If the system is not suitable to be setup for shim e.g.
+    not EFI based, we don't consider it as a fatal error
+    and continue while keeping the log information about the
+    attempt.
     """
     Command.run(
-        ['chroot', root_path, 'shim-install', '--removable']
+        ['chroot', root_path, 'shim-install', '--removable'],
+        raise_on_error=False
     )
 
 

--- a/test/unit/units/update_bootloader_test.py
+++ b/test/unit/units/update_bootloader_test.py
@@ -34,7 +34,7 @@ class TestUpdateBootloader:
                 [
                     'chroot', '/system-root',
                     'shim-install', '--removable'
-                ]
+                ], raise_on_error=False
             ),
             call(
                 [


### PR DESCRIPTION
The DMS tries to make the system gain secure boot capabilities. However, several reasons e.g. system was not EFI based can cause an error when attempting the setup. This action should not cause the entire migration to fail. The DMS upgrades a system based on the content of the existing disk layout. If the disk layout to begin with is not suitable for EFI or secure boot, the DMS will not interfere with the foundation of the system during upgrade. However, in such a case the DMS should still be able to upgrade the OS.