### PR TITLE
Add proper release package for SLE16 migration

### DIFF
--- a/image/generic/sle16/config.kiwi
+++ b/image/generic/sle16/config.kiwi
@@ -99,5 +99,6 @@
         <package name="glibc-locale"/>
         <package name="cracklib-dict-full"/>
         <package name="ca-certificates"/>
+        <package name="SLES-release"/>
     </packages>
 </image>


### PR DESCRIPTION
Make sure to install sles-release otherwise the ALP-dummy-release is installed by default which leads to a broken zypper migration because the target product is wrong. This is partially related to Issue #349