### PR TITLE
sle16/config.sh - use dropin for s390 migration-config

### DIFF
--- a/image/generic/sle16/config.sh
+++ b/image/generic/sle16/config.sh
@@ -80,7 +80,9 @@ chown -R migration:users /home/migration
 
 # Add s390 specific network rules to migration config
 if [ "$(arch)" = "s390x" ]; then
-    cat <<EOF >> /etc/migration-config.yml
+    mkdir -p /etc/migration-config.d
+    cat <<EOF > /etc/migration-config.d/50-s390x.yml
+preserve:
   rules:
     - /etc/udev/rules.d/*qeth*.rules
     - /etc/udev/rules.d/*-cio-ignore*.rules


### PR DESCRIPTION
Because of this https://github.com/SUSE/suse-migration-services/pull/385#discussion_r2391635398 ,use drop-in method.