### PR TITLE
Include image changelog to version bump

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -10,10 +10,13 @@ tag = True
 [bumpversion:file:image/pubcloud/sle15/config.kiwi]
 
 [bumpversion:file:image/pubcloud/product/sles_sap/config.kiwi]
+[bumpversion:file:image/pubcloud/product/sles_sap/SLES15-SAP_Migration.changes]
 
 [bumpversion:file:image/product/sle16/sles_sap/config.kiwi]
+[bumpversion:file:image/product/sle16/sles_sap/SLES16-SAP_Migration.changes]
 
 [bumpversion:file:image/generic/sle16/config.kiwi]
+[bumpversion:file:image/generic/sle16/SLES16-Migration.changes]
 
 [bumpversion:file:container/sle15/config.kiwi]
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,22 @@ tar: clean check test
 	# build the sdist source tarball
 	poetry build --format=sdist
 
+image_changelog:
+	for changelog in `find image -name "*Migration.changes"`; do \
+		pushd `dirname $$changelog` ;\
+		osc vc -m "Bump version: ${version}" ;\
+		popd ;\
+	done
+
+patch: image_changelog
+	poetry run bumpversion --allow-dirty patch
+
+minor: image_changelog
+	poetry run bumpversion --allow-dirty minor
+
+major: image_changelog
+	poetry run bumpversion --allow-dirty major
+
 build: tar
 	# provide rpm source tarball
 	mv dist/suse_migration_services-${version}.tar.gz \


### PR DESCRIPTION
Make sure the image changelog file also contains an entry to match with the version of the DMS