### PR TITLE
Fix booting issue for some architectures

### DIFF
--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -56,9 +56,11 @@ for host_boot_option in $(xargs -n1 < /proc/cmdline);do
     boot_options="${boot_options} ${host_boot_option}"
 done
 
+ARCH=$(uname -m)
+
 if grub_file_is_not_garbage "${migration_iso}"; then
-    kernel="(loop)/boot/x86_64/loader/linux"
-    initrd="(loop)/boot/x86_64/loader/initrd"
+    kernel="(loop)/boot/${ARCH}/loader/linux"
+    initrd="(loop)/boot/${ARCH}/loader/initrd"
     boot_device_id="$(grub_get_device_id "${GRUB_DEVICE_BOOT}")"
     printf "menuentry '%s' %s \${menuentry_id_option} '%s' {\n" \
         "${OS}" "${CLASS}" "Migration-${boot_device_id}"
@@ -74,10 +76,12 @@ if grub_file_is_not_garbage "${migration_iso}"; then
         "${migration_iso}"
     printf "    set linux=linux\n"
     printf "    set initrd=initrd\n"
-    printf "    if [ \"\${grub_platform}\" = \"efi\" ]; then\n"
-    printf "        set linux=linuxefi\n"
-    printf "        set initrd=initrdefi\n"
-    printf "    fi\n"
+    if [ "$ARCH" = "x86_64" ]; then
+       printf "    if [ \"\${grub_platform}\" = \"efi\" ]; then\n"
+       printf "        set linux=linuxefi\n"
+       printf "        set initrd=initrdefi\n"
+       printf "    fi\n"
+    fi
     printf "    loopback loop (\$root)\$isofile\n"
     printf "    \$linux %s iso-scan/filename=\$isofile %s\n" \
         "${kernel}" "${boot_options}"

--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -16,6 +16,7 @@
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import platform
 from collections import namedtuple
 
 
@@ -69,7 +70,18 @@ class Defaults:
 
     @staticmethod
     def get_target_kernel():
-        return 'boot/vmlinuz'
+        machine = platform.machine()
+        if machine == "x86_64":
+            return 'boot/vmlinuz'
+        elif machine == "aarch64":
+            return 'boot/Image'
+        elif machine == "ppc64le":
+            return 'boot/vmlinux'
+        elif machine == "s390x":
+            return 'boot/image'
+        else:
+            raise NotImplementedError(
+                f'get_target_kernel not implemented for machine type {machine}')
 
     @staticmethod
     def get_target_initrd():

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import (
     patch, MagicMock
 )
+from pytest import raises
 import io
 from collections import namedtuple
 
@@ -18,6 +19,20 @@ class TestDefaults(object):
     def test_get_grub_default_file(self):
         assert self.defaults.get_grub_default_file() == \
             '/system-root/etc/default/grub'
+
+    def test_get_target_kernel(self):
+        with patch('platform.machine') as mock_platform_machine:
+            mock_platform_machine.return_value = 'x86_64'
+            assert self.defaults.get_target_kernel() == 'boot/vmlinuz'
+            mock_platform_machine.return_value = 'aarch64'
+            assert self.defaults.get_target_kernel() == 'boot/Image'
+            mock_platform_machine.return_value = 'ppc64le'
+            assert self.defaults.get_target_kernel() == 'boot/vmlinux'
+            mock_platform_machine.return_value = 's390x'
+            assert self.defaults.get_target_kernel() == 'boot/image'
+            mock_platform_machine.return_value = 'unknown_platform'
+            with raises(NotImplementedError):
+                self.defaults.get_target_kernel()
 
     def test_get_os_release(self):
         os_release_tuple = namedtuple(


### PR DESCRIPTION
There are differences across architectures (e.g. naming of kernel files) which might prevent migration image from booting, or causing failures in pre-checks. This PR contains fixes for those issues.

For s390x we still need to discuss and decide how to boot since on that platform there are issues with grub loopbacks, so this PR leave it out for now; booting on aarch64 and ppc64le should work with this PR.

Fix bsc#1246225 (except for s390x) and bsc#1246907.