### PR TITLE
Add changes for newest wicked2nm

### DIFF
--- a/image/generic/sle16/root/etc/migration-config.yml
+++ b/image/generic/sle16/root/etc/migration-config.yml
@@ -1,6 +1,4 @@
 soft_reboot: false
-network:
-  wicked2nm-continue-migration: true
 preserve:
   sysctl:
   - /etc/sysctl.conf

--- a/image/product/sle16/sles_sap/root/etc/migration-config.yml
+++ b/image/product/sle16/sles_sap/root/etc/migration-config.yml
@@ -1,6 +1,4 @@
 soft_reboot: false
-network:
-  wicked2nm-continue-migration: true
 preserve:
   sysctl:
   - /etc/sysctl.conf

--- a/package/suse-migration-sle16-activation-spec-template
+++ b/package/suse-migration-sle16-activation-spec-template
@@ -64,7 +64,6 @@ fi
 if [ -x "$(command -v wicked)" ]; then
   mkdir -p /var/cache/wicked_config
   wicked show-config > /var/cache/wicked_config/config.xml
-  cp /etc/sysconfig/network/{config,dhcp} /var/cache/wicked_config/
 fi
 if [ -f /etc/udev/rules.d/70-persistent-net.rules ]; then
   mkdir -p /var/cache/udev_rules

--- a/suse_migration_services/units/setup_host_network.py
+++ b/suse_migration_services/units/setup_host_network.py
@@ -142,7 +142,8 @@ def wicked2nm_migrate(root_path):
     skipped.
     """
     log = logging.getLogger(Defaults.get_migration_log_name())
-    wicked_config_path = root_path + '/var/cache/wicked_config'
+    wicked_config_path = os.sep.join([root_path, 'var/cache/wicked_config'])
+    netconf_dir_path = os.sep.join([root_path, 'etc/sysconfig/network'])
     migration_config = MigrationConfig()
     net_info = migration_config.get_network_info()
 
@@ -159,8 +160,7 @@ def wicked2nm_migrate(root_path):
     log.info('Running wicked2nm')
     wicked2nm_cmd = [
         'wicked2nm', 'migrate', '--activate-connections',
-        '--netconfig-path', os.sep.join([wicked_config_path, 'config']),
-        '--netconfig-dhcp-path', os.sep.join([wicked_config_path, 'dhcp']),
+        '--netconfig-base-dir', netconf_dir_path,
         os.sep.join([wicked_config_path, 'config.xml'])
     ]
     if net_info and 'wicked2nm-continue-migration' in net_info and net_info['wicked2nm-continue-migration']:
@@ -171,8 +171,7 @@ def wicked2nm_migrate(root_path):
     except Exception as issue:
         wicked2nm_cmd = [
             'wicked2nm', 'show',
-            '--netconfig-path', os.sep.join([wicked_config_path, 'config']),
-            '--netconfig-dhcp-path', os.sep.join([wicked_config_path, 'dhcp']),
+            '--netconfig-base-dir', netconf_dir_path,
             os.sep.join([wicked_config_path, 'config.xml'])
         ]
         log.info(
@@ -202,7 +201,7 @@ def setup_interfaces(root_path):
     isn't present this part is skipped.
     """
     log = logging.getLogger(Defaults.get_migration_log_name())
-    migration_udev_rules = root_path + '/var/cache/udev_rules/70-migration-persistent-net.rules'
+    migration_udev_rules = os.sep.join([root_path, 'var/cache/udev_rules/70-migration-persistent-net.rules'])
 
     if not os.path.exists(migration_udev_rules):
         log.info('No migration udev rules present, skipping copy and application of migration rules')

--- a/test/unit/pre_checks_test.py
+++ b/test/unit/pre_checks_test.py
@@ -818,9 +818,8 @@ class TestPreChecks():
         mock_subprocess_check_output.assert_called_once_with(
             [
                 'wicked2nm', 'migrate', '--dry-run',
-                '--netconfig-path', '/system-root//var/cache/wicked_config/config',
-                '--netconfig-dhcp-path', '/system-root//var/cache/wicked_config/dhcp',
-                '/system-root//var/cache/wicked_config/config.xml'
+                '--netconfig-base-dir', '/system-root/etc/sysconfig/network',
+                '/system-root/var/cache/wicked_config/config.xml'
             ],
             stderr=-2
         )
@@ -841,9 +840,8 @@ class TestPreChecks():
         mock_subprocess_check_output.assert_called_once_with(
             [
                 'wicked2nm', 'migrate', '--dry-run',
-                '--netconfig-path', '/system-root//var/cache/wicked_config/config',
-                '--netconfig-dhcp-path', '/system-root//var/cache/wicked_config/dhcp',
-                '/system-root//var/cache/wicked_config/config.xml'
+                '--netconfig-base-dir', '/system-root/etc/sysconfig/network',
+                '/system-root/var/cache/wicked_config/config.xml'
             ],
             stderr=-2
         )
@@ -899,11 +897,16 @@ class TestPreChecks():
     ):
         mock_os_access.return_value = False
         mock_shutil_which.return_value = True
-        mock_subprocess_check_output.side_effect = subprocess.CalledProcessError(returncode=1, cmd=[], output=b'[ERROR] wicked2nm failed')
+        mock_subprocess_check_output.side_effect = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=[],
+            output=b'[ERROR] Migration failed because of warnings, use the `--continue-migration` flag to ignore'
+        )
 
         with self._caplog.at_level(logging.ERROR):
             check_wicked2nm.check_wicked2nm(migration_system=False)
-            assert '[ERROR] wicked2nm failed' in self._caplog.text
+            assert '[ERROR] Migration failed' in self._caplog.text
+            assert 'wicked2nm-continue-migration: true' in self._caplog.text
         mock_subprocess_Popen.assert_called_once_with(
             ['wicked', 'show-config'],
             stdout=subprocess.PIPE

--- a/test/unit/units/setup_host_network_test.py
+++ b/test/unit/units/setup_host_network_test.py
@@ -129,8 +129,7 @@ class TestSetupHostNetwork(object):
             call(
                 [
                     'wicked2nm', 'migrate', '--activate-connections',
-                    '--netconfig-path', '/system-root/var/cache/wicked_config/config',
-                    '--netconfig-dhcp-path', '/system-root/var/cache/wicked_config/dhcp',
+                    '--netconfig-base-dir', '/system-root/etc/sysconfig/network',
                     '/system-root/var/cache/wicked_config/config.xml'
                 ]
             ),
@@ -207,8 +206,7 @@ class TestSetupHostNetwork(object):
             call(
                 [
                     'wicked2nm', 'migrate', '--activate-connections',
-                    '--netconfig-path', '/system-root/var/cache/wicked_config/config',
-                    '--netconfig-dhcp-path', '/system-root/var/cache/wicked_config/dhcp',
+                    '--netconfig-base-dir', '/system-root/etc/sysconfig/network',
                     '/system-root/var/cache/wicked_config/config.xml', '--continue-migration'
                 ]
             ),
@@ -279,8 +277,7 @@ class TestSetupHostNetwork(object):
         assert call(
             [
                 'wicked2nm', 'show',
-                '--netconfig-path', '/system-root/var/cache/wicked_config/config',
-                '--netconfig-dhcp-path', '/system-root/var/cache/wicked_config/dhcp',
+                '--netconfig-base-dir', '/system-root/etc/sysconfig/network',
                 '/system-root/var/cache/wicked_config/config.xml'
             ],
             raise_on_error=False

--- a/tools/run_migration
+++ b/tools/run_migration
@@ -111,7 +111,6 @@ function setup_wicked_to_NetworkManager_prereqs {
     if [ -x "$(command -v wicked)" ]; then
         mkdir -p /var/cache/wicked_config
         wicked show-config > /var/cache/wicked_config/config.xml
-        cp /etc/sysconfig/network/{config,dhcp} /var/cache/wicked_config/
     fi
     if [ -f /etc/udev/rules.d/70-persistent-net.rules ]; then
         mkdir -p /var/cache/udev_rules


### PR DESCRIPTION
With the new wicked2nm version 1.3.0 hopefully wicked2nm-continue-migration is less necessary so this removes the default true in SLE16. Also there are some changes to the netconfig handling so it makes more sense to read the base netconfig dir instead of copying the files to '/var/cache/wicked_config'.
I've also added an explanation to the pre-checks to explain how to apply the `--continue-migration` flag to the migration.