### PR TITLE
Move script package to the main migration provider

### DIFF
--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -74,6 +74,16 @@ Provides:	  python3-migration = %{version}-%{release}
 %description -n  %{pythonpkgname}
 Python based implementation for suse major code stream upgrade system
 
+%package          -n suse-migration-scripts
+Summary:          The common scripts collection for migrations
+Group:            System/Management
+Requires:         bash
+Requires:         grep
+BuildArch:        noarch
+
+%description -n suse-migration-scripts
+Common script collection for migrations.
+
 %package          -n suse-migration-pre-checks
 Summary:          The pre-checks code used with the python migration module
 Group:            System/Management
@@ -98,6 +108,7 @@ Group:            System/Management
 Requires:         podman
 Requires:         sysvinit-tools
 Requires:         sudo
+Requires:         suse-migration-scripts
 BuildArch:        noarch
 
 %description -n suse-migration
@@ -123,6 +134,9 @@ The migrate tool to start the migration as container based process
 
 install -D -m 755 tools/run_migration \
     %{buildroot}%{_sbindir}/run_migration
+
+install -D -m 755 tools/network_pre.functions \
+    %{buildroot}%{_datarootdir}/suse_migration_services/network_pre.functions
 
 install -D -m 644 systemd/suse-migration-mount-system.service \
     %{buildroot}%{_unitdir}/suse-migration-mount-system.service
@@ -305,6 +319,10 @@ install -D -m 755 tools/migrate \
 %files -n %{pythonpkgname}
 %{python_sitelib}/suse_migration_services
 %{python_sitelib}/suse_migration_services-%{version}*-info
+
+%files -n suse-migration-scripts
+%dir %{_datarootdir}/suse_migration_services
+%{_datarootdir}/suse_migration_services
 
 %files -n suse-migration-pre-checks
 %{_bindir}/suse-migration-pre-checks

--- a/package/suse-migration-sle16-activation-spec-template
+++ b/package/suse-migration-sle16-activation-spec-template
@@ -31,23 +31,12 @@ Requires(post):   util-linux-systemd
 Requires(postun): util-linux-systemd
 Requires(pre):	  sed
 Requires(pre):	  zypper
-Requires(pre):    suse-migration-sle16-scripts
+Requires(pre):    suse-migration-scripts
 ExclusiveArch:    aarch64 ppc64le x86_64
 
 %description -n suse-migration-sle16-activation
 Script code to activate the SLE16 migration image to be booted at
 next reboot of the machine.
-
-%package          -n suse-migration-sle16-scripts
-Summary:          The migrate helper scripts collection
-Group:            System/Management
-Requires:         bash
-Requires:         wicked
-Requires:         grep
-BuildArch:        noarch
-
-%description -n suse-migration-sle16-scripts
-Helper script collection to migrate to sle16.
 
 %prep
 %setup -q -n suse_migration_services-%{version}
@@ -55,9 +44,6 @@ Helper script collection to migrate to sle16.
 %install
 install -D -m 755 grub.d/99_migration \
     %{buildroot}/etc/grub.d/99_migration
-
-install -D -m 755 tools/network_pre.functions \
-    %{buildroot}%{_datarootdir}/suse_migration_services/network_pre.functions
 
 %pre
 # Prevent installation for CPUs that are too old
@@ -91,9 +77,5 @@ setup_wicked_to_NetworkManager_prereqs
 %dir /etc/grub.d
 /etc/grub.d/*
 %ghost /var/cache/suse_migration_snapper_btrfs_pre_snapshot_number
-
-%files -n suse-migration-sle16-scripts
-%dir %{_datarootdir}/suse_migration_services
-%{_datarootdir}/suse_migration_services/network_pre.functions
 
 %changelog

--- a/tools/migrate
+++ b/tools/migrate
@@ -18,6 +18,8 @@
 #
 set -e
 
+source /usr/share/suse_migration_services/network_pre.functions
+
 # default migration system
 MIGRATION_SYSTEM=registry.opensuse.org/home/marcus.schaefer/dms/containers_sle15/migration:latest
 
@@ -60,56 +62,6 @@ function migration_target {
         echo generic
     fi
 }
-
-function setup_wicked_to_NetworkManager_prereqs {
-    # """
-    # Set up required files for wicked to NetworkManager migration
-    # """
-    if [ -x "$(command -v wicked)" ]; then
-        mkdir -p /var/cache/wicked_config
-        wicked show-config > /var/cache/wicked_config/config.xml
-    fi
-
-    # Create systemd.link file for VMWARE or Hyper-V virtual interfaces
-    for netdev in /sys/class/net/*; do
-        dev=$(basename "${netdev}")
-        link_file=/etc/systemd/network/70-persistent-net-"${dev}".link
-        test -e "${link_file}" && continue
-
-        ! grep -E '^(00:0c:29:|00:50:56:|00:15:5d:)' \
-            /sys/class/net/"${dev}"/address >/dev/null && continue
-        ID_PATH=$(
-            udevadm info -q property --property=ID_PATH \
-            /sys/class/net/"${dev}"
-        )
-        ID_PATH=${ID_PATH#ID_PATH=}
-        ID_NET_DRIVER=$(
-            udevadm info -q property --property=ID_NET_DRIVER \
-            /sys/class/net/"${dev}"
-        )
-        ID_NET_DRIVER=${ID_NET_DRIVER#ID_NET_DRIVER=}
-        if [ -z "$ID_PATH" ] || [ -z "$ID_NET_DRIVER" ]; then
-            echo "[ERROR] failed to create systemd.link file for ${dev}"
-            exit 1
-        fi
-        grep -sE '^Name="?'"$dev"'"?$' \
-            /etc/systemd/network/*.link && continue
-        grep -sE '^\s*[^#].*[ \t,]NAME="'"$dev"'"$' \
-            /etc/udev/rules.d/*.rules && continue
-
-        echo "Create $link_file with Path=$ID_PATH Driver=$ID_NET_DRIVER"
-        cat > "${link_file}" <<-EOT
-		# This file was created from run_migration
-		[Match]
-		Path=$ID_PATH
-		Driver=$ID_NET_DRIVER
-		[Link]
-		NamePolicy=
-		Name=$dev
-		EOT
-    done
-}
-
 
 migrate() {
     set -x


### PR DESCRIPTION
In the effort to provide a common script code package, the package suse-migration-sle16-scripts was provided. During testing I found that not all places where script duplication exists was covered. This commit addresses the code that was missed and also suggests that we move the common script code as a sub package to the main suse-migration-services package. The reason here is that the common code is not only used in the activation package. In addition I also suggest that the package name changes to be more generic. The reason here is that this will go beyond sle16 and can also contain common script code for sle15 migrations as well as for past sle16 migrations as we are moving forward. As such my suggestion to also rename the package to just suse-migration-scripts.