### PR TITLE
Workaround for enable booting on s390x

### DIFF
--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -59,8 +59,13 @@ done
 ARCH=$(uname -m)
 
 if grub_file_is_not_garbage "${migration_iso}"; then
-    kernel="(loop)/boot/${ARCH}/loader/linux"
-    initrd="(loop)/boot/${ARCH}/loader/initrd"
+    if [ "$ARCH" != "s390x" ]; then # Workaround for s390x grub loopback issues
+	kernel="(loop)/boot/${ARCH}/loader/linux"
+	initrd="(loop)/boot/${ARCH}/loader/initrd"
+    else
+	kernel="/migration-image/linux"
+	initrd="/migration-image/initrd"
+    fi
     boot_device_id="$(grub_get_device_id "${GRUB_DEVICE_BOOT}")"
     printf "menuentry '%s' %s \${menuentry_id_option} '%s' {\n" \
         "${OS}" "${CLASS}" "Migration-${boot_device_id}"
@@ -71,7 +76,9 @@ if grub_file_is_not_garbage "${migration_iso}"; then
     fi
     printf "    insmod lvm\n"
     printf "    insmod %s\n" "${image_fs_type}"
-    printf "    search --no-floppy --fs-uuid --set=root %s\n" "${image_fs_uuid}"
+    if [ "$ARCH" != "s390x" ]; then # search does not work on s390x yet
+	printf "    search --no-floppy --fs-uuid --set=root %s\n" "${image_fs_uuid}"
+    fi
     printf "    set isofile='%s'\n" \
         "${migration_iso}"
     printf "    set linux=linux\n"
@@ -82,7 +89,9 @@ if grub_file_is_not_garbage "${migration_iso}"; then
        printf "        set initrd=initrdefi\n"
        printf "    fi\n"
     fi
-    printf "    loopback loop (\$root)\$isofile\n"
+    if [ "$ARCH" != "s390x" ]; then # Wrokaround for s390x grub loopback issues
+	printf "    loopback loop (\$root)\$isofile\n"
+    fi
     printf "    \$linux %s iso-scan/filename=\$isofile %s\n" \
         "${kernel}" "${boot_options}"
     printf "    \$initrd %s\n" \

--- a/image/package/suse-migration-rpm.spec
+++ b/image/package/suse-migration-rpm.spec
@@ -28,6 +28,7 @@ BuildRequires:  filesystem
 Requires:       suse-migration-services
 Requires:       build
 Requires:       perl(Date::Parse)
+Requires:       p7zip-full
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description

--- a/image/package/suse-migration-rpm/image.spec.in
+++ b/image/package/suse-migration-rpm/image.spec.in
@@ -14,6 +14,9 @@ Requires:       __PRODUCT__
 Requires:       suse-migration-pre-checks
 Provides:       Migration = __VERSION__
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+%ifarch s390x
+BuildRequires:  p7zip-full
+%endif
 
 %description
 This package contains the Migration Live System.
@@ -27,6 +30,10 @@ install -d -m 755 $RPM_BUILD_ROOT/migration-image
 install -d -m 755 $RPM_BUILD_ROOT/%{_sbindir}
 cp %{SOURCE0} $RPM_BUILD_ROOT/migration-image
 cp %{_sbindir}/run_migration $RPM_BUILD_ROOT/%{_sbindir}
+%ifarch s390x
+# Workaround for s390x grub loopback issues
+7z e %{SOURCE0} -o$RPM_BUILD_ROOT/migration-image boot/s390x/loader/linux boot/s390x/loader/initrd
+%endif
 
 %post
 /usr/bin/suse-migration-pre-checks


### PR DESCRIPTION
This is a workaround for booting on s390x.

For now we haven't decided how to move forward with booting on s390x, so I'm creating this as a draft; basically this workaround is to extract the kernel and the initrd directly to the local filesystem and let grub boot from there. This fixes bsc#1245225.

Let me know your opinions about the workaround, and if there's some better method to solve this...