### PR TITLE
Follow up fix for the wicked to nm migration

### DIFF
--- a/suse_migration_services/units/wicked_migration.py
+++ b/suse_migration_services/units/wicked_migration.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
+import os
 import logging
 import glob
 
@@ -56,12 +57,18 @@ def main():
         )
 
         log.info('Copy connections to migrated system')
-        Command.run(
-            ['mkdir', '-p', root_path + '/etc/NetworkManager/system-connections']
+        nm_connection_pattern = \
+            '/etc/NetworkManager/system-connections/*.nmconnection'
+        nm_connections_path = os.path.normpath(
+            os.sep.join([root_path, 'etc/NetworkManager/system-connections'])
         )
         Command.run(
-            ['cp'] + glob.glob('/etc/NetworkManager/system-connections/*.nmconnection') + [root_path + '/etc/NetworkManager/system-connections/']
+            ['mkdir', '-p', nm_connections_path]
         )
+        for connection in sorted(glob.iglob(nm_connection_pattern)):
+            Command.run(
+                ['cp', connection, nm_connections_path]
+            )
     except Exception as issue:
         message = 'wicked to NetworkManager migration failed with {}'.format(
             issue

--- a/test/unit/units/wicked_migration_test.py
+++ b/test/unit/units/wicked_migration_test.py
@@ -12,7 +12,11 @@ from suse_migration_services.exceptions import (
 @patch('suse_migration_services.logger.Logger.setup')
 class TestMigrationWicked(object):
     @patch('suse_migration_services.command.Command.run')
-    def test_main(self, mock_Command_run, mock_logger_setup):
+    @patch('glob.iglob')
+    def test_main(self, mock_iglob, mock_Command_run, mock_logger_setup):
+        mock_iglob.return_value = [
+            '/etc/NetworkManager/system-connections/some.nmconnection'
+        ]
         main()
         assert mock_Command_run.call_args_list == [
             call(
@@ -35,7 +39,9 @@ class TestMigrationWicked(object):
             ),
             call(
                 [
-                    'cp', '/system-root/etc/NetworkManager/system-connections/'
+                    'cp',
+                    '/etc/NetworkManager/system-connections/some.nmconnection',
+                    '/system-root/etc/NetworkManager/system-connections'
                 ]
             )
         ]


### PR DESCRIPTION
The unit test to cover the copy of nm connection files did not mock the glob call which leads to broken test runs on systems that uses nm connections. This commit fixes that part. The commit also fixes the way the cp call is issued with the result of a glob call. In case glob does not match the cp call would be done with only one parameter and would cause a raise condition which I believe is unwanted. If there are no nm connection files the code should just not copy them. This commit also changes that part along with the broken unit test.