### PR TITLE
Use systemctl kexec

### DIFF
--- a/tools/run_migration
+++ b/tools/run_migration
@@ -136,4 +136,4 @@ kexec \
     --initrd "${boot_dir}/initrd" \
     --kexec-file-syscall \
     --command-line "$(get_boot_options "${migration_iso}")"
-kexec --exec
+systemctl kexec


### PR DESCRIPTION
Instead of direct kexec --exec let the system shutdown in a controlled way and run kexec through systemd. This is related to Issue #365