### PR TITLE
Fix error evaluation from offline_migrations API

### DIFF
--- a/suse_migration_services/prechecks/scc.py
+++ b/suse_migration_services/prechecks/scc.py
@@ -83,9 +83,10 @@ def request_migration_offer(
             uri, json=data, auth=(user, secret), headers=headers
         )
         offline_migrations = response.json()
-        result_error = offline_migrations.get('error')
-        if result_error:
-            log.error(result_error)
+        if isinstance(offline_migrations, dict):
+            result_error = offline_migrations.get('error')
+            if result_error:
+                log.error(result_error)
     except Exception as issue:
         log.error(
             'Post request to {} failed with {}'.format(


### PR DESCRIPTION
SCC provides the systems/products/offline_migrations API which is used by the DMS to check if there is an upgrade path available. In case of an existing upgrade path the response data type is a list of dicts. In case of an error the response datatype is just a dict. Checking for get() on a list type leads to an exception reported as a problem with the upgrade path. This commit fixes it.