### PR TITLE
Fix ordering of pre-checks and actual migration

### DIFF
--- a/systemd/suse-migration.service
+++ b/systemd/suse-migration.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Run Zypper Migration
-After=suse-migration-product-setup.service
+After=suse-migration-product-setup.service suse-migration-pre-checks.service
 Requisite=suse-migration-product-setup.service
 
 [Service]


### PR DESCRIPTION
Make sure the pre-checks service runs before the actual migration. As pre-checks are also called with the --fix option it is mandatory to run it prior the actual migration such that fixes becomes effective. This is related to #341