### PR TITLE
Remove menitoning of SLES 12-SP4

### DIFF
--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -106,7 +106,6 @@ Upgrade is supported from SLES12 SP5 to SLES 15 SP3. It is possible to
 configure other versions of SLES as the migration target, but doing so
 is not a tested or supported use case.
 
-Support for SLES12 SP4 will end December 31 2023. From 2024 onward
 SLES12 SP5 is the only supported migration starting point.
 
 == Upgrade Pre-Checks


### PR DESCRIPTION
Since support for SLES 12-SP4 has ended in 2023, there is no need to mention that the support will phase out. Remove the mentioning of SLES 12-SP4.