### PR TITLE
Fix order of reboot service

### DIFF
--- a/systemd/suse-migration-container-reboot.service
+++ b/systemd/suse-migration-container-reboot.service
@@ -1,11 +1,12 @@
 [Unit]
 Description=Reboot System
-After=suse-migration-container.service
+After=suse-migration-container.service suse-migration-container-apparmor-selinux.service
 Requires=suse-migration-container.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/suse-migration-reboot
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/suse-migration-reboot.service
+++ b/systemd/suse-migration-reboot.service
@@ -1,11 +1,12 @@
 [Unit]
 Description=Reboot System
-After=suse-migration-kernel-load.service suse-migration-update-bootloader.service
+After=suse-migration-kernel-load.service suse-migration-update-bootloader.service suse-migration-apparmor-selinux.service
 ConditionKernelCommandLine=!migration.noreboot
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/suse-migration-reboot
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Make sure the reboot service is started after the potential apparmor-selinux service. Without the ordering the reboot service starts while the apparmor-selinux is installing additional software. Please note: The apparmor-selinux is intentionally not set as a required service because depending on the migration target apparmor-selinux is enabled or not. For example SLE12-to-SLE15 migrations does not enable apparmor-selinux migration.