### PR TITLE
Fixed azuremetadata device lookup

### DIFF
--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -320,6 +320,9 @@ def get_root_disk_device(root_path):
         ]
     ).output
     if root_device:
+        # The findmnt output can contain extra volume information
+        # which we don't need for the subsequent lsblk call.
+        root_device = root_device.split('[')[0]
         lsblk_call = Command.run(
             [
                 'lsblk', '-p', '-n', '-r', '-s', '-o',

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -347,9 +347,10 @@ class TestSetupPrepare(object):
         mock_Command_run, mock_Fstab, mock_logger_setup,
         mock_update_regionsrv_setup
     ):
+        # test with volume based block device returned from findmnt
         mock_command_return_values = [
             Mock(output='/dev/sda3 part\n/dev/sda disk'),
-            Mock(output='dev/sda3\n')
+            Mock(output='dev/sda3[/@/.snapshots/1/snapshot]\n')
         ]
 
         def command_returns(arg):
@@ -383,6 +384,24 @@ class TestSetupPrepare(object):
         assert regionsrv_setup.get('instance', 'dataProvider') == \
             '/usr/bin/azuremetadata --api latest --subscriptionId --billingTag ' \
             '--attestedData --signature --xml --device /dev/sda'
+
+        # test with standard block device returned from findmnt
+        mock_command_return_values = [
+            Mock(output='/dev/sdb7 part\n/dev/sdb disk'),
+            Mock(output='dev/sdb7\n')
+        ]
+        shutil.copy(
+            '../data/regionserverclnt-azure.cfg', tmp_regionserverclnt.name
+        )
+        update_regionsrv_setup(
+            '/system-root', tmp_regionserverclnt.name
+        )
+
+        regionsrv_setup = ConfigParser()
+        regionsrv_setup.read(tmp_regionserverclnt.name)
+        assert regionsrv_setup.get('instance', 'dataProvider') == \
+            '/usr/bin/azuremetadata --api latest --subscriptionId --billingTag ' \
+            '--attestedData --signature --xml --device /dev/sdb'
 
     @patch('os.listdir')
     @patch('os.path.isdir')


### PR DESCRIPTION
On Azure the azuremetadata call is prepared with the --device option pointing to the disk containing the system. This disk device is obtained via the get_root_disk_device method which makes use of the findmnt tool to read the device that contains the root filesystem mountpoint. If that filesystem is using sophisticated technology like subvolumes on btrfs, findmnt reports this information in addition to the actual unix block device in brackets [...]. For the logic flow of get_root_disk_device this extra information broke the subsequent lsblk call. This commit strips eventually existing extra block device information from the findmnt call output.