### PR TITLE
Make activation package require by provides tag

### DIFF
--- a/image/package/suse-migration-rpm/image.spec.in
+++ b/image/package/suse-migration-rpm/image.spec.in
@@ -12,6 +12,7 @@ License:        SUSE-EULA
 Source0:        __SOURCE__
 Requires:       __PRODUCT__
 Requires:       suse-migration-pre-checks
+Provides:       Migration = __VERSION__
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description

--- a/package/suse-migration-sle15-activation-spec-template
+++ b/package/suse-migration-sle15-activation-spec-template
@@ -26,7 +26,7 @@ BuildRoot:        %{_tmppath}/%{name}-%{version}-build
 BuildArch:        noarch
 Conflicts:        suse-migration-services
 BuildRequires:    grub2
-Requires:         SLES15-Migration >= 2.1.2
+Requires:         Migration >= 2.1.2
 
 Requires:         grub2
 

--- a/package/suse-migration-sle16-activation-spec-template
+++ b/package/suse-migration-sle16-activation-spec-template
@@ -26,7 +26,7 @@ BuildRoot:        %{_tmppath}/%{name}-%{version}-build
 BuildArch:        noarch
 Conflicts:        suse-migration-services
 BuildRequires:    grub2
-Requires:         SLES16-Migration >= 2.1.2
+Requires:         Migration >= 2.1.2
 Requires:         grub2
 Requires(post):   util-linux-systemd
 Requires(postun): util-linux-systemd


### PR DESCRIPTION
With the introduction of product specific migrations packaged up in different package names we can no longer make the activation package require a specific package. Instead the activation requires a capability which can be provided by different packages