### PR TITLE
Fixed behavior of wicked2m pre check

### DIFF
--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -35,6 +35,10 @@ class Defaults:
         return '/etc/migration-config.yml'
 
     @staticmethod
+    def get_migration_host_config_file():
+        return '/etc/sle-migration-service.yml'
+
+    @staticmethod
     def get_migration_config_dir():
         return '/etc/migration-config.d'
 


### PR DESCRIPTION
The output produced by the pre-check is in my opinion very misleading. It outputs information from wicked2m which says that warnings can be ignored by passing an option to the tool but for the actual DMS system migration this has no meaning. The additional information to place a config setting to a DMS config file is correct but completely confusing with regards to the first information provided. This commit refactors the code which also doesn't use the existing command interface and imho can be done simpler. In addition the precheck runs code when inside of the migration, but this code is useless because the real (no dry-run) call of wicked2nm happens in the setup_host_network service.