### PR TITLE
Fixed reading of migration config for target class

### DIFF
--- a/suse_migration_services/migration_target.py
+++ b/suse_migration_services/migration_target.py
@@ -17,38 +17,26 @@
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
 import logging
-import yaml
-import os
 import platform
 from glob import glob
 from fnmatch import fnmatch
 
+from suse_migration_services.migration_config import MigrationConfig
 from suse_migration_services.defaults import Defaults
 
 log = logging.getLogger(Defaults.get_migration_log_name())
 
 
 class MigrationTarget:
-    """Implements the detection of migration target"""
-    @staticmethod
-    def _parse_custom_config():
-        migration_config = '/etc/sle-migration-service.yml'
-        if os.path.isfile(migration_config):
-            try:
-                with open(migration_config, 'r') as config:
-                    return yaml.safe_load(config) or {}
-            except Exception as issue:
-                message = 'Loading {0} failed: {1}: {2}'.format(
-                    migration_config, type(issue).__name__, issue
-                )
-                log.error(message)
-
-        return {}
-
+    """
+    Implements the detection of migration target
+    """
     @staticmethod
     def get_migration_target():
-        config_data = MigrationTarget._parse_custom_config()
-        migration_product = config_data.get('migration_product')
+        migration_config = MigrationConfig()
+        migration_product = migration_config.config_data.get(
+            'migration_product'
+        )
         if migration_product:
             product = migration_product.split('/')
             return {

--- a/test/unit/migration_target_test.py
+++ b/test/unit/migration_target_test.py
@@ -1,5 +1,5 @@
 from unittest.mock import (
-    patch
+    patch, Mock
 )
 
 from suse_migration_services.migration_target import MigrationTarget
@@ -9,22 +9,43 @@ class TestMigrationTarget(object):
     @patch('platform.machine')
     @patch('os.path.isfile')
     @patch('suse_migration_services.migration_target.glob')
+    @patch('suse_migration_services.migration_target.MigrationConfig')
     def test_get_migration_target_empty(
-        self, mock_glob, mock_os_path_isfile,
+        self, mock_MigrationConfig, mock_glob, mock_os_path_isfile,
         mock_platform_machine
     ):
+        migration_config = Mock()
+        migration_config.config_data = {}
+        mock_MigrationConfig.return_value = migration_config
         mock_platform_machine.return_value = 'x86_64'
         mock_glob.return_value = []
         mock_os_path_isfile.return_value = False
         assert MigrationTarget.get_migration_target() == {}
 
+    @patch('suse_migration_services.migration_target.MigrationConfig')
+    def test_get_migration_target_configured(self, mock_MigrationConfig):
+        migration_config = Mock()
+        migration_config.config_data = {
+            'migration_product': 'SLES/15.4/x86_64'
+        }
+        mock_MigrationConfig.return_value = migration_config
+        assert MigrationTarget.get_migration_target() == {
+            'identifier': 'SLES',
+            'version': '15.4',
+            'arch': 'x86_64'
+        }
+
     @patch('platform.machine')
     @patch('os.path.isfile')
     @patch('suse_migration_services.migration_target.glob')
+    @patch('suse_migration_services.migration_target.MigrationConfig')
     def test_get_migration_target_sles15(
-        self, mock_glob, mock_os_path_isfile,
+        self, mock_MigrationConfig, mock_glob, mock_os_path_isfile,
         mock_platform_machine
     ):
+        migration_config = Mock()
+        migration_config.config_data = {}
+        mock_MigrationConfig.return_value = migration_config
         mock_platform_machine.return_value = 'x86_64'
         mock_glob.return_value = [
             '/migration-image/SLES15-Migration.x86_64-2.1.9-Build6.64.99.iso'
@@ -39,10 +60,14 @@ class TestMigrationTarget(object):
     @patch('platform.machine')
     @patch('os.path.isfile')
     @patch('suse_migration_services.migration_target.glob')
+    @patch('suse_migration_services.migration_target.MigrationConfig')
     def test_get_migration_target_sles16(
-        self, mock_glob, mock_os_path_isfile,
+        self, mock_MigrationConfig, mock_glob, mock_os_path_isfile,
         mock_platform_machine
     ):
+        migration_config = Mock()
+        migration_config.config_data = {}
+        mock_MigrationConfig.return_value = migration_config
         mock_glob.return_value = [
             '/migration-image/SLES16-Migration.x86_64-2.1.23-Build2.1.iso'
         ]


### PR DESCRIPTION
The MigrationTarget class implementation duplicates the reading of the config file for which we have the MigrationConfig class. This commit fixes the MigrationTarget by using an instance of the MigrationConfig class such that the latest changes in reading the configuration becomes effective