### PR TITLE
Omit cio_ignore kernel commandline on zkvm

### DIFF
--- a/tools/run_migration
+++ b/tools/run_migration
@@ -78,6 +78,9 @@ function get_boot_options {
             quiet)
                 continue
             ;;
+            cio_ignore=*)
+                [ "$(systemd-detect-virt)" == "kvm" ] && continue
+            ;;
             security=apparmor)
             if ${is_sles16_migration}; then
                 boot_options="${boot_options} security=selinux"


### PR DESCRIPTION
Based on bsc#1250003 make the migration
more robust, when removing `cio_ignore`
from commandline only for zKVM.