### PR TITLE
do not build sles4sap migration on s390x

### DIFF
--- a/image/product/sle16/sles_sap/config.kiwi
+++ b/image/product/sle16/sles_sap/config.kiwi
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- OBS-ExclusiveArch: ppc64le x86_64 s390x -->
+<!-- OBS-ExclusiveArch: ppc64le x86_64 -->
 
 <image schemaversion="7.4" name="SLES16-SAP_Migration">
     <description type="system">


### PR DESCRIPTION
SLES for SAP is only available on x86_64 and ppc64le, do not build it for other architectures.