### PR TITLE
Duplicate the solver test case information

### DIFF
--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -31,6 +31,10 @@ class Defaults:
         return '/system-root'
 
     @staticmethod
+    def get_zypper_solver_test_case_dir():
+        return '/var/log/zypper.solverTestCase'
+
+    @staticmethod
     def get_migration_config_file():
         return '/etc/migration-config.yml'
 

--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -20,6 +20,7 @@ import os
 import re
 
 # project
+from suse_migration_services.command import Command
 from suse_migration_services.migration_config import MigrationConfig
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.logger import Logger
@@ -31,6 +32,24 @@ from suse_migration_services.units.post_mount_system import (
 from suse_migration_services.exceptions import (
     DistMigrationZypperException,
 )
+
+
+def duplicate_solver_test_case_data():
+    """
+    We duplicate the created solver test case to cover both use cases
+    a user looging into the migration system and wanting to see the
+    solver case and a user expecting the solver case to be on the
+    system that is/has being migrated.
+    """
+    test_case_dir = Defaults.get_zypper_solver_test_case_dir()
+
+    if os.path.isdir(test_case_dir):
+        target = os.sep.join(
+            [Defaults.get_system_root_path(), test_case_dir]
+        )
+        Command.run(
+            ['cp', '-r', test_case_dir, target]
+        )
 
 
 def is_single_rpmtrans_requested() -> str:
@@ -143,3 +162,5 @@ def main():
         raise DistMigrationZypperException(
             'Migration failed with {0}'.format(issue)
         )
+    finally:
+        duplicate_solver_test_case_data()

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -238,6 +238,34 @@ class TestMigration(object):
         )
         zypper_call.raise_if_failed.assert_called_once()
 
+    @patch('suse_migration_services.units.migrate.is_single_rpmtrans_requested')
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.zypper.Zypper.run')
+    @patch('suse_migration_services.units.migrate.log_env')
+    @patch('suse_migration_services.units.migrate.update_env')
+    @patch('suse_migration_services.units.migrate.MigrationConfig')
+    @patch('os.path.isdir')
+    @patch('suse_migration_services.units.migrate.Command.run')
+    def test_main_zypper_dup_with_solver_test_case(
+        self, mock_Command_run, mock_os_path_isdir, mock_MigrationConfig,
+        mock_update_env, mock_log_env, mock_Zypper_run, mock_logger_setup,
+        mock_is_single_rpmtrans_requested
+    ):
+        mock_os_path_isdir.return_value = True
+        mock_MigrationConfig.return_value = self.migration_config_dup
+        zypper_call = Mock()
+        mock_Zypper_run.return_value = zypper_call
+        mock_is_single_rpmtrans_requested.return_value = '0'
+        with patch('builtins.open', create=True):
+            main()
+        mock_Command_run.assert_called_once_with(
+            [
+                'cp', '-r',
+                '/var/log/zypper.solverTestCase',
+                '/system-root//var/log/zypper.solverTestCase'
+            ]
+        )
+
     @patch('builtins.open', new_callable=MagicMock)
     def test_is_single_rpmtrans_requested(self, mock_open):
         # Test case 1: migration.single_rpmtrans is not present


### PR DESCRIPTION
We have 2 use cases, one where a user may create a solver test case and expect the data in the documented location in the live system that is performing the migration. This allows for checking the test case while the system is being migrated without having to look at the system via system_root and accidentally interfering with the migration. The second use case is the expectation that the solver test case is left behind on the system that is/has been migrated. Copy the test case data.

Solves #326 