### PR TITLE
Use of f-strings not allowed in the DMS

### DIFF
--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -89,7 +89,10 @@ class Defaults:
             return 'boot/image'
         else:
             raise NotImplementedError(
-                f'get_target_kernel not implemented for machine type {machine}')
+                'get_target_kernel not implemented for machine type {}'.format(
+                    machine
+                )
+            )
 
     @staticmethod
     def get_target_initrd():


### PR DESCRIPTION
The code has to stay compatible with python 3.4 because SLE12-to-SLE15 migrations has to continue to work. On SLE12 only python 3.4 exists. This commit fixes the code that used f-strings executed on python 3.4.
This is related to bsc#1248137