### PR TITLE
Install patterns-base-selinux for Apparmor migration

### DIFF
--- a/suse_migration_services/units/update_bootloader.py
+++ b/suse_migration_services/units/update_bootloader.py
@@ -22,6 +22,7 @@ import logging
 from suse_migration_services.command import Command
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.logger import Logger
+from suse_migration_services.zypper import Zypper
 
 
 def main():
@@ -46,25 +47,20 @@ def install_shim_package(root_path):
     """
     Install the shim package
     """
-    bash_command = ' '.join(
+    Zypper.run(
         [
-            'zypper',
             '--no-cd',
             '--non-interactive',
             '--gpg-auto-import-keys',
             '--root', root_path,
-            'in',
+            'install',
             '--auto-agree-with-licenses',
             '--allow-vendor-change',
             '--download', 'in-advance',
             '--replacefiles',
             '--allow-downgrade',
             'shim',
-            '&>>', Defaults.get_migration_log_file()
         ]
-    )
-    Command.run(
-        ['bash', '-c', bash_command]
     )
 
 

--- a/suse_migration_services/zypper.py
+++ b/suse_migration_services/zypper.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2018 SUSE Linux LLC.  All rights reserved.
+#
+# This file is part of suse-migration-services.
+#
+# suse-migration-services is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# suse-migration-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
+#
+
+
+# project
+from suse_migration_services.command import Command
+from suse_migration_services.defaults import Defaults
+from suse_migration_services.exceptions import (
+    DistMigrationZypperException
+)
+
+
+class Zypper:
+    """
+    **Implements zypper invocation**
+    """
+
+    @staticmethod
+    def run(args: list[str], raise_on_error=True):
+        """
+        Invoke zypper and block the caller. The return value is a `ZypperCall` instance
+        containing the result of invocation.
+
+        The `raise_on_error` is directly passed to the underlying `Command.run` invocation
+        and thus will raise whenever zypper exists with a non-zero status. To check the status
+        according to zypper sematics, use `raise_on_error = False` with `ZypperCall.success` and
+        `ZypperCall.raise_if_failed`.
+        """
+        log_file = Defaults.get_migration_log_file()
+        command = ' '.join(['zypper'] + list(args) + ['&>>', log_file])
+
+        try:
+            result = Command.run(['bash', '-c', command], raise_on_error=raise_on_error)
+        except Exception as e:
+            raise DistMigrationZypperException('{0} failed with: {1}'.format(
+                command, str(e)
+            ))
+
+        return ZypperCall(args, command, result)
+
+
+class ZypperCall:
+    def __init__(self, args: list[str], command, result):
+        self.args = args
+        self.command = command
+        self.output = result.output
+        self.error = result.error
+        self.returncode = result.returncode
+
+    @property
+    def success(self):
+        """
+        Evaluate the return code of zypper call
+
+        In zypper any return code == 0 or >= 100 is considered success.
+        Any return code different from 0 and < 100 is treated as an
+        error we care for. Return codes >= 100 indicates an issue
+        like 'new kernel needs reboot of the system' or similar which
+        we don't care in the scope of image building
+
+        :return: True|False
+
+        :rtype: boolean
+        """
+        error_codes = [
+            104,  # ZYPPER_EXIT_INF_CAP_NOT_FOUND
+            105,  # ZYPPER_EXIT_ON_SIGNAL
+            106,  # ZYPPER_EXIT_INF_REPOS_SKIPPED
+        ]
+
+        if self.returncode == 0:
+            # All is good
+            return True
+        elif self.returncode in error_codes:
+            return False
+        elif self.returncode >= 100:
+            # Treat all other 100 codes as non error codes
+            return True
+
+        # Treat any other error code as error
+        return False
+
+    def raise_if_failed(self):
+        """
+        Raise `DistMigationZypperException` if zypper exited unsuccessfully.
+        """
+        if self.success:
+            return
+
+        raise DistMigrationZypperException(
+            '{0} failed with: {1}: {2}'.format(
+                self.command, self.output, self.error
+            )
+        )

--- a/test/unit/units/apparmor_migration_test.py
+++ b/test/unit/units/apparmor_migration_test.py
@@ -10,8 +10,9 @@ from suse_migration_services.exceptions import (
 
 @patch('suse_migration_services.logger.Logger.setup')
 class TestAppArmorMigration(object):
+    @patch('suse_migration_services.zypper.Zypper.run')
     @patch('suse_migration_services.defaults.Defaults.get_grub_default_file')
-    def test_main(self, mock_get_grub_default_file, mock_logger_setup):
+    def test_main(self, mock_get_grub_default_file, mock_Zypper_run, mock_logger_setup):
         test_data = NamedTemporaryFile()
         with open(test_data.name, 'w') as f:
             f.write(
@@ -22,6 +23,21 @@ class TestAppArmorMigration(object):
         with open(test_data.name) as f:
             assert f.read() == \
                 'GRUB_CMDLINE_LINUX_DEFAULT="splash=silent security=selinux"'
+        mock_Zypper_run.assert_called_once_with(
+            [
+                '--no-cd',
+                '--non-interactive',
+                '--gpg-auto-import-keys',
+                '--root', '/system-root',
+                'install',
+                '--auto-agree-with-licenses',
+                '--allow-vendor-change',
+                '--download', 'in-advance',
+                '--replacefiles',
+                '--allow-downgrade',
+                'patterns-base-selinux'
+            ]
+        )
 
     @patch('fileinput.input')
     def test_main_raises(self, mock_fileinput, mock_logger_setup):

--- a/test/unit/units/update_bootloader_test.py
+++ b/test/unit/units/update_bootloader_test.py
@@ -11,25 +11,26 @@ class TestUpdateBootloader:
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
+    @patch('suse_migration_services.zypper.Zypper.run')
     @patch('suse_migration_services.command.Command.run')
-    def test_main(self, mock_Command_run, mock_logger_setup):
+    def test_main(self, mock_Command_run, mock_Zypper_run, mock_logger_setup):
         main()
+        mock_Zypper_run.assert_called_once_with(
+            [
+                '--no-cd',
+                '--non-interactive',
+                '--gpg-auto-import-keys',
+                '--root', '/system-root',
+                'install',
+                '--auto-agree-with-licenses',
+                '--allow-vendor-change',
+                '--download', 'in-advance',
+                '--replacefiles',
+                '--allow-downgrade',
+                'shim'
+            ]
+        )
         assert mock_Command_run.call_args_list == [
-            call(
-                [
-                    'bash', '-c',
-                    'zypper --no-cd --non-interactive --gpg-auto-import-keys '
-                    '--root /system-root '
-                    'in '
-                    '--auto-agree-with-licenses '
-                    '--allow-vendor-change '
-                    '--download in-advance '
-                    '--replacefiles '
-                    '--allow-downgrade '
-                    'shim '
-                    '&>> /system-root/var/log/distro_migration.log'
-                ]
-            ),
             call(
                 [
                     'chroot', '/system-root',

--- a/test/unit/zypper_test.py
+++ b/test/unit/zypper_test.py
@@ -1,0 +1,110 @@
+from unittest.mock import patch
+from pytest import raises
+from collections import namedtuple
+
+from suse_migration_services.zypper import Zypper, ZypperCall
+
+from suse_migration_services.exceptions import (
+    DistMigrationZypperException
+)
+
+
+@patch('suse_migration_services.command.Command.run')
+class TestCommand(object):
+    def test_zypper_run(self, mock_Command_run):
+        command_run_result = namedtuple(
+            'command', ['output', 'error', 'returncode']
+        )
+        mock_Command_run.return_value = command_run_result(
+            output='', error='', returncode=0
+        )
+        Zypper.run(['in', 'test', '--root', '/system-root'])
+        mock_Command_run.assert_called_once_with(
+            [
+                'bash', '-c',
+                'zypper in test --root /system-root '
+                '&>> /system-root/var/log/distro_migration.log'
+            ], raise_on_error=True
+        )
+
+    def test_zypper_raises(self, mock_Command_run):
+        mock_Command_run.side_effect = Exception
+        with raises(DistMigrationZypperException):
+            Zypper.run([])
+
+    def test_zypper_dont_raise_on_error(self, mock_Command_run):
+        command_run_result = namedtuple(
+            'command', ['output', 'error', 'returncode']
+        )
+        mock_Command_run.return_value = command_run_result(
+            output='', error='', returncode=1
+        )
+        zypper_call = Zypper.run(['in', 'test', '--root', '/system-root'], raise_on_error=False)
+        mock_Command_run.assert_called_once_with(
+            [
+                'bash', '-c',
+                'zypper in test --root /system-root '
+                '&>> /system-root/var/log/distro_migration.log'
+            ], raise_on_error=False
+        )
+
+        assert not zypper_call.success
+        with raises(DistMigrationZypperException):
+            zypper_call.raise_if_failed()
+
+    def test_zypper_call_failed(self, mock_Command_run):
+        command_run_result = namedtuple(
+            'command', ['output', 'error', 'returncode']
+        )
+
+        # zypper exit code is 0, all ok
+        result = command_run_result(
+            output='', error='', returncode=0
+        )
+        zypper_call = ZypperCall([], '', result)
+        assert zypper_call.success
+        zypper_call.raise_if_failed()
+
+        # zypper exit code is 1, error
+        result = command_run_result(
+            output='', error='', returncode=1
+        )
+        zypper_call = ZypperCall([], '', result)
+        assert not zypper_call.success
+        with raises(DistMigrationZypperException):
+            zypper_call.raise_if_failed()
+
+        # zypper exit code is 104, error
+        result = command_run_result(
+            output='', error='', returncode=104
+        )
+        zypper_call = ZypperCall([], '', result)
+        assert not zypper_call.success
+        with raises(DistMigrationZypperException):
+            zypper_call.raise_if_failed()
+
+        # zypper exit code is 105, error
+        result = command_run_result(
+            output='', error='', returncode=105
+        )
+        zypper_call = ZypperCall([], '', result)
+        assert not zypper_call.success
+        with raises(DistMigrationZypperException):
+            zypper_call.raise_if_failed()
+
+        # zypper exit code is 106, error
+        result = command_run_result(
+            output='', error='', returncode=106
+        )
+        zypper_call = ZypperCall([], '', result)
+        assert not zypper_call.success
+        with raises(DistMigrationZypperException):
+            zypper_call.raise_if_failed()
+
+        # zypper exit code is 107, ok
+        result = command_run_result(
+            output='', error='', returncode=107
+        )
+        zypper_call = ZypperCall([], '', result)
+        assert zypper_call.success
+        zypper_call.raise_if_failed()


### PR DESCRIPTION
Install patterns-base-selinux for Apparmor migration. This is necessary to make SELinux enabled after migration.

Fix bsc#1246219.