### PR TITLE
Drop obsolete check for resolv.conf

### DIFF
--- a/suse_migration_services/units/setup_name_resolver.py
+++ b/suse_migration_services/units/setup_name_resolver.py
@@ -49,11 +49,6 @@ def main():
     resolv_conf = os.sep.join(
         [root_path, 'etc', 'resolv.conf']
     )
-    if not os.path.exists(resolv_conf):
-        raise DistMigrationNameResolverException(
-            'Could not find {0} on migration host'.format(resolv_conf)
-        )
-
     try:
         log.info('Running setup resolver service')
         if has_host_resolv_setup(resolv_conf):

--- a/test/unit/units/setup_name_resolver_test.py
+++ b/test/unit/units/setup_name_resolver_test.py
@@ -13,16 +13,6 @@ from suse_migration_services.exceptions import (
 
 
 class TestSetupNameResolver(object):
-    @patch('suse_migration_services.logger.Logger.setup')
-    @patch('os.path.exists')
-    @patch('suse_migration_services.units.setup_name_resolver.Fstab')
-    def test_main_resolv_conf_not_present(
-        self, mock_Fstab, mock_os_path_exists, mock_logger_setup
-    ):
-        mock_os_path_exists.return_value = False
-        with raises(DistMigrationNameResolverException):
-            main()
-
     @patch('suse_migration_services.units.setup_name_resolver.has_host_resolv_setup')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')


### PR DESCRIPTION
There is a file check for a resolv.conf file at a very early stage of setup_host_network.py. This check shadows the init log information and is also pointless because further on in the code there is a proper handling for the resolv.conf presence via has_host_resolv_setup(resolv_conf). This Fixes #341