### PR TITLE
Implement x86_64 architecture version check as a pre-check

### DIFF
--- a/package/suse-migration-sle16-activation-spec-template
+++ b/package/suse-migration-sle16-activation-spec-template
@@ -46,7 +46,7 @@ install -D -m 755 grub.d/99_migration \
 
 %pre
 # Prevent installation for CPUs that are too old
-# SLE16 image panics on CPUs older than x86_64_v1 (i.e. x86_64) (bsc#1249593), so we need to block migration before getting into the image.
+# SLE16 image panics on CPUs older than x86_64_v2 (i.e. x86_64) (bsc#1249593), so we need to block migration before getting into the image.
 # We need the ZYPP_READONLY_HACK here since we are running inside a zypper transaction; without this the invocation of zypper will fail due to locking issues.
 if [ "$(ZYPP_READONLY_HACK=1 zypper system-architecture)" == "x86_64" ]; then
    echo "CPU Architecture too old. Aborting installation."

--- a/suse_migration_services/migration_target.py
+++ b/suse_migration_services/migration_target.py
@@ -1,0 +1,78 @@
+
+# Copyright (c) 2025 SUSE Linux LLC.  All rights reserved.
+#
+# This file is part of suse-migration-services.
+#
+# suse-migration-services is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# suse-migration-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
+#
+import logging
+import yaml
+import os
+import platform
+
+from suse_migration_services.defaults import Defaults
+from suse_migration_services.command import Command
+
+log = logging.getLogger(Defaults.get_migration_log_name())
+
+
+class MigrationTarget:
+    """Implements the detection of migration target"""
+    @staticmethod
+    def _parse_custom_config():
+        migration_config = '/etc/sle-migration-service.yml'
+        if os.path.isfile(migration_config):
+            try:
+                with open(migration_config, 'r') as config:
+                    return yaml.safe_load(config) or {}
+            except Exception as issue:
+                message = 'Loading {0} failed: {1}: {2}'.format(
+                    migration_config, type(issue).__name__, issue
+                )
+                log.error(message)
+
+        return {}
+
+    @staticmethod
+    def get_migration_target():
+        config_data = MigrationTarget._parse_custom_config()
+        migration_product = config_data.get('migration_product')
+        if migration_product:
+            product = migration_product.split('/')
+            return {
+                'identifier': product[0],
+                'version': product[1],
+                'arch': product[2]
+            }
+        sles15_migration = Command.run(
+            ['rpm', '-q', 'SLES15-Migration'], raise_on_error=False
+        )
+        if sles15_migration.returncode == 0:
+            # return default migration target
+            return {
+                'identifier': 'SLES',
+                'version': '15.3',
+                'arch': platform.machine()
+            }
+        sles16_migration = Command.run(
+            ['rpm', '-q', 'SLES16-Migration'], raise_on_error=False
+        )
+        if sles16_migration.returncode == 0:
+            # return default migration target
+            return {
+                'identifier': 'SLES',
+                'version': '16.0',
+                'arch': platform.machine()
+            }
+        return {}

--- a/suse_migration_services/prechecks/cpu_arch.py
+++ b/suse_migration_services/prechecks/cpu_arch.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2025
+#
+# SUSE Linux LLC.  All rights reserved.
+#
+# This file is part of suse-migration-services.
+#
+# suse-migration-services is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# suse-migration-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
+"""Module for checking for CPU architecture support"""
+import logging
+import os
+
+from suse_migration_services.defaults import Defaults
+from suse_migration_services.command import Command
+
+
+def x86_64_version():
+    """Function to check whether current CPU architecture is new enough to support SLE16"""
+    log = logging.getLogger(Defaults.get_migration_log_name())
+    os.environ['ZYPPER_READONLY_HACK'] = '1'
+    zypper_call = Command.run(['zypper', 'system-architecture'])
+    arch = zypper_call.output
+
+    if arch.strip().lower() == "x86_64":
+        log.error(
+            'SLE16 requires x86_64_v1 at minimum. The architecture version '
+            'of this system is too old.'
+        )
+
+
+def cpu_arch():
+    """Function for CPU architecture related checks"""
+    x86_64_version()

--- a/suse_migration_services/prechecks/cpu_arch.py
+++ b/suse_migration_services/prechecks/cpu_arch.py
@@ -22,18 +22,25 @@ import os
 
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.command import Command
+from suse_migration_services.migration_target import MigrationTarget
 
 
 def x86_64_version():
     """Function to check whether current CPU architecture is new enough to support SLE16"""
+    target = MigrationTarget.get_migration_target()
+
+    if target.get('version') != '16.0':
+        # This check is only necessary for migration to SLE16
+        return
+
     log = logging.getLogger(Defaults.get_migration_log_name())
-    os.environ['ZYPPER_READONLY_HACK'] = '1'
+    os.environ['ZYPP_READONLY_HACK'] = '1'
     zypper_call = Command.run(['zypper', 'system-architecture'])
     arch = zypper_call.output
 
     if arch.strip().lower() == "x86_64":
         log.error(
-            'SLE16 requires x86_64_v1 at minimum. The architecture version '
+            'SLE16 requires x86_64_v2 at minimum. The architecture version '
             'of this system is too old.'
         )
 

--- a/suse_migration_services/prechecks/pre_checks.py
+++ b/suse_migration_services/prechecks/pre_checks.py
@@ -30,6 +30,7 @@ import suse_migration_services.prechecks.fs as check_fs
 import suse_migration_services.prechecks.kernels as check_multi_kernels
 import suse_migration_services.prechecks.scc as check_scc
 import suse_migration_services.prechecks.wicked2nm as check_wicked2nm
+import suse_migration_services.prechecks.cpu_arch as check_cpu_arch
 
 
 def main():
@@ -91,6 +92,9 @@ def main():
         args.fix = False
 
     log.info('Checking harmful migration conditions')
+
+    log.info('--> Checking system architecture version...')
+    check_cpu_arch.cpu_arch()
 
     log.info('--> Checking for local private repos...')
     check_repos.remote_repos(

--- a/test/unit/migration_target_test.py
+++ b/test/unit/migration_target_test.py
@@ -1,0 +1,45 @@
+from unittest.mock import (
+    patch, Mock
+)
+
+from suse_migration_services.migration_target import MigrationTarget
+
+
+class TestMigrationTarget(object):
+    @patch('platform.machine')
+    @patch('os.path.isfile')
+    @patch('suse_migration_services.command.Command.run')
+    def test_get_migration_target(
+        self, mock_Command_run, mock_os_path_isfile,
+        mock_platform_machine
+    ):
+        mock_platform_machine.return_value = 'x86_64'
+        sles15_migration = Mock()
+        sles15_migration.returncode = 0
+        mock_Command_run.return_value = sles15_migration
+        mock_os_path_isfile.return_value = False
+        assert MigrationTarget.get_migration_target() == {
+            'identifier': 'SLES',
+            'version': '15.3',
+            'arch': 'x86_64'
+        }
+
+    @patch('platform.machine')
+    @patch('os.path.isfile')
+    @patch('suse_migration_services.command.Command.run')
+    def test_get_migration_target_sles16(
+        self, mock_Command_run, mock_os_path_isfile,
+        mock_platform_machine
+    ):
+        mock_platform_machine.return_value = 'x86_64'
+        sles15_migration_not_found = Mock()
+        sles15_migration_not_found.returncode = 1  # SLES15-Migration not found
+        sles16_migration_found = Mock()
+        sles16_migration_found.returncode = 0  # SLES16-Migration found
+        mock_Command_run.side_effect = [sles15_migration_not_found, sles16_migration_found]
+        mock_os_path_isfile.return_value = False  # No /etc/sle-migration-service.yml
+        assert MigrationTarget.get_migration_target() == {
+            'identifier': 'SLES',
+            'version': '16.0',
+            'arch': 'x86_64'
+        }

--- a/test/unit/pre_checks_test.py
+++ b/test/unit/pre_checks_test.py
@@ -16,6 +16,7 @@ import suse_migration_services.prechecks.kernels as check_kernels
 import suse_migration_services.prechecks.scc as check_scc
 import suse_migration_services.prechecks.ha as check_ha
 import suse_migration_services.prechecks.wicked2nm as check_wicked2nm
+import suse_migration_services.prechecks.cpu_arch as check_cpu_arch
 import suse_migration_services.prechecks.pre_checks as check_pre_checks
 from suse_migration_services.exceptions import DistMigrationCommandException
 from suse_migration_services.defaults import Defaults
@@ -32,6 +33,7 @@ class TestPreChecks():
     @patch('suse_migration_services.prechecks.repos.remote_repos')
     @patch('suse_migration_services.prechecks.fs.encryption')
     @patch('suse_migration_services.prechecks.kernels.multiversion_and_multiple_kernels')
+    @patch('suse_migration_services.prechecks.cpu_arch.cpu_arch')
     @patch.dict(
         os.environ, {"SUSE_MIGRATION_PRE_CHECKS_MODE": "foo"}, clear=True
     )
@@ -40,7 +42,7 @@ class TestPreChecks():
         return_value=argparse.Namespace(fix=False)
     )
     def test_main(
-        self, mock_arg_parse, mock_kernels,
+        self, mock_arg_parse, mock_cpu_arch, mock_kernels,
         mock_fs, mock_repos, mock_os_geteuid, mock_log
     ):
         mock_os_geteuid.return_value = 0
@@ -51,6 +53,7 @@ class TestPreChecks():
     @patch('suse_migration_services.prechecks.repos.remote_repos')
     @patch('suse_migration_services.prechecks.fs.encryption')
     @patch('suse_migration_services.prechecks.kernels.multiversion_and_multiple_kernels')
+    @patch('suse_migration_services.prechecks.cpu_arch.cpu_arch')
     @patch.dict(
         os.environ,
         {
@@ -62,7 +65,7 @@ class TestPreChecks():
         return_value=argparse.Namespace(fix=True)
     )
     def test_main_with_fix_and_migration_system_mode(
-        self, mock_arg_parse, mock_kernels, mock_fs,
+        self, mock_arg_parse, mock_cpu_arch, mock_kernels, mock_fs,
         mock_repos, mock_os_geteuid, mock_log
     ):
         """
@@ -543,6 +546,7 @@ class TestPreChecks():
     @patch('suse_migration_services.prechecks.repos.remote_repos')
     @patch('suse_migration_services.prechecks.fs.encryption')
     @patch('suse_migration_services.prechecks.kernels.multiversion_and_multiple_kernels')
+    @patch('suse_migration_services.prechecks.cpu_arch.cpu_arch')
     @patch.dict(
         os.environ, {
             "SUSE_MIGRATION_PRE_CHECKS_MODE": "migration_system_iso_image"
@@ -553,7 +557,7 @@ class TestPreChecks():
         return_value=argparse.Namespace(fix=True)
     )
     def test_pre_checks_false(
-        self, mock_argparse, mock_kernels, mock_fs,
+        self, mock_argparse, mock_cpu_arch, mock_kernels, mock_fs,
         mock_repos, mock_scc_migration, mock_get_migration_config_file,
         mock_os_geteuid, mock_log
     ):
@@ -685,44 +689,6 @@ class TestPreChecks():
             file_handle_credentials.read.side_effect = Exception('IO error')
             check_scc.migration()
             assert not mock_requests_post.called
-
-    @patch('platform.machine')
-    @patch('os.path.isfile')
-    @patch.object(Command, 'run')
-    def test_check_scc_migration_default_target(
-        self, mock_Command_run, mock_os_path_isfile,
-        mock_platform_machine, mock_os_geteuid, mock_log
-    ):
-        mock_platform_machine.return_value = 'x86_64'
-        sles15_migration = Mock()
-        sles15_migration.returncode = 0
-        mock_Command_run.return_value = sles15_migration
-        mock_os_path_isfile.return_value = False
-        assert check_scc.get_migration_target() == {
-            'identifier': 'SLES',
-            'version': '15.3',
-            'arch': 'x86_64'
-        }
-
-    @patch('platform.machine')
-    @patch('os.path.isfile')
-    @patch.object(Command, 'run')
-    def test_check_scc_migration_default_target_sles16(
-        self, mock_Command_run, mock_os_path_isfile,
-        mock_platform_machine, mock_os_geteuid, mock_log
-    ):
-        mock_platform_machine.return_value = 'x86_64'
-        sles15_migration_not_found = Mock()
-        sles15_migration_not_found.returncode = 1  # SLES15-Migration not found
-        sles16_migration_found = Mock()
-        sles16_migration_found.returncode = 0  # SLES16-Migration found
-        mock_Command_run.side_effect = [sles15_migration_not_found, sles16_migration_found]
-        mock_os_path_isfile.return_value = False  # No /etc/sle-migration-service.yml
-        assert check_scc.get_migration_target() == {
-            'identifier': 'SLES',
-            'version': '16.0',
-            'arch': 'x86_64'
-        }
 
     def test_privileges(self, mock_os_geteuid, mock_log):
         with self._caplog.at_level(logging.ERROR):
@@ -914,3 +880,25 @@ class TestPreChecks():
             ],
             stdin=mock_subprocess_Popen().stdout, stderr=-2
         )
+
+    @patch('suse_migration_services.command.Command.run')
+    def test_check_x86_64_version_v2(
+            self, mock_Command_run,
+            mock_os_getuid, mock_log
+    ):
+        mock_Command_run.return_value.output = 'x86_64_v2'
+
+        check_cpu_arch.cpu_arch()
+        mock_Command_run.assert_called_once_with(['zypper', 'system-architecture'])
+
+    @patch('suse_migration_services.command.Command.run')
+    def test_check_x86_64_old(
+            self, mock_Command_run,
+            mock_os_getuid, mock_log
+    ):
+        mock_Command_run.return_value.output = 'x86_64'
+
+        with self._caplog.at_level(logging.ERROR):
+            check_cpu_arch.cpu_arch()
+            assert 'SLE16 requires x86_64_v1 at minimum' in self._caplog.text
+        mock_Command_run.assert_called_once_with(['zypper', 'system-architecture'])

--- a/tools/run_migration
+++ b/tools/run_migration
@@ -139,14 +139,6 @@ if (( EUID != 0 )); then
     exit 1
 fi
 
-# Do not start migration for CPUs that are too old
-# SLE16 image panics on CPUs older than x86_64_v1 (i.e. x86_64) (bsc#1249593), so we need to block
-# migration before getting into the image.
-if [ "$(zypper system-architecture)" == "x86_64" ]; then
-   echo "CPU Architecture too old. Aborting migration."
-   exit 1
-fi
-
 # Set signal handler on EXIT
 trap cleanup EXIT
 
@@ -167,6 +159,14 @@ if [[ "${migration_iso}" == *SLES16*-*Migration*.iso ]]; then
 fi
 
 if ${is_sles16_migration}; then
+    # Do not start migration for CPUs that are too old
+    # SLE16 image panics on CPUs older than x86_64_v2 (i.e. x86_64) (bsc#1249593), so we need to
+    # block migration before getting into the image.
+    if [ "$(zypper system-architecture)" == "x86_64" ]; then
+	echo "CPU Architecture too old. Aborting migration."
+	exit 1
+    fi
+
     # store snapper pre snapshot if available
     store_snapper_pre_snapshot
 


### PR DESCRIPTION
This is a follow-up of #377.

It makes sense to implement x86_64 architecture version check as a pre-check as well, so user can catch the issue when running pre-checks before actually attempt to activate the migration.