### PR TITLE
Fixed glob pattern match for package name

### DIFF
--- a/suse_migration_services/units/grub_setup.py
+++ b/suse_migration_services/units/grub_setup.py
@@ -44,7 +44,7 @@ def main():
     try:
         log.info('Running grub setup service')
         migration_packages = [
-            'SLE*-Migration',
+            'SLE*Migration',
             'suse-migration-*-activation'
         ]
         log.info(

--- a/test/unit/units/grub_setup_test.py
+++ b/test/unit/units/grub_setup_test.py
@@ -31,7 +31,7 @@ class TestGrubSetup(object):
                 [
                     'chroot', '/system-root',
                     'zypper', '--non-interactive', '--no-gpg-checks',
-                    'remove', 'SLE*-Migration',
+                    'remove', 'SLE*Migration',
                     'suse-migration-*-activation'
                 ], raise_on_error=False
             ),


### PR DESCRIPTION
The glob match for the name of the migration live image does not take product specific live images into account Example: SLES15-Migration and SLES15-SAP_Migration