### PR TITLE
Fixed selinux to apparmor migration

### DIFF
--- a/suse_migration_services/units/apparmor_migration.py
+++ b/suse_migration_services/units/apparmor_migration.py
@@ -29,24 +29,6 @@ from suse_migration_services.exceptions import (
 )
 
 
-def install_patterns_base_selinux(root_path):
-    """Install patterns-base-selinux"""
-    Zypper.run([
-        '--no-cd',
-        '--non-interactive',
-        '--gpg-auto-import-keys',
-        '--root', root_path,
-        'install',
-        '--auto-agree-with-licenses',
-        '--allow-vendor-change',
-        '--download', 'in-advance',
-        '--replacefiles',
-        '--allow-downgrade',
-        '--no-recommends',
-        'patterns-base-selinux'
-    ])
-
-
 def main():
     """
     DistMigration migrate from apparmor to SELinux
@@ -71,8 +53,25 @@ def main():
             for line in finput:
                 print(re.sub(pattern, "security=selinux", line), end='')
 
-            log.info('Installing patterns-base-selinux')
-            install_patterns_base_selinux(root_path)
+        log.info('Installing patterns-base-selinux')
+        # selinux migration is allowed to fail, it can be fixed
+        # after the migration
+        Zypper.run(
+            [
+                '--no-cd',
+                '--non-interactive',
+                '--gpg-auto-import-keys',
+                '--root', root_path,
+                'install',
+                '--auto-agree-with-licenses',
+                '--allow-vendor-change',
+                '--download', 'in-advance',
+                '--replacefiles',
+                '--allow-downgrade',
+                '--no-recommends',
+                'patterns-base-selinux'
+            ], raise_on_error=False
+        )
     except Exception as issue:
         message = 'Apparmor to SELinux migration failed with {0}'.format(issue)
         log.error(message)

--- a/systemd/suse-migration-container-wicked-networkmanager.service
+++ b/systemd/suse-migration-container-wicked-networkmanager.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Wicked to NetworkManager migration
-After=suse-migration-container.service
+After=suse-migration-container.service suse-migration-container-apparmor-selinux.service
 Requisite=suse-migration-container.service
 Before=suse-migration-container-regenerate-initrd.service
 

--- a/systemd/suse-migration-wicked-networkmanager.service
+++ b/systemd/suse-migration-wicked-networkmanager.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Wicked to NetworkManager migration
-After=suse-migration.service
+After=suse-migration.service suse-migration-apparmor-selinux.service
 Requisite=suse-migration.service
 Before=suse-migration-regenerate-initrd.service
 

--- a/test/unit/units/apparmor_migration_test.py
+++ b/test/unit/units/apparmor_migration_test.py
@@ -37,7 +37,7 @@ class TestAppArmorMigration(object):
                 '--allow-downgrade',
                 '--no-recommends',
                 'patterns-base-selinux'
-            ]
+            ], raise_on_error=False
         )
 
     @patch('fileinput.input')


### PR DESCRIPTION
The selinux to apparmor migration is based on a grub default setting change followed by the installation of a pattern package. It's important that this action is done prior the network migration from wicked to NetworkManager because this migration can lead to network inconsistencies which prevents the installation of packages from the remote repos. So happened in cloud instances and also in the container based workflow. As such this commit makes sure the selinux to apparmor migration happens before the network migration. In addition the selinux to apparmor migration should not mark the entire migration as failed as such a problem can also be fixed in the migrated system later