### PR TITLE
Refactor mount_system service

### DIFF
--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -14,6 +14,8 @@ else
     ) ${CLASS}"
 fi
 
+migration_rootfs_uuid=$(findmnt --noheadings --output UUID /)
+
 migration_iso=$(echo /migration-image/*-*Migration.*.iso)
 is_sles16_migration=false
 if [[ "${migration_iso}" == *SLES16*-*Migration*.iso ]]; then
@@ -31,6 +33,9 @@ fi
 
 # init boot options needed for live boot
 boot_options="rd.live.image root=live:CDLABEL=CDROM"
+
+# add rootfs UUID to identify migration target disk
+boot_options="${boot_options} migration_target=${migration_rootfs_uuid}"
 
 # add auto activation of devices in soft raid mode
 if mdadm --detail "${root_device}" &>/dev/null; then

--- a/tools/run_migration
+++ b/tools/run_migration
@@ -58,7 +58,15 @@ function get_boot_options {
     local host_boot_option
     local migration_iso=$1
     local is_sles16_migration=$2
-    boot_options="iso-scan/filename=${migration_iso} root=live:CDLABEL=CDROM rd.live.image"
+    local migration_rootfs_uuid
+    migration_rootfs_uuid=$(findmnt --noheadings --output UUID /)
+    # init boot options needed for live boot
+    boot_options="rd.live.image root=live:CDLABEL=CDROM"
+    # add live image reference filename for iso-scan module
+    boot_options="${boot_options} iso-scan/filename=${migration_iso}"
+    # add rootfs UUID to identify migration target disk
+    boot_options="${boot_options} migration_target=${migration_rootfs_uuid}"
+    # add auto activation of devices in soft raid mode
     if mdadm --detail "$(get_system_root_device)" &>/dev/null; then
         boot_options="${boot_options} rd.auto"
     fi


### PR DESCRIPTION
So far the mount_system unit run through all disk devices and uses the first one providing a system with an fstab file. This concept is weak and fails on machines with multiple linux OS disks attached. This commit refactors mount_system such that it reads the migration_target= variable from the kernel cmdline. The kernel cmdline gets this information added by either the grub.d/99_migration menuentry or via the run_migration kexec method. The migration_target= variable is expected to contain the rootfs UUID value of the host that should be migrated. This is a unique identifier and as such cannot be confused by other devices attached to the system.