### PR TITLE
Store snapper pre snapshot in run_migration

### DIFF
--- a/image/package/suse-migration-rpm/image.spec.in
+++ b/image/package/suse-migration-rpm/image.spec.in
@@ -38,5 +38,6 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-, root, root)
 /migration-image
 %{_sbindir}/run_migration
+%ghost /var/cache/suse_migration_snapper_btrfs_pre_snapshot_number
 
 %changelog

--- a/tools/run_migration
+++ b/tools/run_migration
@@ -104,6 +104,23 @@ function extract_kernel_and_initrd {
     fi
 }
 
+function store_snapper_pre_snapshot {
+    # """
+    # Store snapper pre snapshot if available
+    # """
+    if [ -x /usr/bin/snapper ]; then
+	PRE_SNAPSHOT=$(\
+		       snapper -c root --machine-readable csv list --disable-used-space\
+			       --columns subvolume,number,type 2>/dev/null |\
+			   grep '^/,[^,]*,pre' |\
+			   sed -e '$!d' -e 's|/,\([^,]*\),pre|\1|g'\
+		    )
+	if [ "$PRE_SNAPSHOT" != "" ]; then
+	    echo "$PRE_SNAPSHOT" > /var/cache/suse_migration_snapper_btrfs_pre_snapshot_number
+	fi
+    fi
+}
+
 # Check on permissions
 if (( EUID != 0 )); then
     echo "Migration startup requires root permissions"
@@ -129,6 +146,9 @@ if [ ! -e "${boot_dir}" ];then
     echo "Failed to extract boot files"
     exit 1
 fi
+
+# Store snapper pre snapshot for rollback
+store_snapper_pre_snapshot
 
 # Run Migration
 kexec \


### PR DESCRIPTION
The migration process is activated by either of two processes: the installation of the activation package, or the run_migration script. We store snapper pre snapshot in %pre in the first way, but didn't do that when the migration is initialized by run_migration before. This PR adds the missing piece.