### PR TITLE
Fix preserve doc formatting in adoc

### DIFF
--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -243,15 +243,12 @@ Preserve System Data::
 Preserve custom data file(s) e.g. udev rules from the system
 to be migrated into the upgrade live system and make sure
 they will become effective.
-+
-The `preserve` section has three subsections that govern file
-preservation and system actions:
-* `static`: Files in this subsection are copied into the DMS
-  directly, with no further processing.
-* `rules`: If this subsection contains files, they are preserved, and
-  the DMS reloads udev to make these rules effective.
-* `sysctl`: Preserving these files triggers sysctl --system to apply
-  the configuration changes.
+This `preserve` section is organized into three subsections that govern file 
+preservation and corresponding system actions. The subsection `static`, 
+defines files which are copied, with no further processing. If the 
+`rules` subsection contains files, the DMS also reloads udev to make 
+these rules effective. If files are defined in `sysctl`, the DMS 
+triggers `sysctl --system` to apply the configurations.
 +
 [listing]
 ----
@@ -262,6 +259,8 @@ preserve:
   static:
     - /etc/sysconfig/proxy
     - /path/to/be/preserved/*.suffix
+  sysctl:
+    - /etc/sysctl.conf
 ----
 +
 [NOTE]
@@ -269,7 +268,7 @@ udev rules that require custom drivers will not have the desired effect
 as the migration system will not include these drivers and therefore
 execution of those rules will fail. Rules with such properties should
 not be listed.
-
++
 [NOTE]
 The DMS provides a set of default preservable files that vary based on
 the target version and architecture. User-defined values will supplement


### PR DESCRIPTION
The listing wasn't formatted well. And I wasn't able to format it in a way, that the INFO blocks are on the same indention level as the initial text. 
Thus I removed them and used floating text.

<img width="1167" height="626" alt="Screenshot_2025-10-02_17:19:08" src="https://github.com/user-attachments/assets/afab2b73-8441-435c-be72-8cc2aa49f653" />
