### PR TITLE
Apply sysctl to migration system

### DIFF
--- a/image/generic/sle16/config.sh
+++ b/image/generic/sle16/config.sh
@@ -81,7 +81,6 @@ chown -R migration:users /home/migration
 # Add s390 specific network rules to migration config
 if [ "$(arch)" = "s390x" ]; then
     cat <<EOF >> /etc/migration-config.yml
-preserve:
   rules:
     - /etc/udev/rules.d/*qeth*.rules
     - /etc/udev/rules.d/*-cio-ignore*.rules

--- a/image/generic/sle16/root/etc/migration-config.yml
+++ b/image/generic/sle16/root/etc/migration-config.yml
@@ -1,3 +1,7 @@
 soft_reboot: false
 network:
   wicked2nm-continue-migration: true
+preserve:
+  sysctl:
+  - /etc/sysctl.conf
+  - /etc/sysctl.d/*.conf

--- a/image/product/sle16/sles_sap/root/etc/migration-config.yml
+++ b/image/product/sle16/sles_sap/root/etc/migration-config.yml
@@ -1,3 +1,7 @@
 soft_reboot: false
 network:
   wicked2nm-continue-migration: true
+preserve:
+  sysctl:
+  - /etc/sysctl.conf
+  - /etc/sysctl.d/*.conf

--- a/suse_migration_services/schema.py
+++ b/suse_migration_services/schema.py
@@ -21,6 +21,11 @@ schema = {
                 'type': 'list',
                 'nullable': False
             },
+            'sysctl': {
+                'required': False,
+                'type': 'list',
+                'nullable': False
+            }
         }
     },
     'soft_reboot': {

--- a/suse_migration_services/units/post_mount_system.py
+++ b/suse_migration_services/units/post_mount_system.py
@@ -70,6 +70,10 @@ def main():
             Command.run(
                 ['udevadm', 'trigger', '--type=devices', '--action=add']
             )
+        if 'sysctl' in preserve_info.keys():
+            Command.run(
+                ['sysctl', '--system']
+            )
 
 
 def update_env(preserve_info):

--- a/test/data/migration-config.yml
+++ b/test/data/migration-config.yml
@@ -3,3 +3,5 @@ preserve:
   - /etc/udev/rules.d/*.rules
   static:
   - /etc/sysconfig/proxy
+  sysctl:
+  - /etc/sysctl.conf

--- a/test/unit/units/post_mount_system_test.py
+++ b/test/unit/units/post_mount_system_test.py
@@ -33,7 +33,7 @@ class TestPostMountSystem(object):
         mock_get_system_root_path.return_value = '../data'
         mock_get_migration_config_file.return_value = \
             '../data/migration-config.yml'
-        mock_os_path_exists.side_effect = [True, False, True, False]
+        mock_os_path_exists.side_effect = [True, False, True, False, True]
 
         def mock_glob_patterns(glob):
             if '*' in glob:
@@ -47,14 +47,16 @@ class TestPostMountSystem(object):
         assert mock_shutil_copy.call_args_list == [
             call('../data/etc/udev/rules.d/a.rules', '/etc/udev/rules.d'),
             call('../data/etc/udev/rules.d/b.rules', '/etc/udev/rules.d'),
-            call('../data/etc/sysconfig/proxy', '/etc/sysconfig')
+            call('../data/etc/sysconfig/proxy', '/etc/sysconfig'),
+            call('../data/etc/sysctl.conf', '/etc')
         ]
         assert mock_Command_run.call_args_list == [
             call(['mkdir', '-p', '/etc/udev/rules.d']),
             call(['mkdir', '-p', '/etc/sysconfig']),
             call(['udevadm', 'control', '--reload']),
             call(['udevadm', 'trigger', '--type=subsystems', '--action=add']),
-            call(['udevadm', 'trigger', '--type=devices', '--action=add'])
+            call(['udevadm', 'trigger', '--type=devices', '--action=add']),
+            call(['sysctl', '--system'])
         ]
 
     @patch.dict(os.environ, {'foo': 'bar', 'a': 'b'}, clear=True)


### PR DESCRIPTION
Sysctls are often times crucial for e.g. correct network connectivity. All files in the preserve: sysctl list are copied to the migration system post mount and then activated via `sysctl --system`.
For SLE16 it by default applies the sysctl configs present at `/etc/sysctl.conf` and `/etc/sysctl.d/*.conf`.