### PR TITLE
Ensure wicked2nm migration is always running, despite warnings

### DIFF
--- a/image/product/sle16/sles_sap/SLES16-SAP_Migration.changes
+++ b/image/product/sle16/sles_sap/SLES16-SAP_Migration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Sep 12 13:00:01 UTC 2025 - Frederic Crozat <fcrozat@suse.com>
+
+- Version 2.1.19:
+  - Support wicked2nm migration
+
+-------------------------------------------------------------------
 Mon Aug 11 12:51:41 UTC 2025 - Marcus Schäfer <marcus.schaefer@suse.com>
 
 - Migration live image for SLES4SAP 15 to 16

--- a/image/product/sle16/sles_sap/root/etc/migration-config.yml
+++ b/image/product/sle16/sles_sap/root/etc/migration-config.yml
@@ -1,0 +1,3 @@
+soft_reboot: false
+network:
+  wicked2nm-continue-migration: true


### PR DESCRIPTION
Allow wicked2nm migration to run, even if there are warnings, to keep the same behavior as SLES16 migration.