### PR TITLE
Setup ExclusiveArch for activation packages

### DIFF
--- a/package/suse-migration-sle15-activation-spec-template
+++ b/package/suse-migration-sle15-activation-spec-template
@@ -27,8 +27,8 @@ BuildArch:        noarch
 Conflicts:        suse-migration-services
 BuildRequires:    grub2
 Requires:         Migration >= 2.1.2
-
 Requires:         grub2
+ExclusiveArch:    aarch64 x86_64
 
 %description -n suse-migration-sle15-activation
 Script code to activate the SLE15 migration image to be booted at

--- a/package/suse-migration-sle16-activation-spec-template
+++ b/package/suse-migration-sle16-activation-spec-template
@@ -31,6 +31,7 @@ Requires:         grub2
 Requires(post):   util-linux-systemd
 Requires(postun): util-linux-systemd
 Requires(pre):	  sed
+ExclusiveArch:    aarch64 ppc64le x86_64
 
 %description -n suse-migration-sle16-activation
 Script code to activate the SLE16 migration image to be booted at


### PR DESCRIPTION
For migrations of SLE12 to SLE15 the DMS was used in the cloud context only. grub based activation is supported there only on x86_64 and aarch64

For migrations of SLE15 to SLE16 the DMS is used in a broader context across SUSE products and architectures. grub based activation is supported for all archs except s390. On s390 we support the kexec (run_migration) based method for activation only.

This commit sets the ExclusiveArch option respectively