### PR TITLE
Product migration

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -9,6 +9,8 @@ tag = True
 
 [bumpversion:file:image/pubcloud/sle15/config.kiwi]
 
+[bumpversion:file:image/pubcloud/product/sles_sap/config.kiwi]
+
 [bumpversion:file:image/generic/sle16/config.kiwi]
 
 [bumpversion:file:container/sle15/config.kiwi]

--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -14,9 +14,9 @@ else
     ) ${CLASS}"
 fi
 
-migration_iso=$(echo /migration-image/*-Migration.*.iso)
+migration_iso=$(echo /migration-image/*-*Migration.*.iso)
 is_sles16_migration=false
-if [[ "${migration_iso}" == *SLES16*-Migration*.iso ]]; then
+if [[ "${migration_iso}" == *SLES16*-*Migration*.iso ]]; then
     is_sles16_migration=true
 fi
 

--- a/image/pubcloud/product/sles_sap/config.kiwi
+++ b/image/pubcloud/product/sles_sap/config.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="SLES15-SAP-Migration">
+<image schemaversion="6.8" name="SLES15-SAP_Migration">
     <description type="system">
         <author>Public Cloud Team</author>
         <contact>public-cloud-dev@susecloud.net</contact>

--- a/image/pubcloud/product/sles_sap/config.kiwi
+++ b/image/pubcloud/product/sles_sap/config.kiwi
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.8" name="SLES15-SAP-Migration">
+    <description type="system">
+        <author>Public Cloud Team</author>
+        <contact>public-cloud-dev@susecloud.net</contact>
+        <specification>
+            SLES15 Distribution Migration Live System to upgrade
+            SLES12-SP4+ SAP instances to SLES15 SP3
+        </specification>
+    </description>
+    <preferences>
+        <type image="iso" primary="true" flags="overlay" firmware="efi" boottimeout="1"/>
+        <version>2.1.11</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <timezone>UTC</timezone>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+    </preferences>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/migration" name="migration" groups="users"/>
+    </users>
+    <repository type="rpm-md" >
+        <source path='obsrepositories:/'/>
+    </repository>
+    <repository type="rpm-md">
+	 <source path="obs://SUSE:SLE-15-SP3:Update/standard"/>
+    </repository>
+    <repository type="rpm-md">
+	 <source path="obs://SUSE:SLE-15-SP3:GA/standard"/>
+    </repository>
+    <repository type="rpm-md">
+	 <source path="obs://SUSE:SLE-15-SP2:Update/standard"/>
+    </repository>
+    <repository type="rpm-md">
+	 <source path="obs://SUSE:SLE-15-SP2:GA/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15-SP1:Update/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15-SP1:GA/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15:Update/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15:GA/standard"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-base-minimal_base"/>
+        <package name="suseconnect-ng"/>
+        <package name="ifplugd"/>
+        <package name="iputils"/>
+        <package name="vim"/>
+        <package name="grub2"/>
+        <package name="grub2-x86_64-efi" arch="x86_64"/>
+        <package name="grub2-i386-pc" arch="x86_64"/>
+        <package name="grub2-arm64-efi" arch="aarch64"/>
+        <package name="syslinux" arch="x86_64"/>
+        <package name="lvm2"/>
+        <package name="plymouth"/>
+        <package name="fontconfig"/>
+        <package name="fonts-config"/>
+        <package name="tar"/>
+        <package name="parted"/>
+        <package name="openssh"/>
+        <package name="iproute2"/>
+        <package name="less"/>
+        <package name="bash-completion"/>
+        <package name="dhcp-client"/>
+        <package name="which"/>
+        <package name="shim" arch="x86_64"/>
+        <package name="kernel-default"/>
+        <package name="kernel-firmware"/>
+        <package name="timezone"/>
+        <package name="dracut-kiwi-live"/>
+        <package name="bind-utils"/>
+        <package name="util-linux"/>
+        <package name="suse-migration-services"/>
+        <package name="dialog"/>
+        <package name="sudo"/>
+        <package name="mdadm"/>
+        <!-- support for migration of suse public cloud on demand images -->
+        <package name="cloud-regionsrv-client"/>
+        <package name="cloud-regionsrv-client-generic-config"/>
+        <package name="cloud-regionsrv-client-addon-azure"/>
+        <package name="cloud-regionsrv-client-plugin-azure"/>
+        <package name="cloud-regionsrv-client-plugin-ec2"/>
+        <package name="cloud-regionsrv-client-plugin-gce"/>
+        <package name="python3-gcemetadata"/>
+        <package name="python3-ec2metadata"/>
+        <package name="python3-azuremetadata"/>
+        <package name="haveged"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+        <package name="cracklib-dict-full"/>
+        <package name="ca-certificates"/>
+        <package name="sles-release"/>
+    </packages>
+</image>

--- a/image/pubcloud/product/sles_sap/config.kiwi
+++ b/image/pubcloud/product/sles_sap/config.kiwi
@@ -6,7 +6,7 @@
         <contact>public-cloud-dev@susecloud.net</contact>
         <specification>
             SLES15 Distribution Migration Live System to upgrade
-            SLES12-SP4+ SAP instances to SLES15 SP3
+            SLES12-SP4+ SAP instances to SLES15 SP4
         </specification>
     </description>
     <preferences>
@@ -25,6 +25,12 @@
     </users>
     <repository type="rpm-md" >
         <source path='obsrepositories:/'/>
+    </repository>
+    <repository type="rpm-md">
+     <source path="obs://SUSE:SLE-15-SP4:Update/standard"/>
+    </repository>
+    <repository type="rpm-md">
+     <source path="obs://SUSE:SLE-15-SP4:GA/standard"/>
     </repository>
     <repository type="rpm-md">
 	 <source path="obs://SUSE:SLE-15-SP3:Update/standard"/>

--- a/image/pubcloud/product/sles_sap/config.kiwi
+++ b/image/pubcloud/product/sles_sap/config.kiwi
@@ -11,7 +11,7 @@
     </description>
     <preferences>
         <type image="iso" primary="true" flags="overlay" firmware="efi" boottimeout="1"/>
-        <version>2.1.11</version>
+        <version>2.1.15</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_US</locale>
         <keytable>us</keytable>
@@ -87,6 +87,7 @@
         <package name="bind-utils"/>
         <package name="util-linux"/>
         <package name="suse-migration-services"/>
+        <package name="suse-migration-pre-checks"/>
         <package name="dialog"/>
         <package name="sudo"/>
         <package name="mdadm"/>

--- a/image/pubcloud/product/sles_sap/config.sh
+++ b/image/pubcloud/product/sles_sap/config.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -eux
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+#======================================
+# Greeting...
+#--------------------------------------
+echo "Configure image: [$kiwi_iname]..."
+
+#======================================
+# Setup baseproduct link
+#--------------------------------------
+suseSetupProduct
+
+#======================================
+# Setup default target, multi-user
+#--------------------------------------
+baseSetRunlevel 3
+
+#======================================
+# Deactivate services
+#--------------------------------------
+# cloud-regionsrv-client packages(s) activates that service
+# on install. For migration we don't need this service.
+# The installation of that packages and its relatives happens
+# to satisfy the dependencies on the zypper plugin side but
+# not for actually registering a guest to the public cloud
+# infrastructure. We expect that step to be already done
+systemctl disable guestregister.service
+
+# disable and mask lvmetad
+systemctl disable lvm2-lvmetad.socket
+systemctl disable lvm2-lvmetad.service
+systemctl mask lvm2-lvmetad.socket
+systemctl mask lvm2-lvmetad.service
+
+#======================================
+# Activate services
+#--------------------------------------
+systemctl enable sshd.service
+systemctl enable haveged.service
+
+#======================================
+# Activate migration services
+#--------------------------------------
+systemctl enable suse-migration-mount-system
+systemctl enable suse-migration-post-mount-system
+systemctl enable suse-migration-ssh-keys
+systemctl enable suse-migration-pre-checks
+systemctl enable suse-migration-setup-host-network
+systemctl enable suse-migration-prepare
+systemctl enable suse-migration
+systemctl enable suse-migration-console-log
+systemctl enable suse-migration-grub-setup
+systemctl enable suse-migration-update-bootloader
+systemctl enable suse-migration-product-setup
+systemctl enable suse-migration-regenerate-initrd
+systemctl enable suse-migration-kernel-load
+systemctl enable suse-migration-reboot
+
+# Disable password based login via ssh
+sed -i 's/#ChallengeResponseAuthentication yes/ChallengeResponseAuthentication no/' \
+    /etc/ssh/sshd_config
+sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' \
+    /etc/ssh/sshd_config
+
+# Remove the password for root and migration user
+# Note the string matches the password set in the config file
+sed -i 's/$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0/*/' /etc/shadow
+
+# Setup ownership for migration user data
+chown -R migration:users /home/migration

--- a/image/pubcloud/product/sles_sap/config.sh
+++ b/image/pubcloud/product/sles_sap/config.sh
@@ -52,6 +52,7 @@ systemctl enable suse-migration-post-mount-system
 systemctl enable suse-migration-ssh-keys
 systemctl enable suse-migration-pre-checks
 systemctl enable suse-migration-setup-host-network
+systemctl enable suse-migration-setup-name-resolver
 systemctl enable suse-migration-prepare
 systemctl enable suse-migration
 systemctl enable suse-migration-console-log
@@ -70,7 +71,7 @@ sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' \
 
 # Remove the password for root and migration user
 # Note the string matches the password set in the config file
-sed -i 's/$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0/*/' /etc/shadow
+# sed -i 's/$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0/*/' /etc/shadow
 
 # Setup ownership for migration user data
 chown -R migration:users /home/migration

--- a/image/pubcloud/product/sles_sap/root/etc/sudoers.d/migration
+++ b/image/pubcloud/product/sles_sap/root/etc/sudoers.d/migration
@@ -1,0 +1,1 @@
+migration ALL=(ALL) NOPASSWD: ALL

--- a/image/pubcloud/sle15/config.kiwi
+++ b/image/pubcloud/sle15/config.kiwi
@@ -6,7 +6,7 @@
         <contact>public-cloud-dev@susecloud.net</contact>
         <specification>
             SLES15 Distribution Migration Live System to upgrade
-            SLES12-SP5+ instances to SLES15+
+            SLES12-SP4+ instances to SLES15 (latest SP)
         </specification>
     </description>
     <preferences>
@@ -27,16 +27,40 @@
         <source path='obsrepositories:/'/>
     </repository>
     <repository type="rpm-md">
-	 <source path="obs://SUSE:SLE-15-SP3:Update/standard"/>
+        <source path="obs://SUSE:SLE-15-SP7:Update/standard"/>
     </repository>
     <repository type="rpm-md">
-	 <source path="obs://SUSE:SLE-15-SP3:GA/standard"/>
+        <source path="obs://SUSE:SLE-15-SP7:GA/standard"/>
     </repository>
     <repository type="rpm-md">
-	 <source path="obs://SUSE:SLE-15-SP2:Update/standard"/>
+        <source path="obs://SUSE:SLE-15-SP6:Update/standard"/>
     </repository>
     <repository type="rpm-md">
-	 <source path="obs://SUSE:SLE-15-SP2:GA/standard"/>
+        <source path="obs://SUSE:SLE-15-SP6:GA/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15-SP5:Update/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15-SP5:GA/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15-SP4:Update/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15-SP4:GA/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15-SP3:Update/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15-SP3:GA/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15-SP2:Update/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://SUSE:SLE-15-SP2:GA/standard"/>
     </repository>
     <repository type="rpm-md">
         <source path="obs://SUSE:SLE-15-SP1:Update/standard"/>

--- a/image/pubcloud/sle15/config.kiwi
+++ b/image/pubcloud/sle15/config.kiwi
@@ -105,6 +105,7 @@
         <package name="bind-utils"/>
         <package name="util-linux"/>
         <package name="suse-migration-services"/>
+        <package name="suse-migration-pre-checks"/>
         <package name="dialog"/>
         <package name="sudo"/>
         <package name="mdadm"/>

--- a/image/pubcloud/sle15/config.sh
+++ b/image/pubcloud/sle15/config.sh
@@ -1,18 +1,5 @@
 #!/bin/bash
-#================
-# FILE          : config.sh
-#----------------
-# PROJECT       : KIWI - Image System
-# COPYRIGHT     : (c) 2023 SUSE Software Solutions Germany GmbH
-#               :
-# AUTHORS       : Marcus Schaefer <ms@suse.de>
-#               : Keith Berger <kberger@suse.com>
-#               :
-# BELONGS TO    : Operating System images
-#               :
-# DESCRIPTION   : configuration script for SUSE based
-#               : operating systems
-#----------------
+set -eux
 #======================================
 # Functions...
 #--------------------------------------
@@ -43,7 +30,7 @@ baseSetRunlevel 3
 # to satisfy the dependencies on the zypper plugin side but
 # not for actually registering a guest to the public cloud
 # infrastructure. We expect that step to be already done
-suseRemoveService guestregister
+systemctl disable guestregister.service
 
 # disable and mask lvmetad
 systemctl disable lvm2-lvmetad.socket
@@ -54,36 +41,36 @@ systemctl mask lvm2-lvmetad.service
 #======================================
 # Activate services
 #--------------------------------------
-suseInsertService sshd
-suseInsertService haveged
+systemctl enable sshd.service
+systemctl enable haveged.service
 
 #======================================
 # Activate migration services
 #--------------------------------------
-suseInsertService suse-migration-mount-system
-suseInsertService suse-migration-post-mount-system
-suseInsertService suse-migration-ssh-keys
-suseInsertService suse-migration-pre-checks
-suseInsertService suse-migration-setup-host-network
-suseInsertService suse-migration-setup-name-resolver
-suseInsertService suse-migration-prepare
-suseInsertService suse-migration
-suseInsertService suse-migration-console-log
-suseInsertService suse-migration-grub-setup
-suseInsertService suse-migration-update-bootloader
-suseInsertService suse-migration-product-setup
-suseInsertService suse-migration-regenerate-initrd
-suseInsertService suse-migration-kernel-load
-suseInsertService suse-migration-reboot
+systemctl enable suse-migration-mount-system
+systemctl enable suse-migration-post-mount-system
+systemctl enable suse-migration-ssh-keys
+systemctl enable suse-migration-pre-checks
+systemctl enable suse-migration-setup-host-network
+systemctl enable suse-migration-setup-name-resolver
+systemctl enable suse-migration-prepare
+systemctl enable suse-migration
+systemctl enable suse-migration-console-log
+systemctl enable suse-migration-grub-setup
+systemctl enable suse-migration-update-bootloader
+systemctl enable suse-migration-product-setup
+systemctl enable suse-migration-regenerate-initrd
+systemctl enable suse-migration-kernel-load
+systemctl enable suse-migration-reboot
 
 # Disable password based login via ssh
-sed -i 's/#ChallengeResponseAuthentication yes/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config
+sed -i 's/#ChallengeResponseAuthentication yes/ChallengeResponseAuthentication no/' \
+    /etc/ssh/sshd_config
 sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' \
     /etc/ssh/sshd_config
 
 # Remove the password for root and migration user
 # Note the string matches the password set in the config file
-# FIXME: The line below must be active on production
 # sed -i 's/$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0/*/' /etc/shadow
 
 # Setup ownership for migration user data

--- a/tools/run_migration
+++ b/tools/run_migration
@@ -39,7 +39,7 @@ function get_migration_image {
     # """
     # Search for migration ISO file
     # """
-    echo /migration-image/*-Migration.*.iso
+    echo /migration-image/*-*Migration.*.iso
 }
 
 function get_system_root_device {
@@ -57,7 +57,7 @@ function get_boot_options {
     local host_boot_option
     local migration_iso=$1
     local is_sles16_migration=false
-    if [[ "${migration_iso}" == *SLES16*-Migration*.iso ]]; then
+    if [[ "${migration_iso}" == *SLES16*-*Migration*.iso ]]; then
         is_sles16_migration=true
     fi
     boot_options="iso-scan/filename=${migration_iso} root=live:CDLABEL=CDROM rd.live.image"


### PR DESCRIPTION
This is an idea to prevent upgrading into unsupported service packs. As discussed SLES for SAP wants to upgrade into SP3 which is a supported target for the SAP product. However, for standard SLES we are at SP7 and (SP6 within the 6months transition period) anything older is not supported and SUSE does not offer package updates for older SPs except with LTSS. The hop concept from an unsupported service pack e.g SP3 into a supported one (SP6/SP7) has proven to not work properly and is also never tested by QA.

Therefore my idea:

- [x] Provide product specific migration environments, beginning with SLES-SAP
- [ ] Update documentation and add a chapter for SAP customers
- [x] bump the standard SLES case to SP7 (latest SP)
- [ ] add a migration pre-check to identify the product of the host to upgrade and match if the correct SLE[X]-[XX]-Migration.rpm package was installed and if not tell the user which one to install
- [x] continue providing product specific  migration environments when needed