### PR TITLE
fix: add --no-recommends on patterns-base-selinux installation

### DIFF
--- a/suse_migration_services/units/apparmor_migration.py
+++ b/suse_migration_services/units/apparmor_migration.py
@@ -42,6 +42,7 @@ def install_patterns_base_selinux(root_path):
         '--download', 'in-advance',
         '--replacefiles',
         '--allow-downgrade',
+        '--no-recommends',
         'patterns-base-selinux'
     ])
 

--- a/test/unit/units/apparmor_migration_test.py
+++ b/test/unit/units/apparmor_migration_test.py
@@ -35,6 +35,7 @@ class TestAppArmorMigration(object):
                 '--download', 'in-advance',
                 '--replacefiles',
                 '--allow-downgrade',
+                '--no-recommends',
                 'patterns-base-selinux'
             ]
         )


### PR DESCRIPTION
This should avoid pulling in a large number of unnecessary packages.