### PR TITLE
Fix suse-migration-console-log service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,15 @@ SLES16-Migration: clean check test
 	cp image/generic/sle16/config.sh dist/config.sh
 	cp image/generic/sle16/SLES16-Migration.changes dist/SLES16-Migration.changes
 
+SLES15-Migration: clean check test
+	mkdir -p dist
+	tar --sort=name --owner=0 --group=0 --numeric-owner \
+		--transform 's,^\./,,' \
+		-czf dist/root.tar.gz \
+		-C image/pubcloud/sle15/root .
+	cp image/pubcloud/sle15/config.kiwi dist/config.kiwi
+	cp image/pubcloud/sle15/config.sh dist/config.sh
+
 setup:
 	poetry install --all-extras
 

--- a/image/generic/sle16/SLES16-Migration.changes
+++ b/image/generic/sle16/SLES16-Migration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 22 13:34:52 UTC 2025 - Marcus Schäfer <marcus.schaefer@suse.com>
+
+- Add etc/motd overlay file
+
+  Print message how to show migration progress information
+
+-------------------------------------------------------------------
 Fri Jun 27 11:48:55 UTC 2025 - Frederic Crozat <fcrozat@suse.com>
 
 - Fix build on more architectures

--- a/image/generic/sle16/root/etc/motd
+++ b/image/generic/sle16/root/etc/motd
@@ -1,0 +1,7 @@
+Migration System:
+
+If no progress is shown on this terminal watch via
+
+    tail -f /system-root/var/log/distro_migration.log
+
+Have a lot of fun :-)

--- a/image/pubcloud/sle15/root/etc/motd
+++ b/image/pubcloud/sle15/root/etc/motd
@@ -1,0 +1,7 @@
+Migration System:
+
+If no progress is shown on this terminal watch via
+
+    tail -f /system-root/var/log/distro_migration.log
+
+Have a lot of fun :-)

--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -51,6 +51,7 @@ Requires:         util-linux
 Requires:         kexec-tools
 Requires:         ca-certificates
 Requires:         dialog
+Requires:         kbd
 Requires:         rsync
 Requires:         suseconnect-ng
 Requires:         suse-migration-services = %{version}-%{release}

--- a/systemd/suse-migration-console-log.service
+++ b/systemd/suse-migration-console-log.service
@@ -5,18 +5,19 @@ DefaultDependencies=no
 After=systemd-vconsole-setup.service suse-migration-prepare.service
 Wants=systemd-vconsole-setup.service
 Conflicts=emergency.service emergency.target
+ConditionPathExists=/dev/tty8
 
 [Service]
-ExecStart=/usr/bin/dialog --tailbox /system-root/var/log/distro_migration.log 60 75
-Type=simple
-Restart=on-failure
-RestartSec=2
-StandardInput=tty-force
-StandardOutput=inherit
-StandardError=inherit
-KillMode=process
-IgnoreSIGPIPE=no
-KillSignal=SIGHUP
+ExecStart=/bin/bash -c "/usr/bin/dialog --tailbox /system-root/var/log/distro_migration.log 60 75; chvt 1"
+ExecStartPre=/usr/bin/chvt 8
+Type=idle
+Restart=always
+RestartSec=10
+StandardInput=tty
+StandardOutput=tty
+StandardError=tty
+TTYPath=/dev/tty8
+TTYReset=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The console logging was based on forcing a dialog program on the main console. If the main console also runs a getty which is by default the case we run into several signal conflicts. This battle is always won by the getty because it restarts always whereas the console log service only restarts on failure. This leads to very weird conditions such as no log displayed on the console at all up to only a fraction of the log shown leading to wrong assumptions on the current state of the migration. This commit now changes the following:

1. The console log is forced into its own tty (8) and the service actively switches to this terminal

2. If the dialog ends (e.g user hits Exit) the service switches back to the first virtual terminal and restarts after 10 seconds. This is enough time to stop the log service in case it's unwanted, e.g. for debugging on this console

3. The dialog logging does no longer run on serial terminals. dialog does not really support to work well on serial consoles. The output is often completely broken and input sequences requires its own terminal. If the migration system is accessed from a terminal that doesn't show progress information a message in etc/motd has been added which provides information how to see progress