### PR TITLE
Fix MinSLEVersion value depending on target

### DIFF
--- a/image/package/suse-migration-rpm.changes
+++ b/image/package/suse-migration-rpm.changes
@@ -1,4 +1,16 @@
 -------------------------------------------------------------------
+Tue Oct  7 16:04:17 UTC 2025 - Marcus Schäfer <marcus.schaefer@gmail.com>
+
+- Fix MinSLEVersion value depending on target
+
+  The MinSLEVersion global variable was set to a value
+  suitable for migrations from SLE12 to SLE15. Now that the
+  scope of the DMS is not only this target we have to add
+  a mechanism to dynamically set an appropriate value.
+  I added explanatory comments which hopefully makes sense
+  to explain when this information is taken into account
+
+-------------------------------------------------------------------
 Fri Aug  8 09:43:03 UTC 2025 - Marcus Schäfer <marcus.schaefer@suse.com>
 
 - Add product requirement according to image name.

--- a/image/package/suse-migration-rpm.spec
+++ b/image/package/suse-migration-rpm.spec
@@ -25,6 +25,7 @@ Group:          System/Management
 Url:            https://github.com/SUSE/suse-migration-services
 Source:         %{name}.tar.gz
 BuildRequires:  filesystem
+BuildRequires:  sed
 Requires:       suse-migration-services
 Requires:       build
 Requires:       perl(Date::Parse)
@@ -41,6 +42,25 @@ ISO image in an rpm package.
 
 %install
 mkdir -p %{buildroot}/usr/lib/build/
+
+%if 0%{?suse_version} >= 1600 && 0%{?is_opensuse}
+# suse-migration-rpm building for SLE16, is used when building the SLE16
+# based live migration image for SLE15. As such the later package with
+# the image gets installed to a SLE15 system. The min SLE version must
+# be set to 15.4 (SLE15 SP4)
+sed -ie 's@__MINVERSION__@15.4@' image.spec.in
+%elif 0%{?sle_version} >= 150000 && !0%{?is_opensuse}
+# suse-migration-rpm building for SLE15, is used when building the SLE15
+# based live migration image for SLE12. As such the later package with
+# the image gets installed to a SLE12 system. The min SLE version must
+# be set to 12.3 (SLE12 SP3)
+sed -ie 's@__MINVERSION__@12.3@' image.spec.in
+%else
+# suse-migration-rpm building for unknown SLES, set min SLE version
+# to the lowest we support
+sed -ie 's@__MINVERSION__@12.3@' image.spec.in
+%endif
+
 install -m 644 image.spec.in %{buildroot}/usr/lib/build/
 install -m 755 kiwi_post_run %{buildroot}/usr/lib/build/
 

--- a/image/package/suse-migration-rpm/image.spec.in
+++ b/image/package/suse-migration-rpm/image.spec.in
@@ -1,6 +1,6 @@
 # needsrootforbuild
 
-%global MinSLEVersion 12.3
+%global MinSLEVersion __MINVERSION__
 
 Url:            http://www.suse.com/
 Name:           __NAME__


### PR DESCRIPTION
The MinSLEVersion global variable was set to a value suitable for migrations from SLE12 to SLE15. Now that the scope of the DMS is not only this target we have to add a mechanism to dynamically set an appropriate value. I added explanatory comments which hopefully makes sense to explain when this information is taken into account