### PR TITLE
Add DropComponents class

### DIFF
--- a/suse_migration_services/drop_components.py
+++ b/suse_migration_services/drop_components.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2025 SUSE Linux LLC.  All rights reserved.
+#
+# This file is part of suse-migration-services.
+#
+# suse-migration-services is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# suse-migration-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
+#
+import os
+import shutil
+import pathlib
+
+# project
+from suse_migration_services.zypper import Zypper
+from suse_migration_services.defaults import Defaults
+
+
+class DropComponents:
+    """
+    **Base class to drop packages, files from the system**
+
+    When replacing an implementation for a certain feature
+    with another implementation where the replacing implementation
+    has no compatibility it may occur that the transition path
+    contains steps that cannot be handled in the replacing RPM
+    package or the to be replaced RPM or the combination thereof.
+
+    In these cases an instance of DropComponents can be used to
+    interfere in the upgrade process, rather than just driving
+    the upgrade process.
+    """
+    def __init__(self):
+        self.drop_packages = []
+        self.drop_files_and_directories = []
+        self.root_path = Defaults.get_system_root_path()
+
+    def drop_package(self, name):
+        self.drop_packages.append(name)
+
+    def drop_path(self, path):
+        if self.root_path:
+            self.drop_files_and_directories.append(
+                os.path.normpath(os.sep.join([self.root_path, path]))
+            )
+
+    def drop_perform(self):
+        self._uninstall_packages()
+        self._delete_paths()
+
+    def _uninstall_packages(self):
+        if self.drop_packages and self.root_path:
+            zypper_call = Zypper.run(
+                [
+                    '--no-cd',
+                    '--non-interactive',
+                    '--gpg-auto-import-keys',
+                    '--root', self.root_path,
+                    'remove',
+                    '--clean-deps'
+                ] + self.drop_packages, raise_on_error=False
+            )
+            zypper_call.raise_if_failed()
+
+    def _delete_paths(self):
+        if self.drop_files_and_directories:
+            for element in self.drop_files_and_directories:
+                if os.path.isdir(element):
+                    shutil.rmtree(element)
+                else:
+                    pathlib.Path(element).unlink(missing_ok=True)

--- a/suse_migration_services/units/btrfs_snapshot_post_migration.py
+++ b/suse_migration_services/units/btrfs_snapshot_post_migration.py
@@ -27,46 +27,53 @@ from suse_migration_services.exceptions import (
 )
 
 
+class BtrfsSnapshotPostMigration:
+    def __init__(self):
+        """
+        Post-migration btrfs snapshot creation.
+
+        Creates a image of the system after the distribution migration .
+        """
+        Logger.setup()
+        self.log = logging.getLogger(Defaults.get_migration_log_name())
+        self.root_path = Defaults.get_system_root_path()
+
+    def perform(self):
+        try:
+            self.log.info('Running Post-migration btrfs snapshot creation')
+            with open(
+                '/run/suse_migration_snapper_btrfs_pre_snapshot_number'
+            ) as pre_snapshot_number_file:
+                pre_snapshot_number = pre_snapshot_number_file.read().strip()
+                if not pre_snapshot_number.isdigit():
+                    message = f'Invalid snapshot number: {pre_snapshot_number}'
+                    self.log.error(message)
+                    raise ValueError(message)
+
+            Command.run(
+                [
+                    'chroot', self.root_path, 'snapper',
+                    '--no-dbus',
+                    'create',
+                    '--type', 'single',
+                    '--read-only',
+                    '--cleanup-algorithm', 'number',
+                    '--print-number',
+                    '--userdata', 'important=yes',
+                    '--description', 'after offline migration'
+                ]
+            )
+            self.log.info(
+                'BTRFS post-migration snapshot creation completed successfully.'
+            )
+        except Exception as issue:
+            message = 'BTRFS post-migration snapshot creation failed with: {}'
+            self.log.error(message.format(issue))
+            raise DistMigrationBtrfsSnapshotPostMigrationException(
+                message.format(issue)
+            )
+
+
 def main():
-    """
-    Post-migration btrfs snapshot creation.
-
-    Creates a image of the system after the distribution migration .
-    """
-    Logger.setup()
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    root_path = Defaults.get_system_root_path()
-
-    try:
-        log.info('Running Post-migration btrfs snapshot creation')
-        with open(
-            '/run/suse_migration_snapper_btrfs_pre_snapshot_number'
-        ) as pre_snapshot_number_file:
-            pre_snapshot_number = pre_snapshot_number_file.read().strip()
-            if not pre_snapshot_number.isdigit():
-                message = f'Invalid snapshot number: {pre_snapshot_number}'
-                log.error(message)
-                raise ValueError(message)
-
-        Command.run(
-            [
-                'chroot', root_path, 'snapper',
-                '--no-dbus',
-                'create',
-                '--type', 'single',
-                '--read-only',
-                '--cleanup-algorithm', 'number',
-                '--print-number',
-                '--userdata', 'important=yes',
-                '--description', 'after offline migration'
-            ]
-        )
-        log.info(
-            'BTRFS post-migration snapshot creation completed successfully.'
-        )
-    except Exception as issue:
-        message = f'BTRFS post-migration snapshot creation failed with {issue}'
-        log.error(message)
-        raise DistMigrationBtrfsSnapshotPostMigrationException(
-            message
-        ) from issue
+    snapshot_post = BtrfsSnapshotPostMigration()
+    snapshot_post.perform()

--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -25,142 +25,146 @@ from suse_migration_services.migration_config import MigrationConfig
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.logger import Logger
 from suse_migration_services.zypper import Zypper
-from suse_migration_services.units.post_mount_system import (
-    update_env, log_env
-)
 
 from suse_migration_services.exceptions import (
     DistMigrationZypperException,
 )
 
 
-def duplicate_solver_test_case_data():
-    """
-    We duplicate the created solver test case to cover both use cases
-    a user looging into the migration system and wanting to see the
-    solver case and a user expecting the solver case to be on the
-    system that is/has being migrated.
-    """
-    test_case_dir = Defaults.get_zypper_solver_test_case_dir()
+class MigrateSystem:
+    def __init__(self):
+        """
+        DistMigration run zypper based migration
 
-    if os.path.isdir(test_case_dir):
-        target = os.sep.join(
-            [Defaults.get_system_root_path(), test_case_dir]
-        )
-        Command.run(
-            ['cp', '-r', test_case_dir, target]
-        )
+        Call zypper migration plugin and migrate the system.
+        The output of the call is logged on the system to migrate
+        """
+        Logger.setup()
+        self.log = logging.getLogger(Defaults.get_migration_log_name())
+        self.root_path = Defaults.get_system_root_path()
+        self.exit_code_file = Defaults.get_migration_exit_code_file()
 
+    def perform(self):
+        try:
+            self.log.info('Running migrate service')
+            migration_config = MigrationConfig()
+            migration_config.update_migration_config_file()
+            self.log.info(
+                'Config file content:\n{content}\n'. format(
+                    content=migration_config.get_migration_config_file_content()
+                )
+            )
+            if migration_config.get_preserve_info():
+                # set potential missing settings in env
+                self.log.info('Update env variables')
+                Defaults.update_env(migration_config.get_preserve_info())
+                Defaults.log_env(self.log)
+            verbose_migration = '--no-verbose'
+            if migration_config.is_verbosity_requested():
+                verbose_migration = '--verbose'
+            solver_case = Defaults.get_zypp_gen_solver_test_case()
+            if migration_config.is_zypp_solver_test_case_requested():
+                solver_case = '--debug-solver'
+            os.environ['ZYPP_SINGLE_RPMTRANS'] = \
+                self.is_single_rpmtrans_requested()
+            os.environ['ZYPP_NO_USRMERGE_PROTECT'] = \
+                self.is_single_rpmtrans_requested()
 
-def is_single_rpmtrans_requested() -> str:
-    """
-    Return the value of single_rpmtrans
+            if migration_config.is_zypper_migration_plugin_requested():
+                Zypper.run(
+                    [
+                        'migration',
+                        verbose_migration,
+                        solver_case,
+                        '--non-interactive',
+                        '--gpg-auto-import-keys',
+                        '--no-selfupdate',
+                        '--auto-agree-with-licenses',
+                        '--allow-vendor-change',
+                        '--strict-errors-dist-migration',
+                        '--replacefiles',
+                        '--product', migration_config.get_migration_product(),
+                        '--root', self.root_path
+                    ]
+                )
+            else:
+                zypper_call = Zypper.run(
+                    [
+                        '--no-cd',
+                        '--non-interactive',
+                        '--gpg-auto-import-keys',
+                        '--root', self.root_path,
+                        'dup',
+                        '--auto-agree-with-licenses',
+                        '--allow-vendor-change',
+                        '--download', 'in-advance',
+                        '--replacefiles',
+                        '--allow-downgrade'
+                    ], raise_on_error=False
+                )
+                zypper_call.raise_if_failed()
+            # report success(0) return code
+            with open(self.exit_code_file, 'w') as exit_code:
+                exit_code.write('0{}'.format(os.linesep))
+        except Exception as issue:
+            etc_issue_path = os.sep.join(
+                [self.root_path, 'etc/issue']
+            )
+            log_path_migrated_system = os.sep + os.path.relpath(
+                Defaults.get_migration_log_file(), self.root_path
+            )
+            with open(etc_issue_path, 'w') as issue_file:
+                issue_file.write(
+                    'Migration has failed, for further details see {0}'.format(
+                        log_path_migrated_system
+                    )
+                )
+            # report failed(1) return code
+            with open(self.exit_code_file, 'w') as exit_code:
+                exit_code.write('1{}'.format(os.linesep))
+            self.log.error('migrate service failed with {0}'.format(issue))
+            raise DistMigrationZypperException(
+                'Migration failed with {0}'.format(issue)
+            )
+        finally:
+            self.duplicate_solver_test_case_data()
 
-    The value is read from the kernel command line argument:
-    migration.single_rpmtrans=<value>
-    """
-    # The default is 0
-    single_rpmtrans = '0'
-    with open('/proc/cmdline', 'r') as f:
-        cmdline = f.read()
-    match = re.search(r'migration.single_rpmtrans=([\w]+)', cmdline)
-    if match:
-        value = match.group(1).lower()
-        if value == 'true' or value == '1':
-            single_rpmtrans = '1'
-    return single_rpmtrans
+    def duplicate_solver_test_case_data(self):
+        """
+        We duplicate the created solver test case to cover both use cases
+        a user looging into the migration system and wanting to see the
+        solver case and a user expecting the solver case to be on the
+        system that is/has being migrated.
+        """
+        test_case_dir = Defaults.get_zypper_solver_test_case_dir()
+
+        if os.path.isdir(test_case_dir):
+            target = os.sep.join(
+                [Defaults.get_system_root_path(), test_case_dir]
+            )
+            Command.run(
+                ['cp', '-r', test_case_dir, target]
+            )
+
+    def is_single_rpmtrans_requested(self):
+        """
+        Return the value of single_rpmtrans
+
+        The value is read from the kernel command line argument:
+        migration.single_rpmtrans=<value>
+        """
+        # The default is 0
+        single_rpmtrans = '0'
+        with open('/proc/cmdline', 'r') as f:
+            cmdline = f.read()
+        match = re.search(r'migration.single_rpmtrans=([\w]+)', cmdline)
+        if match:
+            value = match.group(1).lower()
+            if value == 'true' or value == '1':
+                single_rpmtrans = '1'
+        return single_rpmtrans
 
 
 def main():
-    """
-    DistMigration run zypper based migration
-
-    Call zypper migration plugin and migrate the system.
-    The output of the call is logged on the system to migrate
-    """
-    Logger.setup()
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    root_path = Defaults.get_system_root_path()
-    exit_code_file = Defaults.get_migration_exit_code_file()
-
-    try:
-        log.info('Running migrate service')
-        migration_config = MigrationConfig()
-        migration_config.update_migration_config_file()
-        log.info(
-            'Config file content:\n{content}\n'. format(
-                content=migration_config.get_migration_config_file_content()
-            )
-        )
-        if migration_config.get_preserve_info():
-            # set potential missing settings in env
-            log.info('Update env variables')
-            update_env(migration_config.get_preserve_info())
-            log_env(log)
-        verbose_migration = '--no-verbose'
-        if migration_config.is_verbosity_requested():
-            verbose_migration = '--verbose'
-        solver_case = Defaults.get_zypp_gen_solver_test_case()
-        if migration_config.is_zypp_solver_test_case_requested():
-            solver_case = '--debug-solver'
-        os.environ['ZYPP_SINGLE_RPMTRANS'] = is_single_rpmtrans_requested()
-        os.environ['ZYPP_NO_USRMERGE_PROTECT'] = is_single_rpmtrans_requested()
-
-        if migration_config.is_zypper_migration_plugin_requested():
-            Zypper.run(
-                [
-                    'migration',
-                    verbose_migration,
-                    solver_case,
-                    '--non-interactive',
-                    '--gpg-auto-import-keys',
-                    '--no-selfupdate',
-                    '--auto-agree-with-licenses',
-                    '--allow-vendor-change',
-                    '--strict-errors-dist-migration',
-                    '--replacefiles',
-                    '--product', migration_config.get_migration_product(),
-                    '--root', root_path
-                ]
-            )
-        else:
-            zypper_call = Zypper.run(
-                [
-                    '--no-cd',
-                    '--non-interactive',
-                    '--gpg-auto-import-keys',
-                    '--root', root_path,
-                    'dup',
-                    '--auto-agree-with-licenses',
-                    '--allow-vendor-change',
-                    '--download', 'in-advance',
-                    '--replacefiles',
-                    '--allow-downgrade'
-                ], raise_on_error=False
-            )
-            zypper_call.raise_if_failed()
-        # report success(0) return code
-        with open(exit_code_file, 'w') as exit_code:
-            exit_code.write('0{}'.format(os.linesep))
-    except Exception as issue:
-        etc_issue_path = os.sep.join(
-            [root_path, 'etc/issue']
-        )
-        log_path_migrated_system = os.sep + os.path.relpath(
-            Defaults.get_migration_log_file(), root_path
-        )
-        with open(etc_issue_path, 'w') as issue_file:
-            issue_file.write(
-                'Migration has failed, for further details see {0}'.format(
-                    log_path_migrated_system
-                )
-            )
-        # report failed(1) return code
-        with open(exit_code_file, 'w') as exit_code:
-            exit_code.write('1{}'.format(os.linesep))
-        log.error('migrate service failed with {0}'.format(issue))
-        raise DistMigrationZypperException(
-            'Migration failed with {0}'.format(issue)
-        )
-    finally:
-        duplicate_solver_test_case_data()
+    system = MigrateSystem()
+    system.perform()

--- a/suse_migration_services/units/mount_system.py
+++ b/suse_migration_services/units/mount_system.py
@@ -33,242 +33,243 @@ from suse_migration_services.exceptions import (
 )
 
 
-def main():
-    """
-    DistMigration mount system to upgrade
+class MountSystem:
+    def __init__(self):
+        """
+        DistMigration mount system to upgrade
 
-    Searches on all partitions for a fstab file. The first
-    fstab file found is used as the system to upgrade.
-    Filesystems relevant for an upgrade process are read from
-    that fstab in order and mounted such that the system rootfs
-    is available for a zypper based migration process.
-    """
-    Logger.setup()
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    root_path = Defaults.get_system_root_path()
-    Path.create(root_path)
-    log.info('Running mount system service')
+        Searches on all partitions for a fstab file. The first
+        fstab file found is used as the system to upgrade.
+        Filesystems relevant for an upgrade process are read from
+        that fstab in order and mounted such that the system rootfs
+        is available for a zypper based migration process.
+        """
+        Logger.setup()
+        self.log = logging.getLogger(Defaults.get_migration_log_name())
+        self.root_path = Defaults.get_system_root_path()
 
-    if is_mounted(root_path):
-        # root_path is already a mount point, better not continue
-        # The condition is not handled as an error because the
-        # existing mount point under this service created root_path
-        # is considered to represent the system to upgrade and
-        # not something else. Thus if already mounted, let's use
-        # what is there.
-        return
+    def perform(self):
+        Path.create(self.root_path)
+        self.log.info('Running mount system service')
 
-    log.info('Mount system service: {0} is mounted'.format(root_path))
-    # Check if booted via loopback grub
-    isoscan_loop_mount = '/run/initramfs/isoscan'
-    if is_mounted(isoscan_loop_mount):
-        # The system to become migrated was booted via a grub
-        # loopback menuentry. This means the disk is blocked by
-        # that readonly loopback mount and needs to be
-        # remounted for read write access first
-        log.info(
-            'Mount system service: {0} is mounted'
-            .format(isoscan_loop_mount)
+        if self.is_mounted(self.root_path):
+            # root_path is already a mount point, better not continue
+            # The condition is not handled as an error because the
+            # existing mount point under this service created root_path
+            # is considered to represent the system to upgrade and
+            # not something else. Thus if already mounted, let's use
+            # what is there.
+            return
+
+        self.log.info('Mount system service: {0} is mounted'.format(
+            self.root_path)
         )
-        Command.run(
-            ['mount', '-o', 'remount,rw', isoscan_loop_mount]
-        )
-
-    activate_lvm()
-
-    mount_system(
-        root_path, read_system_fstab(root_path)
-    )
-
-    migration_config = MigrationConfig()
-    migration_config.update_migration_config_file()
-    log.info(
-        'Config file content:\n{content}\n'.format(
-            content=migration_config.get_migration_config_file_content()
-        )
-    )
-
-
-def get_uuid(device):
-    """
-    Retrieve UUID from block device
-    """
-    blkid_result = Command.run(
-        ['blkid', device, '-s', 'UUID', '-o', 'value'],
-        raise_on_error=False
-    )
-    return blkid_result.output.strip(os.linesep) if blkid_result else ''
-
-
-def activate_lvm():
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    lsblk_call = Command.run(
-        ['lsblk', '-p', '-n', '-r', '-o', 'NAME,TYPE']
-    )
-    for entry in lsblk_call.output.split(os.linesep):
-        block_record = entry.split()
-        if len(block_record) >= 2:
-            block_type = block_record[1]
-            if block_type == 'lvm':
-                log.info(
-                    'LVM managed block device(s) found, activating LVM'
-                )
-                Command.run(['vgchange', '-a', 'y'])
-                return
-
-
-def get_target_root():
-    """
-    Read the migration_target information from the kernel cmdline
-    and provide the associated device name. The migration_target
-    information was placed to the cmdline by the DMS grub boot
-    menu entry of by the DMS run_migration kexec cmdline parameter
-    """
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    try:
-        with open('/proc/cmdline') as cmdline_fd:
-            cmdline = cmdline_fd.read()
-        match = re.search(r'migration_target=([\w-]+)', cmdline)
-        if match:
-            migration_rootfs_uuid = match.group(1)
-            lsblk_call = Command.run(
-                ['lsblk', '-p', '-n', '-r', '-o', 'NAME,TYPE']
+        # Check if booted via loopback grub
+        isoscan_loop_mount = '/run/initramfs/isoscan'
+        if self.is_mounted(isoscan_loop_mount):
+            # The system to become migrated was booted via a grub
+            # loopback menuentry. This means the disk is blocked by
+            # that readonly loopback mount and needs to be
+            # remounted for read write access first
+            self.log.info(
+                'Mount system service: {0} is mounted'
+                .format(isoscan_loop_mount)
             )
-            considered_block_types = ['part', 'raid', 'lvm']
-            for entry in lsblk_call.output.split(os.linesep):
-                block_record = entry.split()
-                if len(block_record) >= 2:
-                    block_type = block_record[1]
-                    if block_type in considered_block_types:
-                        device = block_record[0]
-                        uuid = get_uuid(device)
-                        if uuid == migration_rootfs_uuid:
-                            return device
-        # nothing was found
-        raise DistMigrationSystemMountException(
-            'no match for migration_target= in cmdline'
-        )
-    except Exception as issue:
-        message = 'Failed to find target disk: {0}'.format(issue)
-        log.error(message)
-        raise DistMigrationSystemMountException(
-            message
-        )
-
-
-def read_system_fstab(root_path):
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    log.info('Reading fstab from DMS selected target disk')
-    migration_target_root = get_target_root()
-    try:
-        log.info(
-            'Lookup for fstab on {0}'.format(migration_target_root)
-        )
-        Command.run(
-            ['mount', migration_target_root, root_path]
-        )
-        fstab_file = os.sep.join(
-            [root_path, 'etc', 'fstab']
-        )
-        if os.path.isfile(fstab_file):
-            log.info(
-                'Found {0} on {1}'.format(fstab_file, migration_target_root)
-            )
-            fstab = Fstab()
-            fstab.read(fstab_file)
-            return fstab
-        raise DistMigrationSystemNotFoundException(
-            'Could not find system with fstab on {0}'.format(
-                migration_target_root
-            )
-        )
-    except Exception as issue:
-        Command.run(
-            ['umount', root_path], raise_on_error=False
-        )
-        raise DistMigrationSystemNotFoundException(
-            'Reading fstab failed with: {}'.format(issue)
-        )
-
-
-def mount_system(root_path, fstab):
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    log.info('Mount system in {0}'.format(root_path))
-    system_mount = Fstab()
-    explicit_mount_points = {
-        'devtmpfs': os.sep.join([root_path, 'dev']),
-        'proc': os.sep.join([root_path, 'proc']),
-        'sysfs': os.sep.join([root_path, 'sys'])
-    }
-    try:
-        for fstab_entry in fstab.get_devices():
-            mountpoint = ''.join(
-                [root_path, fstab_entry.mountpoint]
-            )
-            if mountpoint not in explicit_mount_points.values():
-                if fstab_entry.eligible_for_mount:
-                    log.info('Mounting {0}'.format(mountpoint))
-                    Command.run(
-                        [
-                            'mount', '-o', fstab_entry.options,
-                            fstab_entry.device, mountpoint
-                        ]
-                    )
-                system_mount.add_entry(
-                    fstab_entry.device, mountpoint, fstab_entry.fstype,
-                    fstab_entry.eligible_for_mount
-                )
-
-        log.info('Mounting kernel file systems inside {0}'.format(root_path))
-        for mount_type, mount_point in explicit_mount_points.items():
             Command.run(
-                ['mount', '-t', mount_type, mount_type, mount_point]
+                ['mount', '-o', 'remount,rw', isoscan_loop_mount]
             )
-            system_mount.add_entry(
-                mount_type, mount_point
+
+        self.activate_lvm()
+
+        self.mount_system(
+            self.root_path, self.read_system_fstab(self.root_path)
+        )
+
+        migration_config = MigrationConfig()
+        migration_config.update_migration_config_file()
+        self.log.info(
+            'Config file content:\n{content}\n'.format(
+                content=migration_config.get_migration_config_file_content()
             )
-        log.info(
-            'Bind mount subdirectories from /run inside chroot {0}'.format(
-                root_path
+        )
+
+    def get_uuid(self, device):
+        """
+        Retrieve UUID from block device
+        """
+        blkid_result = Command.run(
+            ['blkid', device, '-s', 'UUID', '-o', 'value'],
+            raise_on_error=False
+        )
+        return blkid_result.output.strip(os.linesep) if blkid_result else ''
+
+    def activate_lvm(self):
+        lsblk_call = Command.run(
+            ['lsblk', '-p', '-n', '-r', '-o', 'NAME,TYPE']
+        )
+        for entry in lsblk_call.output.split(os.linesep):
+            block_record = entry.split()
+            if len(block_record) >= 2:
+                block_type = block_record[1]
+                if block_type == 'lvm':
+                    self.log.info(
+                        'LVM managed block device(s) found, activating LVM'
+                    )
+                    Command.run(['vgchange', '-a', 'y'])
+                    return
+
+    def get_target_root(self):
+        """
+        Read the migration_target information from the kernel cmdline
+        and provide the associated device name. The migration_target
+        information was placed to the cmdline by the DMS grub boot
+        menu entry of by the DMS run_migration kexec cmdline parameter
+        """
+        try:
+            with open('/proc/cmdline') as cmdline_fd:
+                cmdline = cmdline_fd.read()
+            match = re.search(r'migration_target=([\w-]+)', cmdline)
+            if match:
+                migration_rootfs_uuid = match.group(1)
+                lsblk_call = Command.run(
+                    ['lsblk', '-p', '-n', '-r', '-o', 'NAME,TYPE']
+                )
+                considered_block_types = ['part', 'raid', 'lvm']
+                for entry in lsblk_call.output.split(os.linesep):
+                    block_record = entry.split()
+                    if len(block_record) >= 2:
+                        block_type = block_record[1]
+                        if block_type in considered_block_types:
+                            device = block_record[0]
+                            uuid = self.get_uuid(device)
+                            if uuid == migration_rootfs_uuid:
+                                return device
+            # nothing was found
+            raise DistMigrationSystemMountException(
+                'no match for migration_target= in cmdline'
             )
+        except Exception as issue:
+            message = 'Failed to find target disk: {0}'.format(issue)
+            self.log.error(message)
+            raise DistMigrationSystemMountException(
+                message
+            )
+
+    def read_system_fstab(self):
+        self.log.info('Reading fstab from DMS selected target disk')
+        migration_target_root = self.get_target_root()
+        try:
+            self.log.info(
+                'Lookup for fstab on {0}'.format(migration_target_root)
+            )
+            Command.run(
+                ['mount', migration_target_root, self.root_path]
+            )
+            fstab_file = os.sep.join(
+                [self.root_path, 'etc', 'fstab']
+            )
+            if os.path.isfile(fstab_file):
+                self.log.info(
+                    'Found {0} on {1}'.format(fstab_file, migration_target_root)
+                )
+                fstab = Fstab()
+                fstab.read(fstab_file)
+                return fstab
+            raise DistMigrationSystemNotFoundException(
+                'Could not find system with fstab on {0}'.format(
+                    migration_target_root
+                )
+            )
+        except Exception as issue:
+            Command.run(
+                ['umount', self.root_path], raise_on_error=False
+            )
+            raise DistMigrationSystemNotFoundException(
+                'Reading fstab failed with: {}'.format(issue)
+            )
+
+    def mount_system(self, fstab):
+        self.log.info('Mount system in {0}'.format(self.root_path))
+        system_mount = Fstab()
+        explicit_mount_points = {
+            'devtmpfs': os.sep.join([self.root_path, 'dev']),
+            'proc': os.sep.join([self.root_path, 'proc']),
+            'sysfs': os.sep.join([self.root_path, 'sys'])
+        }
+        try:
+            for fstab_entry in fstab.get_devices():
+                mountpoint = ''.join(
+                    [self.root_path, fstab_entry.mountpoint]
+                )
+                if mountpoint not in explicit_mount_points.values():
+                    if fstab_entry.eligible_for_mount:
+                        self.log.info('Mounting {0}'.format(mountpoint))
+                        Command.run(
+                            [
+                                'mount', '-o', fstab_entry.options,
+                                fstab_entry.device, mountpoint
+                            ]
+                        )
+                    system_mount.add_entry(
+                        fstab_entry.device, mountpoint, fstab_entry.fstype,
+                        fstab_entry.eligible_for_mount
+                    )
+
+            self.log.info(
+                'Mounting kernel file systems inside {0}'.format(self.root_path)
+            )
+            for mount_type, mount_point in explicit_mount_points.items():
+                Command.run(
+                    ['mount', '-t', mount_type, mount_type, mount_point]
+                )
+                system_mount.add_entry(
+                    mount_type, mount_point
+                )
+            self.log.info(
+                'Bind mount subdirectories from /run inside chroot {0}'.format(
+                    self.root_path
+                )
+            )
+            os.makedirs(
+                os.sep.join([self.root_path, 'run', 'NetworkManager']),
+                exist_ok=True
+            )
+            Command.run(
+                [
+                    'mount', '-o', 'bind', '/run/NetworkManager',
+                    os.sep.join([self.root_path, 'run', 'NetworkManager'])
+                ]
+            )
+            os.makedirs(
+                os.sep.join([self.root_path, 'run', 'netconfig']),
+                exist_ok=True
+            )
+            Command.run(
+                [
+                    'mount', '-o', 'bind', '/run/netconfig',
+                    os.sep.join([self.root_path, 'run', 'netconfig'])
+                ]
+            )
+        except Exception as issue:
+            self.log.error(
+                'Mounting system for upgrade failed with {0}'.format(issue)
+            )
+            raise DistMigrationSystemMountException(
+                'Mounting system for upgrade failed with {0}'.format(issue)
+            )
+        system_mount.export(
+            Defaults.get_system_mount_info_file()
         )
-        os.makedirs(
-            os.sep.join([root_path, 'run', 'NetworkManager']),
-            exist_ok=True
-        )
-        Command.run(
-            [
-                'mount', '-o', 'bind', '/run/NetworkManager',
-                os.sep.join([root_path, 'run', 'NetworkManager'])
-            ]
-        )
-        os.makedirs(
-            os.sep.join([root_path, 'run', 'netconfig']),
-            exist_ok=True
-        )
-        Command.run(
-            [
-                'mount', '-o', 'bind', '/run/netconfig',
-                os.sep.join([root_path, 'run', 'netconfig'])
-            ]
-        )
-    except Exception as issue:
-        log.error(
-            'Mounting system for upgrade failed with {0}'.format(issue)
-        )
-        raise DistMigrationSystemMountException(
-            'Mounting system for upgrade failed with {0}'.format(issue)
-        )
-    system_mount.export(
-        Defaults.get_system_mount_info_file()
-    )
+
+    def is_mounted(self, mount_point):
+        self.log.info('Checking {0} is mounted'.format(mount_point))
+        # a bind mount is neither a device nor an inode.
+        # Thus, ismount will return False for those, as
+        # it is very unlikely that a bind mount is used in fstab,
+        # that case is not handled
+        return os.path.ismount(mount_point)
 
 
-def is_mounted(mount_point):
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    log.info('Checking {0} is mounted'.format(mount_point))
-    # a bind mount is neither a device nor an inode.
-    # Thus, ismount will return False for those, as
-    # it is very unlikely that a bind mount is used in fstab,
-    # that case is not handled
-    return os.path.ismount(mount_point)
+def main():
+    mount_os = MountSystem()
+    mount_os.perform()

--- a/suse_migration_services/units/pam_config.py
+++ b/suse_migration_services/units/pam_config.py
@@ -24,27 +24,36 @@ from suse_migration_services.defaults import Defaults
 from suse_migration_services.logger import Logger
 
 
-PAM_UNIX_RE = re.compile(r"pam_unix_(auth|acct|session|passwd)\.so")
+class PamConfig:
+    def __init__(self):
+        """
+        DistMigration update PAM configuration
+
+        pam_unix_*.so have been migrated to pam_unix.so. We need to update
+        all configuration under /etc/pam.d to make them refers to the new
+        shared object.
+        """
+        Logger.setup()
+        self.log = logging.getLogger(Defaults.get_migration_log_name())
+
+    def perform(self):
+        self.log.info("Scanning /etc/pam.d")
+        pam_unix_regexp = re.compile(
+            r"pam_unix_(auth|acct|session|passwd)\.so"
+        )
+        system_root = Defaults.get_system_root_path()
+        config_dir_path = os.path.join(system_root, 'etc/pam.d/*')
+        for config_file in glob.glob(config_dir_path):
+            self.log.info(
+                'Migration PAM configuration file {0}'.format(config_file)
+            )
+            with open(config_file, 'r') as f:
+                content = f.read()
+            content = pam_unix_regexp.sub('pam_unix.so', content)
+            with open(config_file, 'w') as f:
+                f.write(content)
 
 
 def main():
-    """
-    DistMigration update PAM configuration
-
-    pam_unix_*.so have been migrated to pam_unix.so. We need to update
-    all configuration under /etc/pam.d to make them refers to the new
-    shared object.
-    """
-    Logger.setup()
-    log = logging.getLogger(Defaults.get_migration_log_name())
-
-    log.info("Scanning /etc/pam.d")
-    system_root = Defaults.get_system_root_path()
-    config_dir_path = os.path.join(system_root, 'etc/pam.d/*')
-    for config_file in glob.glob(config_dir_path):
-        log.info('Migration PAM configuration file {0}'.format(config_file))
-        with open(config_file, 'r') as f:
-            content = f.read()
-        content = PAM_UNIX_RE.sub('pam_unix.so', content)
-        with open(config_file, 'w') as f:
-            f.write(content)
+    pam_setup = PamConfig()
+    pam_setup.perform()

--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -29,9 +29,7 @@ from suse_migration_services.fstab import Fstab
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.suse_connect import SUSEConnect
 from suse_migration_services.logger import Logger
-from suse_migration_services.units.setup_host_network import (
-    log_network_details
-)
+from suse_migration_services.units.setup_host_network import SetupHostNetwork
 
 from suse_migration_services.exceptions import (
     DistMigrationZypperMetaDataException,
@@ -39,323 +37,354 @@ from suse_migration_services.exceptions import (
 )
 
 
-def main():
-    """
-    DistMigration prepare for migration
+class PrepareMigration:
+    def __init__(self):
+        """
+        DistMigration prepare for migration
 
-    Prepare the migration live system to allow zypper migration to
-    upgrade the system across major distribution versions. The zypper
-    migration process contacts the service that provides the configured
-    repositories on the system being migrated. The service must be one
-    of SUSE's repository services, SCC, RMT, or SMT. This requiers
-    information from the target system. This service makes the necessary
-    information available inside the live system that performs the migration.
-    """
-    Logger.setup()
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    log.info('Running prepare for migration')
+        Prepare the migration live system to allow zypper migration to
+        upgrade the system across major distribution versions. The zypper
+        migration process contacts the service that provides the configured
+        repositories on the system being migrated. The service must be one
+        of SUSE's repository services, SCC, RMT, or SMT. This requiers
+        information from the target system. This service makes the necessary
+        information available inside the live system that performs the
+        migration.
+        """
+        Logger.setup()
+        self.log = logging.getLogger(Defaults.get_migration_log_name())
+        self.root_path = Defaults.get_system_root_path()
+        self.suse_connect_setup = os.sep.join(
+            [self.root_path, 'etc', 'SUSEConnect']
+        )
+        self.suse_cloud_regionsrv_setup = os.sep.join(
+            [self.root_path, 'etc', 'regionserverclnt.cfg']
+        )
+        self.hosts_setup = os.sep.join(
+            [self.root_path, 'etc', 'hosts']
+        )
+        self.migration_suse_cloud_regionsrv_setup = '/etc/regionserverclnt.cfg'
+        self.trust_anchors = [
+            '/usr/share/pki/trust/anchors/',
+            '/etc/pki/trust/anchors/'
+        ]
+        self.cache_cloudregister_path = '/var/cache/cloudregister'
+        self.cloud_register_certs_path_fallback = '/usr/lib/regionService/certs'
+        self.cloud_register_certs_bind_mount_path = ''
+        self.cloud_register_metadata_path = ''
+        self.cloud_register_certs_path = ''
 
-    root_path = Defaults.get_system_root_path()
-    suse_connect_setup = os.sep.join(
-        [root_path, 'etc', 'SUSEConnect']
-    )
-    suse_cloud_regionsrv_setup = os.sep.join(
-        [root_path, 'etc', 'regionserverclnt.cfg']
-    )
-    hosts_setup = os.sep.join(
-        [root_path, 'etc', 'hosts']
-    )
-    trust_anchors = [
-        '/usr/share/pki/trust/anchors/',
-        '/etc/pki/trust/anchors/'
-    ]
-    cache_cloudregister_path = '/var/cache/cloudregister'
-    cloud_register_certs_path_fallback = '/usr/lib/regionService/certs'
-    cloud_register_certs_bind_mount_path = ''
-
-    cloud_register_metadata = ''
-
-    if os.path.exists(suse_connect_setup):
-        shutil.copy(
-            suse_connect_setup, '/etc/SUSEConnect'
-        )
-    if os.path.exists(suse_cloud_regionsrv_setup):
-        migration_suse_cloud_regionsrv_setup = '/etc/regionserverclnt.cfg'
-        shutil.copy(
-            suse_cloud_regionsrv_setup, migration_suse_cloud_regionsrv_setup
-        )
-        update_regionsrv_setup(
-            root_path, migration_suse_cloud_regionsrv_setup
-        )
-        cloud_register_certs_path = get_regionsrv_certs_path(
-            suse_cloud_regionsrv_setup,
-            cloud_register_certs_path_fallback
-        )
-        cloud_register_certs_bind_mount_path = \
-            root_path + cloud_register_certs_path
-        report_if_regionsrv_certs_not_found(
-            root_path + cloud_register_certs_path, log
-        )
-    if os.path.exists(hosts_setup):
-        shutil.copy(
-            hosts_setup, '/etc/hosts'
-        )
-    for trust_anchor in trust_anchors:
-        root_trust_anchor = os.path.normpath(
-            os.sep.join([root_path, trust_anchor])
-        )
-        if os.path.isdir(root_trust_anchor):
-            certificates = os.listdir(root_trust_anchor)
-            if certificates:
-                Path.create(trust_anchor)
-                for cert in certificates:
-                    cert_file = os.sep.join([root_trust_anchor, cert])
-                    if os.path.islink(cert_file):
-                        cert_file = os.sep.join(
-                            [root_path, os.readlink(cert_file)]
-                        )
-                    log.info('Importing certificate: %s', cert_file)
-                    try:
-                        shutil.copy(cert_file, trust_anchor)
-                    except FileNotFoundError as issue:
-                        log.warning(
-                            'Import of %s failed with %s', repr(cert_file),
-                            repr(issue)
-                        )
-                log.info('Update certificate pool')
-                Command.run(
-                    ['update-ca-certificates']
+    def perform(self):
+        self.log.info('Running prepare for migration')
+        if os.path.exists(self.suse_connect_setup):
+            shutil.copy(
+                self.suse_connect_setup, '/etc/SUSEConnect'
+            )
+        if os.path.exists(self.suse_cloud_regionsrv_setup):
+            shutil.copy(
+                self.suse_cloud_regionsrv_setup,
+                self.migration_suse_cloud_regionsrv_setup
+            )
+            self.update_regionsrv_setup()
+            self.cloud_register_certs_path = self.get_regionsrv_certs_path(
+                self.cloud_register_certs_path_fallback
+            )
+            self.cloud_register_certs_bind_mount_path = \
+                os.path.normpath(
+                    os.sep.join(
+                        [self.root_path, self.cloud_register_certs_path]
+                    )
                 )
+            self.report_if_regionsrv_certs_not_found(
+                os.path.normpath(
+                    os.sep.join(
+                        [self.root_path, self.cloud_register_certs_path]
+                    )
+                )
+            )
+        if os.path.exists(self.hosts_setup):
+            shutil.copy(
+                self.hosts_setup, '/etc/hosts'
+            )
+        for trust_anchor in self.trust_anchors:
+            root_trust_anchor = os.path.normpath(
+                os.sep.join([self.root_path, trust_anchor])
+            )
+            if os.path.isdir(root_trust_anchor):
+                certificates = os.listdir(root_trust_anchor)
+                if certificates:
+                    Path.create(trust_anchor)
+                    for cert in certificates:
+                        cert_file = os.sep.join([root_trust_anchor, cert])
+                        if os.path.islink(cert_file):
+                            cert_file = os.sep.join(
+                                [self.root_path, os.readlink(cert_file)]
+                            )
+                        self.log.info('Importing certificate: %s', cert_file)
+                        try:
+                            shutil.copy(cert_file, trust_anchor)
+                        except FileNotFoundError as issue:
+                            self.log.warning(
+                                'Import of {} failed with {}'.format(
+                                    cert_file, issue
+                                )
+                            )
+                    self.log.info('Update certificate pool')
+                    Command.run(
+                        ['update-ca-certificates']
+                    )
 
-    zypp_metadata = os.sep.join(
-        [root_path, 'etc', 'zypp']
-    )
-    zypp_plugins_services = os.sep.join(
-        [root_path, 'usr', 'lib', 'zypp', 'plugins', 'services']
-    )
+        zypp_metadata = os.sep.join(
+            [self.root_path, 'etc', 'zypp']
+        )
+        zypp_plugins_services = os.sep.join(
+            [self.root_path, 'usr', 'lib', 'zypp', 'plugins', 'services']
+        )
 
-    with open(hosts_setup, 'r', encoding="utf-8") as fp:
-        contents = fp.read()
-        log.info('Dumping Hosts file:\n %s', contents)
-        if 'susecloud.net' in contents:
-            log.info('Found an entry for "susecloud.net" in %s', hosts_setup)
+        with open(self.hosts_setup, 'r', encoding="utf-8") as fp:
+            contents = fp.read()
+            self.log.info(
+                'Dumping Hosts file:{}{}'.format(os.linesep, contents)
+            )
+            if 'susecloud.net' in contents:
+                self.log.info(
+                    'Found an entry for "susecloud.net" in {}'.format(
+                        self.hosts_setup
+                    )
+                )
+                try:
+                    self.cloud_register_metadata_path = \
+                        self.get_regionsrv_client_file_location()
+                except DistMigrationZypperMetaDataException as issue:
+                    message = 'Failed locating regionsrv-client cache files: {}'
+                    self.log.error(message.format(issue))
+                    raise
+
+        zypper_log_file = os.sep.join(
+            [self.root_path, 'var', 'log', 'zypper.log']
+        )
+        if os.path.exists(zypper_log_file):
             try:
-                cloud_register_metadata = \
-                    get_regionsrv_client_file_location(root_path)
-            except DistMigrationZypperMetaDataException as issue:
-                log.error(
-                    'Failed locating regionsrv-client cache files: {0}'.format(
+                zypper_host_log_file = zypper_log_file.replace(
+                    self.root_path, ''
+                )
+                if not os.path.exists(zypper_host_log_file):
+                    with open(zypper_host_log_file, 'w'):
+                        # we bind mount the system zypper log file
+                        # but the mount target does not exist.
+                        # Create it as empty file prior bind mounting
+                        pass
+                    Command.run(
+                        [
+                            'mount', '--bind',
+                            zypper_log_file, zypper_host_log_file
+                        ]
+                    )
+            except Exception as issue:
+                self.log.warning(
+                    'Bind mounting zypper log file failed with: {0}'.format(
                         issue
                     )
                 )
-                raise
-
-    zypper_log_file = os.sep.join(
-        [root_path, 'var', 'log', 'zypper.log']
-    )
-    if os.path.exists(zypper_log_file):
         try:
-            zypper_host_log_file = zypper_log_file.replace(root_path, '')
-            if not os.path.exists(zypper_host_log_file):
-                with open(zypper_host_log_file, 'w'):
-                    # we bind mount the system zypper log file
-                    # but the mount target does not exist.
-                    # Create it as empty file prior bind mounting
-                    pass
-                Command.run(
-                    ['mount', '--bind', zypper_log_file, zypper_host_log_file]
+            # log network info as network-online.target is done at this point
+            SetupHostNetwork().log_network_details()
+            system_mount = Fstab()
+            system_mount.read(
+                Defaults.get_system_mount_info_file()
+            )
+            self.log.info('Bind mounting /etc/zypp')
+            Command.run(
+                ['mount', '--bind', zypp_metadata, '/etc/zypp']
+            )
+            system_mount.add_entry(
+                zypp_metadata, '/etc/zypp'
+            )
+            self.log.info('Bind mounting /usr/lib/zypp/plugins')
+            Command.run(
+                [
+                    'mount', '--bind', zypp_plugins_services,
+                    '/usr/lib/zypp/plugins/services'
+                ]
+            )
+            system_mount.add_entry(
+                zypp_plugins_services, '/usr/lib/zypp/plugins/services'
+            )
+            if os.path.exists(self.cloud_register_metadata_path):
+                self.log.info(
+                    'Bind mounting {0} from {1}'.format(
+                        self.cache_cloudregister_path,
+                        self.cloud_register_metadata_path
+                    )
                 )
+                Path.create(self.cache_cloudregister_path)
+                Command.run(
+                    [
+                        'mount', '--bind',
+                        self.cloud_register_metadata_path,
+                        self.cache_cloudregister_path
+                    ]
+                )
+            if os.path.exists(self.cloud_register_certs_bind_mount_path):
+                self.log.info(
+                    'Bind mounting {0} from {1}'.format(
+                        self.cloud_register_certs_path,
+                        self.cloud_register_certs_bind_mount_path
+                    )
+                )
+                Path.create(self.cloud_register_certs_path)
+                Command.run(
+                    [
+                        'mount', '--bind',
+                        self.cloud_register_certs_bind_mount_path,
+                        self.cloud_register_certs_path
+                    ]
+                )
+                self.report_if_regionsrv_certs_not_found(
+                    self.cloud_register_certs_path
+                )
+                update_smt_cache = '/usr/sbin/updatesmtcache'
+                if os.path.isfile(update_smt_cache):
+                    self.log.info('Updating SMT cache')
+                    Command.run(
+                        [update_smt_cache]
+                    )
+            system_mount.export(
+                Defaults.get_system_mount_info_file()
+            )
+            # Check if system is registered
+            migration_config = MigrationConfig()
+            migration_config.update_migration_config_file()
+            self.log.info(
+                'Config file content:\n{content}\n'. format(
+                    content=migration_config.get_migration_config_file_content()
+                )
+            )
+            if migration_config.is_zypper_migration_plugin_requested():
+                if not SUSEConnect.is_registered(self.log):
+                    message = 'System not registered. Aborting migration.'
+                    self.log.error(message)
+                    raise DistMigrationSystemNotRegisteredException(
+                        message
+                    )
         except Exception as issue:
-            log.warning(
-                'Bind mounting zypper log file failed with: {0}'.format(issue)
+            self.log.error(
+                'Preparation of zypper metadata failed with {0}'.format(
+                    issue
+                )
             )
-    try:
-        # log network info as network-online.target is done at this point
-        log_network_details()
-        system_mount = Fstab()
-        system_mount.read(
-            Defaults.get_system_mount_info_file()
+            # Not unmounting any of the bind mounts above; the reboot
+            # service should take care of that anyway
+            raise DistMigrationZypperMetaDataException(
+                'Preparation of zypper metadata failed with {0}'.format(
+                    issue
+                )
+            )
+
+    def get_regionsrv_certs_path(self, fallback):
+        """
+        Note: This method is specific to the SUSE Public Cloud Infrastructure
+
+        Retrieve the certlocation from the specified suse_cloud_regionsrv_setup
+        config's server.certlocation setting, defaulting to fallback value
+        if not found.
+        """
+        regionsrv_setup = ConfigParser()
+        regionsrv_setup.read(self.suse_cloud_regionsrv_setup)
+        return regionsrv_setup.get(
+            'server', 'certlocation', fallback=fallback
         )
-        log.info('Bind mounting /etc/zypp')
-        Command.run(
-            ['mount', '--bind', zypp_metadata, '/etc/zypp']
-        )
-        system_mount.add_entry(
-            zypp_metadata, '/etc/zypp'
-        )
-        log.info('Bind mounting /usr/lib/zypp/plugins')
-        Command.run(
+
+    def report_if_regionsrv_certs_not_found(self, certs_path):
+        """
+        Log a message if no PEM files are found at the specified certs path
+        in the system being migrated.
+        """
+        if not glob.glob(os.path.join(certs_path, '*.pem')):
+            self.log.info(
+                'No certs found under specified certs path: {}'.format(
+                    certs_path
+                )
+            )
+
+    def update_regionsrv_setup(self):
+        """
+        Note: This method is specific to the SUSE Public Cloud Infrastructure
+
+        Update regionserverclnt.cfg config file when running in the Azure
+        Cloud. The method modifies the pre-configured azuremetadata call
+        in a way that it passes the root device as option to skip the
+        automated detection of that device. The implementation in azuremetadata
+        does not work when used inside of the special migration live system.
+        """
+        regionsrv_setup = ConfigParser()
+        regionsrv_setup.read(self.suse_cloud_regionsrv_setup)
+        dataProvider = regionsrv_setup.get('instance', 'dataProvider')
+        if 'azuremetadata' in dataProvider:
+            root_disk_device = self.get_root_disk_device()
+            if root_disk_device:
+                dataProvider += ' --device {0}'.format(root_disk_device)
+                regionsrv_setup.set('instance', 'dataProvider', dataProvider)
+                with open(self.suse_cloud_regionsrv_setup, 'w') as regionsrv_fd:
+                    regionsrv_setup.write(regionsrv_fd)
+
+    def get_root_disk_device(self):
+        """
+        Find unix disk device which is associated with the
+        root mount point given in root_path
+        """
+        root_device = Command.run(
             [
-                'mount', '--bind', zypp_plugins_services,
-                '/usr/lib/zypp/plugins/services'
+                'findmnt', '--first', '--noheadings',
+                '--output', 'SOURCE', '--mountpoint', self.root_path
             ]
-        )
-        system_mount.add_entry(
-            zypp_plugins_services, '/usr/lib/zypp/plugins/services'
-        )
-        if os.path.exists(cloud_register_metadata):
-            log.info(
-                'Bind mounting {0} from {1}'.format(
-                    cache_cloudregister_path, cloud_register_metadata
-                )
-            )
-            Path.create(cache_cloudregister_path)
-            Command.run(
+        ).output
+        if root_device:
+            # The findmnt output can contain extra volume information
+            # which we don't need for the subsequent lsblk call.
+            root_device = root_device.split('[')[0]
+            lsblk_call = Command.run(
                 [
-                    'mount', '--bind', cloud_register_metadata,
-                    cache_cloudregister_path
+                    'lsblk', '-p', '-n', '-r', '-s', '-o',
+                    'NAME,TYPE', root_device.strip()
                 ]
             )
-        if os.path.exists(cloud_register_certs_bind_mount_path):
-            log.info(
-                'Bind mounting {0} from {1}'.format(
-                    cloud_register_certs_path,
-                    cloud_register_certs_bind_mount_path
+            considered_block_types = ['disk', 'raid']
+            for entry in lsblk_call.output.split(os.linesep):
+                block_record = entry.split()
+                if len(block_record) >= 2:
+                    block_type = block_record[1]
+                    if block_type in considered_block_types:
+                        return block_record[0]
+
+    def get_regionsrv_client_file_location(self):
+        """
+        Find the correct path for the cloud-regionsrv-client cache files
+        as the location moves from /var/lib/cloudregister
+        (pre cloud-regionsrv-client-10.0.4) to /var/cache/cloudregister
+        (post cloud-regionsrv-client-10.0.4)
+        """
+        for cloud_register_path in [
+            os.sep.join([self.root_path, 'var', 'cache', 'cloudregister']),
+            os.sep.join([self.root_path, 'var', 'lib', 'cloudregister'])
+        ]:
+            self.log.info(
+                'Looking for cache files in: {}'.format(cloud_register_path)
+            )
+            if os.path.isdir(cloud_register_path) and \
+                    any('SMT' in x for x in os.listdir(cloud_register_path)):
+                self.log.info(
+                    'Cache dir exists and contains: {}'.format(
+                        os.listdir(cloud_register_path)
+                    )
                 )
-            )
-            Path.create(cloud_register_certs_path)
-            Command.run(
-                [
-                    'mount', '--bind', cloud_register_certs_bind_mount_path,
-                    cloud_register_certs_path
-                ]
-            )
-            report_if_regionsrv_certs_not_found(
-                cloud_register_certs_path, log
-            )
-            update_smt_cache = '/usr/sbin/updatesmtcache'
-            if os.path.isfile(update_smt_cache):
-                log.info('Updating SMT cache')
-                Command.run(
-                    [update_smt_cache]
-                )
-        system_mount.export(
-            Defaults.get_system_mount_info_file()
-        )
-        # Check if system is registered
-        migration_config = MigrationConfig()
-        migration_config.update_migration_config_file()
-        log.info(
-            'Config file content:\n{content}\n'. format(
-                content=migration_config.get_migration_config_file_content()
-            )
-        )
-        if migration_config.is_zypper_migration_plugin_requested():
-            if not SUSEConnect.is_registered(log):
-                message = 'System not registered. Aborting migration.'
-                log.error(message)
-                raise DistMigrationSystemNotRegisteredException(
-                    message
-                )
-    except Exception as issue:
-        log.error(
-            'Preparation of zypper metadata failed with {0}'.format(
-                issue
-            )
-        )
-        # Not unmounting any of the bind mounts above; the reboot
-        # service should take care of that anyway
+                return cloud_register_path
         raise DistMigrationZypperMetaDataException(
-            'Preparation of zypper metadata failed with {0}'.format(
-                issue
-            )
+            'No cloud-regionsrv-client cache files found in '
+            '/var/cache/cloudregister or /var/lib/cloudregister'
         )
 
 
-def get_regionsrv_certs_path(suse_cloud_regionsrv_setup, fallback):
-    """
-    Note: This method is specific to the SUSE Public Cloud Infrastructure
-
-    Retrieve the certlocation from the specified suse_cloud_regionsrv_setup
-    config's server.certlocation setting, defaulting to fallback value if not
-    found.
-    """
-    regionsrv_setup = ConfigParser()
-    regionsrv_setup.read(suse_cloud_regionsrv_setup)
-
-    return regionsrv_setup.get('server', 'certlocation', fallback=fallback)
-
-
-def report_if_regionsrv_certs_not_found(certs_path, log):
-    """
-    Log a message if no PEM files are found at the specified certs path
-    in the system being migrated.
-    """
-    if not glob.glob(os.path.join(certs_path, '*.pem')):
-        log.info("No certs found under specified certs path: %s",
-                 repr(certs_path))
-
-
-def update_regionsrv_setup(root_path, suse_cloud_regionsrv_setup):
-    """
-    Note: This method is specific to the SUSE Public Cloud Infrastructure
-
-    Update regionserverclnt.cfg config file when running in the Azure
-    Cloud. The method modifies the pre-configured azuremetadata call
-    in a way that it passes the root device as option to skip the
-    automated detection of that device. The implementation in azuremetadata
-    does not work when used inside of the special migration live system.
-    """
-    regionsrv_setup = ConfigParser()
-    regionsrv_setup.read(suse_cloud_regionsrv_setup)
-    dataProvider = regionsrv_setup.get('instance', 'dataProvider')
-    if 'azuremetadata' in dataProvider:
-        root_disk_device = get_root_disk_device(root_path)
-        if root_disk_device:
-            dataProvider += ' --device {0}'.format(root_disk_device)
-            regionsrv_setup.set('instance', 'dataProvider', dataProvider)
-            with open(suse_cloud_regionsrv_setup, 'w') as regionsrv_file:
-                regionsrv_setup.write(regionsrv_file)
-
-
-def get_root_disk_device(root_path):
-    """
-    Find unix disk device which is associated with the
-    root mount point given in root_path
-    """
-    root_device = Command.run(
-        [
-            'findmnt', '--first', '--noheadings',
-            '--output', 'SOURCE', '--mountpoint', root_path
-        ]
-    ).output
-    if root_device:
-        # The findmnt output can contain extra volume information
-        # which we don't need for the subsequent lsblk call.
-        root_device = root_device.split('[')[0]
-        lsblk_call = Command.run(
-            [
-                'lsblk', '-p', '-n', '-r', '-s', '-o',
-                'NAME,TYPE', root_device.strip()
-            ]
-        )
-        considered_block_types = ['disk', 'raid']
-        for entry in lsblk_call.output.split(os.linesep):
-            block_record = entry.split()
-            if len(block_record) >= 2:
-                block_type = block_record[1]
-                if block_type in considered_block_types:
-                    return block_record[0]
-
-
-def get_regionsrv_client_file_location(root_path):
-    """
-    Find the correct path for the cloud-regionsrv-client cache files
-    as the location moves from /var/lib/cloudregister
-    (pre cloud-regionsrv-client-10.0.4) to /var/cache/cloudregister
-    (post cloud-regionsrv-client-10.0.4)
-    """
-    temp_log = logging.getLogger(Defaults.get_migration_log_name())
-    for cloud_register_path in [
-        os.sep.join([root_path, 'var', 'cache', 'cloudregister']),
-        os.sep.join([root_path, 'var', 'lib', 'cloudregister'])
-    ]:
-        temp_log.info('Looking for cache files in %s:\n', cloud_register_path)
-        if os.path.isdir(cloud_register_path) and \
-                any('SMT' in x for x in os.listdir(cloud_register_path)):
-            temp_log.info('Cache dir exists and contains %s:\n', os.listdir(cloud_register_path))
-            return cloud_register_path
-    raise DistMigrationZypperMetaDataException(
-        'No cloud-regionsrv-client cache files found in '
-        '/var/cache/cloudregister or /var/lib/cloudregister'
-    )
+def main():
+    prepare_system = PrepareMigration()
+    prepare_system.perform()

--- a/suse_migration_services/units/product_setup.py
+++ b/suse_migration_services/units/product_setup.py
@@ -27,37 +27,46 @@ from suse_migration_services.exceptions import (
 )
 
 
-def main():
-    """
-    DistMigration setup baseproduct for migration
+class ProductSetup:
+    def __init__(self):
+        """
+        DistMigration setup baseproduct for migration
 
-    Creates a backup of the system products data and prepares
-    the baseproduct to be suitable for the distribution migration.
-    In case of an error the backup information is used by the
-    zypper migration plugin to restore the original product
-    data such that the plugin's rollback mechanism is not
-    negatively influenced.
-    """
-    Logger.setup()
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    log.info('Running setup baseproduct for migration')
-    try:
-        # Note:
-        # zypper implements a handling for the distro_target attribute.
-        # If present in the repository metadata, zypper compares the
-        # value with the baseproduct <target> setup in /etc/products.d.
-        # If they mismatch zypper refuses to create the repo. In the
-        # process of a migration from distribution [A] to [B] this mismatch
-        # always applies by design and prevents the zypper migration
-        # plugin to work. In SCC or RMT the repositories doesn't
-        # contain the distro_target attribute which is the reason
-        # why we don't see this problem there. SMT however creates repos
-        # including distro_target. The current workaround solution is
-        # to delete the target specification in the baseproduct
-        # registration if present.
-        log.info('Updating Base Product to be suitable for migration')
-        SUSEBaseProduct(log).delete_target_registration()
-    except Exception as issue:
-        message = 'Base Product update failed with: {0}'.format(issue)
-        log.error(message)
-        raise DistMigrationProductSetupException(message)
+        Creates a backup of the system products data and prepares
+        the baseproduct to be suitable for the distribution migration.
+        In case of an error the backup information is used by the
+        zypper migration plugin to restore the original product
+        data such that the plugin's rollback mechanism is not
+        negatively influenced.
+        """
+        Logger.setup()
+        self.log = logging.getLogger(Defaults.get_migration_log_name())
+
+    def perform(self):
+        self.log.info('Running setup baseproduct for migration')
+
+        try:
+            # Note:
+            # zypper implements a handling for the distro_target attribute.
+            # If present in the repository metadata, zypper compares the
+            # value with the baseproduct <target> setup in /etc/products.d.
+            # If they mismatch zypper refuses to create the repo. In the
+            # process of a migration from distribution [A] to [B] this mismatch
+            # always applies by design and prevents the zypper migration
+            # plugin to work. In SCC or RMT the repositories doesn't
+            # contain the distro_target attribute which is the reason
+            # why we don't see this problem there. SMT however creates repos
+            # including distro_target. The current workaround solution is
+            # to delete the target specification in the baseproduct
+            # registration if present.
+            self.log.info('Updating Base Product to be suitable for migration')
+            SUSEBaseProduct(self.log).delete_target_registration()
+        except Exception as issue:
+            message = 'Base Product update failed with: {0}'.format(issue)
+            self.log.error(message)
+            raise DistMigrationProductSetupException(message)
+
+
+def main():
+    product = ProductSetup()
+    product.perform()

--- a/suse_migration_services/units/reboot.py
+++ b/suse_migration_services/units/reboot.py
@@ -26,73 +26,81 @@ from suse_migration_services.fstab import Fstab
 from suse_migration_services.migration_config import MigrationConfig
 
 
-def main():
-    """
-    DistMigration reboot with new kernel
+class Reboot:
+    def __init__(self):
+        """
+        DistMigration reboot with new kernel
 
-    After the migration process is finished, the system reboots
-    unless the debug option is set.
+        After the migration process is finished, the system reboots
+        unless the debug option is set.
 
-    Before reboot a reverse umount of the filesystems that got mounted
-    by the mount_system service is performed and thus releases the
-    upgraded system from the migration host. If for whatever reason
-    a filesystem is busy and can't be umounted, this condition is not
-    handled as an error. The reason is that the cleanup should not
-    prevent us from continuing with the reboot process. The risk on
-    reboot of the migration host with a potential active mount
-    is something we accept
-    """
-    Logger.setup()
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    log.info('Running reboot service')
-    try:
-        migration_config = MigrationConfig()
-        migration_config.update_migration_config_file()
-        log.info(
-            'Config file content:\n{content}\n'. format(
-                content=migration_config.get_migration_config_file_content()
+        Before reboot a reverse umount of the filesystems that got mounted
+        by the mount_system service is performed and thus releases the
+        upgraded system from the migration host. If for whatever reason
+        a filesystem is busy and can't be umounted, this condition is not
+        handled as an error. The reason is that the cleanup should not
+        prevent us from continuing with the reboot process. The risk on
+        reboot of the migration host with a potential active mount
+        is something we accept
+        """
+        Logger.setup()
+        self.log = logging.getLogger(Defaults.get_migration_log_name())
+
+    def perform(self):
+        self.log.info('Running reboot service')
+        try:
+            migration_config = MigrationConfig()
+            migration_config.update_migration_config_file()
+            self.log.info(
+                'Config file content:\n{content}\n'. format(
+                    content=migration_config.get_migration_config_file_content()
+                )
             )
-        )
-        # stop console dialog log. The service holds a busy state
-        # on system-root and stands in our way in case of debug
-        # mode because it grabs the master console in/output
-        Command.run(
-            ['systemctl', 'stop', 'suse-migration-console-log'],
-            raise_on_error=False
-        )
-        if migration_config.is_debug_requested():
-            log.info('Reboot skipped due to debug flag set')
-        else:
-            log.info('Umounting system')
-            system_mount = Fstab()
-            system_mount.read(
-                Defaults.get_system_mount_info_file()
+            # stop console dialog log. The service holds a busy state
+            # on system-root and stands in our way in case of debug
+            # mode because it grabs the master console in/output
+            Command.run(
+                ['systemctl', 'stop', 'suse-migration-console-log'],
+                raise_on_error=False
             )
-            for mount in reversed(system_mount.get_devices()):
-                log.info(
-                    'Umounting {0}: {1}'.format(
-                        mount.mountpoint, Command.run(
-                            ['umount', '--lazy', mount.mountpoint],
-                            raise_on_error=False
+            if migration_config.is_debug_requested():
+                self.log.info('Reboot skipped due to debug flag set')
+            else:
+                self.log.info('Umounting system')
+                system_mount = Fstab()
+                system_mount.read(
+                    Defaults.get_system_mount_info_file()
+                )
+                for mount in reversed(system_mount.get_devices()):
+                    self.log.info(
+                        'Umounting {0}: {1}'.format(
+                            mount.mountpoint, Command.run(
+                                ['umount', '--lazy', mount.mountpoint],
+                                raise_on_error=False
+                            )
+                        )
+                    )
+                if not migration_config.is_soft_reboot_requested():
+                    restart_system = 'reboot'
+                else:
+                    restart_system = 'kexec'
+                self.log.info(
+                    'Reboot system: {0}{1}'.format(
+                        os.linesep, Command.run(
+                            ['systemctl', restart_system]
                         )
                     )
                 )
-            if not migration_config.is_soft_reboot_requested():
-                restart_system = 'reboot'
-            else:
-                restart_system = 'kexec'
-            log.info(
-                'Reboot system: {0}{1}'.format(
-                    os.linesep, Command.run(
-                        ['systemctl', restart_system]
-                    )
-                )
+        except Exception:
+            # Uhh, we don't want to be here, but we also don't
+            # want to be stuck in the migration live system.
+            # Keep fingers crossed:
+            self.log.warning('Reboot system: [Force Reboot]')
+            Command.run(
+                ['systemctl', '--force', 'reboot']
             )
-    except Exception:
-        # Uhh, we don't want to be here, but we also don't
-        # want to be stuck in the migration live system.
-        # Keep fingers crossed:
-        log.warning('Reboot system: [Force Reboot]')
-        Command.run(
-            ['systemctl', '--force', 'reboot']
-        )
+
+
+def main():
+    reboot = Reboot()
+    reboot.perform()

--- a/suse_migration_services/units/setup_host_network.py
+++ b/suse_migration_services/units/setup_host_network.py
@@ -32,71 +32,184 @@ from suse_migration_services.exceptions import (
 )
 
 
-def main(container=False):
-    """
-    DistMigration activate host network setup
+class SetupHostNetwork:
+    def __init__(self):
+        """
+        DistMigration activate host network setup
 
-    Setup and activate the network as it is setup on the host
-    to become migrated. This includes the import of the network
-    configuration from the migration host
-    """
-    Logger.setup()
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    root_path = Defaults.get_system_root_path()
+        Setup and activate the network as it is setup on the host
+        to become migrated. This includes the import of the network
+        configuration from the migration host
+        """
+        Logger.setup()
+        self.log = logging.getLogger(Defaults.get_migration_log_name())
+        self.root_path = Defaults.get_system_root_path()
 
-    system_mount = Fstab()
-    system_mount.read(
-        Defaults.get_system_mount_info_file()
-    )
-
-    sysconfig_network_providers = os.sep.join(
-        [root_path, 'etc', 'sysconfig', 'network', 'providers']
-    )
-    sysconfig_network_setup = os.sep.join(
-        [root_path, 'etc', 'sysconfig', 'network', '*']
-    )
-    try:
-        log.info('Running setup host network service')
-        Command.run(
-            [
-                'mount', '--bind', sysconfig_network_providers,
-                '/etc/sysconfig/network/providers'
-            ]
-        )
-        system_mount.add_entry(
-            sysconfig_network_providers, '/etc/sysconfig/network/providers'
-        )
-        for network_setup in glob.glob(sysconfig_network_setup):
-            if os.path.isfile(network_setup):
-                shutil.copy(
-                    network_setup, '/etc/sysconfig/network'
-                )
-        if not container:
-            Command.run(
-                ['systemctl', 'reload', 'network']
-            )
-        wicked2nm_migrate(
-            root_path,
-            activate_connections=False if container else True
-        )
-        system_mount.export(
+    def perform(self, container):
+        system_mount = Fstab()
+        system_mount.read(
             Defaults.get_system_mount_info_file()
         )
-        if container:
+
+        sysconfig_network_providers = os.sep.join(
+            [self.root_path, 'etc', 'sysconfig', 'network', 'providers']
+        )
+        sysconfig_network_setup = os.sep.join(
+            [self.root_path, 'etc', 'sysconfig', 'network', '*']
+        )
+        try:
+            self.log.info('Running setup host network service')
             Command.run(
-                ['systemctl', 'stop', 'NetworkManager']
+                [
+                    'mount', '--bind', sysconfig_network_providers,
+                    '/etc/sysconfig/network/providers'
+                ]
             )
-    except Exception as issue:
-        log.error(
-            'Preparation of migration host network failed with {0}'.format(
-                issue
+            system_mount.add_entry(
+                sysconfig_network_providers, '/etc/sysconfig/network/providers'
+            )
+            for network_setup in glob.glob(sysconfig_network_setup):
+                if os.path.isfile(network_setup):
+                    shutil.copy(
+                        network_setup, '/etc/sysconfig/network'
+                    )
+            if not container:
+                Command.run(
+                    ['systemctl', 'reload', 'network']
+                )
+            self.wicked2nm_migrate(
+                activate_connections=False if container else True
+            )
+            system_mount.export(
+                Defaults.get_system_mount_info_file()
+            )
+            if container:
+                Command.run(
+                    ['systemctl', 'stop', 'NetworkManager']
+                )
+        except Exception as issue:
+            message = 'Preparation of migration host network failed with {}'
+            self.log.error(message.format(issue))
+            raise DistMigrationHostNetworkException(message.format(issue))
+
+    def log_network_details(self):
+        """
+        Provide detailed information about the current network setup
+
+        The method must be called in an active and online network state
+        to provide most useful information about the network interfaces
+        and its setup.
+        """
+        self.log.info(
+            'All Network Interfaces {0}{1}'.format(
+                os.linesep, Command.run(
+                    ['ip', 'a'], raise_on_error=False
+                ).output
             )
         )
-        raise DistMigrationHostNetworkException(
-            'Preparation of migration host network failed with {0}'.format(
-                issue
+        self.log.info(
+            'Routing Tables {0}{1}'.format(
+                os.linesep, Command.run(
+                    ['ip', 'r'], raise_on_error=False
+                ).output
             )
         )
+        self.log.info(
+            'DNS Resolver {0}{1}'.format(
+                os.linesep, Command.run(
+                    ['cat', '/etc/resolv.conf'], raise_on_error=False
+                ).output
+            )
+        )
+        bonding_paths = '/proc/net/bonding/bond*'
+        if os.path.exists(os.path.dirname(bonding_paths)):
+            self.log.info(
+                'Network Bonding {0}{1}'.format(
+                    os.linesep, Command.run(
+                        ['cat', bonding_paths], raise_on_error=False
+                    ).output
+                )
+            )
+
+    def wicked2nm_migrate(self, activate_connections=True):
+        """
+        Migrate from wicked to NetworkManager
+
+        Requires the `wicked show-config` xml along with netconfig files to be
+        present at `/var/cache/wicked_config`. These files are supposed to be
+        generated by rpm scriptlets. If the files aren't present this part is
+        skipped.
+        """
+        self.log.info('Running wicked2nm host network migration')
+
+        wicked_config_path = os.sep.join(
+            [self.root_path, 'var/cache/wicked_config']
+        )
+        netconf_dir_path = os.sep.join(
+            [self.root_path, 'etc/sysconfig/network']
+        )
+        migration_config = MigrationConfig()
+        net_info = migration_config.get_network_info()
+        if not os.path.exists(os.sep.join([wicked_config_path, 'config.xml'])):
+            self.log.info('No wicked config present, skipping wicked2nm.')
+            return
+        if Command.run(
+            ['rpm', '--query', '--quiet', 'wicked2nm'],
+            raise_on_error=False
+        ).returncode != 0:
+            self.log.info('No wicked2nm present, skipping wicked2nm.')
+            return
+        if Command.run(
+            ['rpm', '--query', '--quiet', 'NetworkManager-config-server'],
+            raise_on_error=False
+        ).returncode != 0:
+            self.log.info(
+                'No NetworkManager-config-server present, skipping wicked2nm'
+            )
+            return
+
+        wicked2nm_cmd = [
+            'wicked2nm',
+            'migrate',
+            '--netconfig-base-dir', netconf_dir_path
+        ]
+        if activate_connections:
+            wicked2nm_cmd.append('--activate-connections')
+        wicked2nm_cmd.append(
+            os.sep.join([wicked_config_path, 'config.xml'])
+        )
+        if net_info and 'wicked2nm-continue-migration' in net_info \
+           and net_info['wicked2nm-continue-migration']:
+            self.log.info('Ignoring wicked2nm warnings')
+            wicked2nm_cmd = wicked2nm_cmd + ['--continue-migration']
+        try:
+            Command.run(wicked2nm_cmd)
+            # Wait for NetworkManager online to fix dhcp race condition
+            Command.run(['nm-online', '-q'])
+        except Exception as issue:
+            wicked2nm_cmd = [
+                'wicked2nm', 'show',
+                '--netconfig-base-dir', netconf_dir_path,
+                os.sep.join([wicked_config_path, 'config.xml'])
+            ]
+            self.log.info(
+                'wicked2nm config {0}{1}'.format(
+                    os.linesep, Command.run(
+                        wicked2nm_cmd, raise_on_error=False
+                    ).output
+                )
+            )
+            self.log_network_details()
+            raise DistMigrationHostNetworkException(
+                'Migration from wicked to NetworkManager failed with {}'.format(
+                    issue
+                )
+            )
+
+
+def main(container=False):
+    host_network = SetupHostNetwork()
+    host_network.perform(container)
 
 
 def container():
@@ -110,116 +223,3 @@ def container():
     might still be required
     """
     main(container=True)
-
-
-def log_network_details():
-    """
-    Provide detailed information about the current network setup
-
-    The method must be called in an active and online network state to provide
-    most useful information about the network interfaces and its setup.
-    """
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    log.info(
-        'All Network Interfaces {0}{1}'.format(
-            os.linesep, Command.run(
-                ['ip', 'a'], raise_on_error=False
-            ).output
-        )
-    )
-    log.info(
-        'Routing Tables {0}{1}'.format(
-            os.linesep, Command.run(
-                ['ip', 'r'], raise_on_error=False
-            ).output
-        )
-    )
-    log.info(
-        'DNS Resolver {0}{1}'.format(
-            os.linesep, Command.run(
-                ['cat', '/etc/resolv.conf'], raise_on_error=False
-            ).output
-        )
-    )
-    bonding_paths = '/proc/net/bonding/bond*'
-    if os.path.exists(os.path.dirname(bonding_paths)):
-        log.info(
-            'Network Bonding {0}{1}'.format(
-                os.linesep, Command.run(
-                    ['cat', bonding_paths], raise_on_error=False
-                ).output
-            )
-        )
-
-
-def wicked2nm_migrate(root_path, activate_connections=True):
-    """
-    Migrate from wicked to NetworkManager
-
-    Requires the `wicked show-config` xml along with netconfig files to be
-    present at `/var/cache/wicked_config`. These files are supposed to be
-    generated by rpm scriptlets. If the files aren't present this part is
-    skipped.
-    """
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    log.info('Running wicked2nm host network migration')
-
-    wicked_config_path = os.sep.join([root_path, 'var/cache/wicked_config'])
-    netconf_dir_path = os.sep.join([root_path, 'etc/sysconfig/network'])
-    migration_config = MigrationConfig()
-    net_info = migration_config.get_network_info()
-    if not os.path.exists(os.sep.join([wicked_config_path, 'config.xml'])):
-        log.info('No wicked config present, skipping wicked2nm.')
-        return
-    if Command.run(
-        ['rpm', '--query', '--quiet', 'wicked2nm'],
-        raise_on_error=False
-    ).returncode != 0:
-        log.info('No wicked2nm present, skipping wicked2nm.')
-        return
-    if Command.run(
-        ['rpm', '--query', '--quiet', 'NetworkManager-config-server'],
-        raise_on_error=False
-    ).returncode != 0:
-        log.info(
-            'No NetworkManager-config-server present, skipping wicked2nm'
-        )
-        return
-
-    wicked2nm_cmd = [
-        'wicked2nm',
-        'migrate',
-        '--netconfig-base-dir', netconf_dir_path
-    ]
-    if activate_connections:
-        wicked2nm_cmd.append('--activate-connections')
-    wicked2nm_cmd.append(
-        os.sep.join([wicked_config_path, 'config.xml'])
-    )
-    if net_info and 'wicked2nm-continue-migration' in net_info \
-       and net_info['wicked2nm-continue-migration']:
-        log.info('Ignoring wicked2nm warnings')
-        wicked2nm_cmd = wicked2nm_cmd + ['--continue-migration']
-    try:
-        Command.run(wicked2nm_cmd)
-        # Wait for NetworkManager online to fix dhcp race condition
-        Command.run(['nm-online', '-q'])
-    except Exception as issue:
-        wicked2nm_cmd = [
-            'wicked2nm', 'show',
-            '--netconfig-base-dir', netconf_dir_path,
-            os.sep.join([wicked_config_path, 'config.xml'])
-        ]
-        log.info(
-            'wicked2nm config {0}{1}'.format(
-                os.linesep, Command.run(
-                    wicked2nm_cmd, raise_on_error=False
-                ).output
-            )
-        )
-        log_network_details()
-        raise DistMigrationHostNetworkException(
-            'Migration from wicked to NetworkManager failed with {0}'.format(
-                issue
-            )
-        )

--- a/suse_migration_services/units/setup_name_resolver.py
+++ b/suse_migration_services/units/setup_name_resolver.py
@@ -30,63 +30,67 @@ from suse_migration_services.exceptions import (
 )
 
 
-def main():
-    """
-    DistMigration setup name resolver
+class SetupNameResolver:
+    def __init__(self):
+        """
+        DistMigration setup name resolver
 
-    Setup /etc/resolv.conf by importing the resolver configuration
-    from the migration host
-    """
-    Logger.setup()
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    root_path = Defaults.get_system_root_path()
-
-    system_mount = Fstab()
-    system_mount.read(
-        Defaults.get_system_mount_info_file()
-    )
-
-    resolv_conf = os.sep.join(
-        [root_path, 'etc', 'resolv.conf']
-    )
-    try:
-        log.info('Running setup resolver service')
-        if has_host_resolv_setup(resolv_conf):
-            log.info('Copying {}'.format(resolv_conf))
-            shutil.copy(
-                resolv_conf, '/etc/resolv.conf'
-            )
-        else:
-            log.info('Empty {0}, bind mounting /etc/resolv.conf to {0}'.format(resolv_conf))
-            Command.run(
-                [
-                    'mount', '--bind', '/etc/resolv.conf',
-                    resolv_conf
-                ]
-            )
-            system_mount.add_entry(
-                '/etc/resolv.conf', resolv_conf
-            )
-            system_mount.export(
-                Defaults.get_system_mount_info_file()
-            )
-    except Exception as issue:
-        log.error(
-            'Preparation of migration host network failed with {0}'.format(
-                issue
-            )
+        Setup /etc/resolv.conf by importing the resolver configuration
+        from the migration host
+        """
+        Logger.setup()
+        self.log = logging.getLogger(Defaults.get_migration_log_name())
+        self.root_path = Defaults.get_system_root_path()
+        self.resolv_conf = os.path.normpath(
+            os.sep.join([self.root_path, 'etc', 'resolv.conf'])
         )
-        raise DistMigrationNameResolverException(
-            'Preparation of migration host network failed with {0}'.format(
-                issue
+
+    def perform(self):
+        system_mount = Fstab()
+        system_mount.read(
+            Defaults.get_system_mount_info_file()
+        )
+        try:
+            self.log.info('Running setup resolver service')
+            if self.has_host_resolv_setup():
+                self.log.info('Copying {}'.format(self.resolv_conf))
+                shutil.copy(
+                    self.resolv_conf, '/etc/resolv.conf'
+                )
+            else:
+                self.log.info(
+                    'Empty {0}, bind mounting /etc/resolv.conf to {0}'.format(
+                        self.resolv_conf
+                    )
+                )
+                Command.run(
+                    [
+                        'mount', '--bind', '/etc/resolv.conf',
+                        self.resolv_conf
+                    ]
+                )
+                system_mount.add_entry(
+                    '/etc/resolv.conf', self.resolv_conf
+                )
+                system_mount.export(
+                    Defaults.get_system_mount_info_file()
+                )
+        except Exception as issue:
+            message = 'Preparation of migration host network failed with {}'
+            self.log.error(message.format(issue))
+            raise DistMigrationNameResolverException(
+                message.format(issue)
             )
-        ) from issue
+
+    def has_host_resolv_setup(self):
+        with open(self.resolv_conf, 'r') as resolv:
+            for line in resolv:
+                # check there is useful information in the remaining lines
+                if line.startswith('search') or line.startswith('nameserver'):
+                    return True
+        return False
 
 
-def has_host_resolv_setup(resolv_conf_path):
-    with open(resolv_conf_path, 'r') as resolv:
-        for line in resolv:
-            # check there is useful information in the remaining lines
-            if line.startswith('search') or line.startswith('nameserver'):
-                return True
-    return False
+def main():
+    name_resolver = SetupNameResolver()
+    name_resolver.perform()

--- a/suse_migration_services/units/ssh_keys.py
+++ b/suse_migration_services/units/ssh_keys.py
@@ -26,70 +26,78 @@ from suse_migration_services.logger import Logger
 from suse_migration_services.command import Command
 
 
+class SSHKeys:
+    def __init__(self):
+        """
+        DistMigration ssh access for migration user
+
+        Copy the authoritation key found to the migration user
+        directory in order to access through ssh
+        """
+        Logger.setup()
+        self.log = logging.getLogger(Defaults.get_migration_log_name())
+
+    def perform(self):
+        ssh_keys_glob_paths = Defaults.get_ssh_keys_paths()
+        migration_ssh_file = Defaults.get_migration_ssh_file()
+        system_ssh_host_keys_glob_path = \
+            Defaults.get_system_ssh_host_keys_glob_path()
+        sshd_config_path = Defaults.get_system_sshd_config_path()
+        try:
+            self.log.info('Running ssh keys service')
+            ssh_keys_paths = []
+            for glob_path in ssh_keys_glob_paths:
+                ssh_keys_paths.extend(glob.glob(glob_path))
+
+            keys_list = []
+            for ssh_keys_path in ssh_keys_paths:
+                self.log.info('Getting keys from {0}'.format(ssh_keys_path))
+                with open(ssh_keys_path) as authorized_keys_file:
+                    keys_list.append(authorized_keys_file.read())
+
+            authorized_keys_content = ''.join(keys_list)
+            self.log.info('Save keys to {0}'.format(migration_ssh_file))
+            with open(migration_ssh_file, 'w') as authorized_migration_file:
+                authorized_migration_file.write(authorized_keys_content)
+
+            system_ssh_host_keys = glob.glob(system_ssh_host_keys_glob_path)
+            sshd_config_host_keys_entries = []
+            self.log.info('Copying host ssh keys')
+            for system_ssh_host_key in system_ssh_host_keys:
+                if not system_ssh_host_key.endswith('ssh_host_key'):
+                    shutil.copy(system_ssh_host_key, '/etc/ssh/')
+
+                    if not system_ssh_host_key.endswith('.pub'):
+                        live_private_ssh_host_key_path = os.sep.join(
+                            [
+                                os.path.dirname(sshd_config_path),
+                                os.path.basename(system_ssh_host_key)
+                            ]
+                        )
+                        entry = 'HostKey {0}'.format(
+                            live_private_ssh_host_key_path
+                        )
+                        sshd_config_host_keys_entries.append(entry)
+
+            with open(sshd_config_path, 'a') as live_sshd_config_file:
+                # write one newline to be sure any subsequent
+                # HostKey entry starts correctly
+                live_sshd_config_file.write(os.linesep)
+                live_sshd_config_file.write(
+                    os.linesep.join(sshd_config_host_keys_entries)
+                )
+            self.log.info('Restarting sshd')
+            Command.run(
+                ['systemctl', 'restart', 'sshd']
+            )
+        except Exception as issue:
+            self.log.error(
+                'SSH key/identity setup failed with: {0}. {1}'.format(
+                    issue, 'Continue without ssh access'
+                )
+            )
+
+
 def main():
-    """
-    DistMigration ssh access for migration user
-
-    Copy the authoritation key found to the migration user
-    directory in order to access through ssh
-    """
-    Logger.setup()
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    ssh_keys_glob_paths = Defaults.get_ssh_keys_paths()
-    migration_ssh_file = Defaults.get_migration_ssh_file()
-    system_ssh_host_keys_glob_path = \
-        Defaults.get_system_ssh_host_keys_glob_path()
-    sshd_config_path = Defaults.get_system_sshd_config_path()
-    try:
-        log.info('Running ssh keys service')
-        ssh_keys_paths = []
-        for glob_path in ssh_keys_glob_paths:
-            ssh_keys_paths.extend(glob.glob(glob_path))
-
-        keys_list = []
-        for ssh_keys_path in ssh_keys_paths:
-            log.info('Getting keys from {0}'.format(ssh_keys_path))
-            with open(ssh_keys_path) as authorized_keys_file:
-                keys_list.append(authorized_keys_file.read())
-
-        authorized_keys_content = ''.join(keys_list)
-        log.info('Save keys to {0}'.format(migration_ssh_file))
-        with open(migration_ssh_file, 'w') as authorized_migration_file:
-            authorized_migration_file.write(authorized_keys_content)
-
-        system_ssh_host_keys = glob.glob(system_ssh_host_keys_glob_path)
-        sshd_config_host_keys_entries = []
-        log.info('Copying host ssh keys')
-        for system_ssh_host_key in system_ssh_host_keys:
-            if not system_ssh_host_key.endswith('ssh_host_key'):
-                shutil.copy(system_ssh_host_key, '/etc/ssh/')
-
-                if not system_ssh_host_key.endswith('.pub'):
-                    live_private_ssh_host_key_path = os.sep.join(
-                        [
-                            os.path.dirname(sshd_config_path),
-                            os.path.basename(system_ssh_host_key)
-                        ]
-                    )
-                    entry = 'HostKey {0}'.format(
-                        live_private_ssh_host_key_path
-                    )
-                    sshd_config_host_keys_entries.append(entry)
-
-        with open(sshd_config_path, 'a') as live_sshd_config_file:
-            # write one newline to be sure any subsequent
-            # HostKey entry starts correctly
-            live_sshd_config_file.write(os.linesep)
-            live_sshd_config_file.write(
-                os.linesep.join(sshd_config_host_keys_entries)
-            )
-        log.info('Restarting sshd')
-        Command.run(
-            ['systemctl', 'restart', 'sshd']
-        )
-    except Exception as issue:
-        log.error(
-            'SSH key/identity setup failed with: {0}. {1}'.format(
-                issue, 'Continue without ssh access'
-            )
-        )
+    ssh = SSHKeys()
+    ssh.perform()

--- a/suse_migration_services/units/wicked_migration.py
+++ b/suse_migration_services/units/wicked_migration.py
@@ -23,55 +23,65 @@ import glob
 from suse_migration_services.command import Command
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.logger import Logger
+from suse_migration_services.drop_components import DropComponents
 
 from suse_migration_services.exceptions import (
     DistMigrationWickedMigrationException
 )
 
 
-def main():
-    """
-    DistMigration migrate from wicked to NetworkManager
-    """
-    Logger.setup()
-    log = logging.getLogger(Defaults.get_migration_log_name())
-    root_path = Defaults.get_system_root_path()
+class WickedToNetworkManager(DropComponents):
+    def __init__(self):
+        """
+        DistMigration migrate from wicked to NetworkManager
+        """
+        Logger.setup()
+        self.log = logging.getLogger(Defaults.get_migration_log_name())
+        self.root_path = Defaults.get_system_root_path()
+        super().__init__()
 
-    try:
-        log.info('Running wicked to NetworkManager migration')
-
-        log.info('Enabling NetworkManager in migrated system')
-        Command.run(
-            [
-                'systemctl', '--root', root_path, 'enable',
-                '--force', 'NetworkManager.service'
-            ]
-        )
-
-        log.info('Disable wicked service completely')
-        Command.run(
-            [
-                'systemctl', '--root', root_path, 'mask',
-                'wicked.service'
-            ]
-        )
-
-        log.info('Copy connections to migrated system')
-        nm_connection_pattern = \
-            '/etc/NetworkManager/system-connections/*.nmconnection'
-        nm_connections_path = os.path.normpath(
-            os.sep.join([root_path, 'etc/NetworkManager/system-connections'])
-        )
-        Command.run(
-            ['mkdir', '-p', nm_connections_path]
-        )
-        for connection in sorted(glob.iglob(nm_connection_pattern)):
+    def perform(self):
+        try:
+            self.log.info('Running wicked to NetworkManager migration')
+            self.log.info('Enabling NetworkManager in migrated system')
             Command.run(
-                ['cp', connection, nm_connections_path]
+                [
+                    'systemctl', '--root', self.root_path, 'enable',
+                    '--force', 'NetworkManager.service'
+                ]
             )
-    except Exception as issue:
-        message = 'wicked to NetworkManager migration failed with {}'.format(
-            issue
-        )
-        log.error(message)
-        raise DistMigrationWickedMigrationException(message)
+
+            self.log.info('Disable wicked service completely')
+            Command.run(
+                [
+                    'systemctl', '--root', self.root_path, 'mask',
+                    'wicked.service'
+                ]
+            )
+
+            self.log.info('Copy connections to migrated system')
+            nm_connection_pattern = \
+                '/etc/NetworkManager/system-connections/*.nmconnection'
+            nm_connections_path = os.path.normpath(
+                os.sep.join(
+                    [self.root_path, 'etc/NetworkManager/system-connections']
+                )
+            )
+            Command.run(
+                ['mkdir', '-p', nm_connections_path]
+            )
+            for connection in sorted(glob.iglob(nm_connection_pattern)):
+                Command.run(
+                    ['cp', connection, nm_connections_path]
+                )
+        except Exception as issue:
+            message = 'wicked to NetworkManager migration failed with {}'.format(
+                issue
+            )
+            self.log.error(message)
+            raise DistMigrationWickedMigrationException(message)
+
+
+def main():
+    network_migration = WickedToNetworkManager()
+    network_migration.perform()

--- a/test/unit/drop_components_test.py
+++ b/test/unit/drop_components_test.py
@@ -1,0 +1,68 @@
+from unittest.mock import (
+    patch, Mock
+)
+
+from suse_migration_services.drop_components import DropComponents
+
+
+class TestDropComponents:
+    def setup(self):
+        self.drop = DropComponents()
+
+    def setup_method(self, cls):
+        self.setup()
+
+    def test_drop_package(self):
+        self.drop.drop_package('some')
+        assert self.drop.drop_packages == ['some']
+
+    def test_drop_path(self):
+        self.drop.drop_path('some')
+        assert self.drop.drop_files_and_directories == ['/system-root/some']
+
+    @patch('suse_migration_services.drop_components.Zypper.run')
+    def test_drop_perform_package(
+        self, mock_Zypper_run
+    ):
+        self.drop.drop_package('some')
+        self.drop.drop_package('some_other')
+        self.drop.drop_perform()
+        mock_Zypper_run.assert_called_once_with(
+            [
+                '--no-cd',
+                '--non-interactive',
+                '--gpg-auto-import-keys',
+                '--root', '/system-root',
+                'remove',
+                '--clean-deps',
+                'some',
+                'some_other'
+            ], raise_on_error=False
+        )
+
+    @patch('os.path.isdir')
+    @patch('shutil.rmtree')
+    def test_drop_perform_directory(
+        self, mock_shutil_rmtree, mock_os_path_isdir,
+    ):
+        mock_os_path_isdir.return_value = True
+        self.drop.drop_path('some/directory')
+        self.drop.drop_perform()
+        mock_shutil_rmtree.assert_called_once_with(
+            '/system-root/some/directory'
+        )
+
+    @patch('os.path.isdir')
+    @patch('pathlib.Path')
+    def test_drop_perform_file(
+        self, mock_pathlib_Path, mock_os_path_isdir
+    ):
+        path = Mock()
+        mock_pathlib_Path.return_value = path
+        mock_os_path_isdir.return_value = False
+        self.drop.drop_path('some/file')
+        self.drop.drop_perform()
+        mock_pathlib_Path.assert_called_once_with(
+            '/system-root/some/file'
+        )
+        path.unlink.assert_called_once_with(missing_ok=True)

--- a/test/unit/units/ha_migration_test.py
+++ b/test/unit/units/ha_migration_test.py
@@ -5,20 +5,23 @@ import os
 
 from suse_migration_services.exceptions import DistMigrationException
 from suse_migration_services.units import ha_migration
+from suse_migration_services.units.ha_migration import HighAvailabilityExtension
 
 
 @patch('suse_migration_services.logger.Logger.setup')
 class TestMigrationHa(TestCase):
-
     @patch('os.access')
     def test_corosync_conf_exists(self, mock_os_access, mock_logger_setup):
         mock_os_access.return_value = True
-        self.assertTrue(ha_migration._corosync_conf_exists())
-        mock_os_access.assert_called_once_with('/etc/corosync/corosync.conf', os.F_OK)
+        ha_setup = HighAvailabilityExtension()
+        self.assertTrue(ha_setup._corosync_conf_exists())
+        mock_os_access.assert_called_once_with(
+            '/etc/corosync/corosync.conf', os.F_OK
+        )
 
     @patch('suse_migration_services.command.Command.run')
     @patch('os.chroot')
-    @patch('suse_migration_services.units.ha_migration._corosync_conf_exists')
+    @patch('suse_migration_services.units.ha_migration.HighAvailabilityExtension._corosync_conf_exists')
     @patch('suse_migration_services.defaults.Defaults.get_system_root_path')
     def test_main(
         self,
@@ -36,7 +39,7 @@ class TestMigrationHa(TestCase):
 
     @patch('suse_migration_services.command.Command.run')
     @patch('os.chroot')
-    @patch('suse_migration_services.units.ha_migration._corosync_conf_exists')
+    @patch('suse_migration_services.units.ha_migration.HighAvailabilityExtension._corosync_conf_exists')
     @patch('suse_migration_services.defaults.Defaults.get_system_root_path')
     def test_main_no_corosync_conf(
         self,
@@ -54,7 +57,7 @@ class TestMigrationHa(TestCase):
 
     @patch('suse_migration_services.command.Command.run')
     @patch('os.chroot')
-    @patch('suse_migration_services.units.ha_migration._corosync_conf_exists')
+    @patch('suse_migration_services.units.ha_migration.HighAvailabilityExtension._corosync_conf_exists')
     @patch('suse_migration_services.defaults.Defaults.get_system_root_path')
     def test_main_failure(
         self,

--- a/test/unit/units/kernel_load_test.py
+++ b/test/unit/units/kernel_load_test.py
@@ -9,7 +9,7 @@ from pytest import (
 )
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.units.kernel_load import (
-    main, _get_cmdline
+    main, KernelKexec
 )
 from suse_migration_services.exceptions import (
     DistMigrationKernelRebootException
@@ -27,12 +27,14 @@ class TestKernelLoad(object):
         self, mock_os_path_exists, mock_logger_setup
     ):
         mock_os_path_exists.return_value = False
+        new_kernel = KernelKexec()
         with self._caplog.at_level(logging.ERROR):
             with raises(DistMigrationKernelRebootException):
-                _get_cmdline(Defaults.get_grub_config_file())
+                new_kernel._get_cmdline(Defaults.get_grub_config_file())
 
     def test_get_cmd_line(self, mock_path_exists, mock_logger_setup):
         mock_path_exists.return_value = True
+        new_kernel = KernelKexec()
         with open('../data/fake_grub.cfg') as fake_grub:
             fake_grub_data = fake_grub.read()
         with patch('builtins.open', create=True) as mock_open:
@@ -42,7 +44,7 @@ class TestKernelLoad(object):
             grub_cmd_content = \
                 'root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 ' + \
                 'splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw'
-            result = _get_cmdline(
+            result = new_kernel._get_cmdline(
                 os.path.basename(Defaults.get_target_kernel())
             )
             mock_open.assert_called_once_with(
@@ -52,6 +54,7 @@ class TestKernelLoad(object):
 
     def test_get_cmd_line_linuxefi(self, mock_path_exists, mock_logger_setup):
         mock_path_exists.return_value = True
+        new_kernel = KernelKexec()
         with open('../data/fake_grub_linuxefi.cfg') as fake_grub:
             fake_grub_data = fake_grub.read()
         with patch('builtins.open', create=True) as mock_open:
@@ -61,7 +64,7 @@ class TestKernelLoad(object):
             grub_cmd_content = \
                 'root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 ' + \
                 'splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw'
-            result = _get_cmdline(
+            result = new_kernel._get_cmdline(
                 os.path.basename(Defaults.get_target_kernel())
             )
             mock_open.assert_called_once_with(
@@ -73,6 +76,7 @@ class TestKernelLoad(object):
         self, mock_path_exists, mock_logger_setup
     ):
         mock_path_exists.return_value = True
+        new_kernel = KernelKexec()
         with open('../data/fake_grub_linux_var.cfg') as fake_grub:
             fake_grub_data = fake_grub.read()
         with patch('builtins.open', create=True) as mock_open:
@@ -82,7 +86,7 @@ class TestKernelLoad(object):
             grub_cmd_content = \
                 'root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 ' + \
                 'splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw'
-            result = _get_cmdline(
+            result = new_kernel._get_cmdline(
                 os.path.basename(Defaults.get_target_kernel())
             )
             mock_open.assert_called_once_with(
@@ -94,6 +98,7 @@ class TestKernelLoad(object):
         self, mock_path_exists, mock_logger_setup
     ):
         mock_path_exists.return_value = True
+        new_kernel = KernelKexec()
         with open('../data/fake_grub_with_bootpart.cfg') as fake_grub:
             fake_grub_data = fake_grub.read()
         with patch('builtins.open', create=True) as mock_open:
@@ -103,7 +108,7 @@ class TestKernelLoad(object):
             grub_cmd_content = \
                 'root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 ' + \
                 'splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw'
-            result = _get_cmdline(
+            result = new_kernel._get_cmdline(
                 os.path.basename(Defaults.get_target_kernel())
             )
             mock_open.assert_called_once_with(
@@ -114,7 +119,7 @@ class TestKernelLoad(object):
     @patch.object(Defaults, 'get_migration_config_file')
     @patch('shutil.copy')
     @patch('suse_migration_services.command.Command.run')
-    @patch('suse_migration_services.units.kernel_load._get_cmdline')
+    @patch('suse_migration_services.units.kernel_load.KernelKexec._get_cmdline')
     def test_main_raises_on_kernel_load(
         self, mock_get_cmdline, mock_Command_run, mock_shutil_copy,
         mock_get_migration_config_file, mock_os_path_exists, mock_logger_setup
@@ -150,7 +155,7 @@ class TestKernelLoad(object):
     @patch.object(Defaults, 'get_migration_config_file')
     @patch('shutil.copy')
     @patch('suse_migration_services.command.Command.run')
-    @patch('suse_migration_services.units.kernel_load._get_cmdline')
+    @patch('suse_migration_services.units.kernel_load.KernelKexec._get_cmdline')
     def test_main(
         self, mock_get_cmdline, mock_Command_run, mock_shutil_copy,
         mock_get_migration_config_file, mock_os_path_exists, mock_logger_setup
@@ -180,7 +185,7 @@ class TestKernelLoad(object):
     @patch.object(Defaults, 'get_migration_config_file')
     @patch('shutil.copy')
     @patch('suse_migration_services.command.Command.run')
-    @patch('suse_migration_services.units.kernel_load._get_cmdline')
+    @patch('suse_migration_services.units.kernel_load.KernelKexec._get_cmdline')
     def test_main_hard_reboot(
         self, mock_get_cmdline, mock_Command_run, mock_shutil_copy,
         mock_get_migration_config_file, mock_os_path_exists, mock_logger_setup

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -4,7 +4,9 @@ from unittest.mock import (
 )
 from pytest import raises
 
-from suse_migration_services.units.migrate import main, is_single_rpmtrans_requested
+from suse_migration_services.units.migrate import (
+    MigrateSystem, main
+)
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.migration_config import MigrationConfig
 from suse_migration_services.exceptions import (
@@ -32,11 +34,11 @@ class TestMigration(object):
     def setup_method(self, cls, mock_get_migration_config_file):
         self.setup()
 
-    @patch('suse_migration_services.units.migrate.is_single_rpmtrans_requested')
+    @patch('suse_migration_services.units.migrate.MigrateSystem.is_single_rpmtrans_requested')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.zypper.Zypper.run')
-    @patch('suse_migration_services.units.migrate.log_env')
-    @patch('suse_migration_services.units.migrate.update_env')
+    @patch('suse_migration_services.defaults.Defaults.log_env')
+    @patch('suse_migration_services.defaults.Defaults.update_env')
     @patch('suse_migration_services.defaults.Defaults.get_system_root_path')
     @patch('suse_migration_services.units.migrate.MigrationConfig')
     def test_main_zypper_migration_plugin_raises(
@@ -71,11 +73,11 @@ class TestMigration(object):
                 call('1\n')
             ]
 
-    @patch('suse_migration_services.units.migrate.is_single_rpmtrans_requested')
+    @patch('suse_migration_services.units.migrate.MigrateSystem.is_single_rpmtrans_requested')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.zypper.Zypper.run')
-    @patch('suse_migration_services.units.migrate.log_env')
-    @patch('suse_migration_services.units.migrate.update_env')
+    @patch('suse_migration_services.defaults.Defaults.log_env')
+    @patch('suse_migration_services.defaults.Defaults.update_env')
     @patch('suse_migration_services.defaults.Defaults.get_system_root_path')
     @patch('suse_migration_services.units.migrate.MigrationConfig')
     def test_main_zypper_dup_raises(
@@ -96,11 +98,11 @@ class TestMigration(object):
             with raises(DistMigrationZypperException):
                 main()
 
-    @patch('suse_migration_services.units.migrate.is_single_rpmtrans_requested')
+    @patch('suse_migration_services.units.migrate.MigrateSystem.is_single_rpmtrans_requested')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.zypper.Zypper.run')
-    @patch('suse_migration_services.units.migrate.log_env')
-    @patch('suse_migration_services.units.migrate.update_env')
+    @patch('suse_migration_services.defaults.Defaults.log_env')
+    @patch('suse_migration_services.defaults.Defaults.update_env')
     @patch.object(MigrationConfig, 'get_migration_product')
     @patch('suse_migration_services.units.migrate.MigrationConfig')
     def test_main_zypper_migration_plugin(
@@ -137,11 +139,11 @@ class TestMigration(object):
             ]
         )
 
-    @patch('suse_migration_services.units.migrate.is_single_rpmtrans_requested')
+    @patch('suse_migration_services.units.migrate.MigrateSystem.is_single_rpmtrans_requested')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.zypper.Zypper.run')
-    @patch('suse_migration_services.units.migrate.log_env')
-    @patch('suse_migration_services.units.migrate.update_env')
+    @patch('suse_migration_services.defaults.Defaults.log_env')
+    @patch('suse_migration_services.defaults.Defaults.update_env')
     @patch.object(MigrationConfig, 'get_migration_product')
     @patch('suse_migration_services.units.migrate.MigrationConfig')
     def test_main_zypper_migration_plugin_verbose(
@@ -171,11 +173,11 @@ class TestMigration(object):
             ]
         )
 
-    @patch('suse_migration_services.units.migrate.is_single_rpmtrans_requested')
+    @patch('suse_migration_services.units.migrate.MigrateSystem.is_single_rpmtrans_requested')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.zypper.Zypper.run')
-    @patch('suse_migration_services.units.migrate.log_env')
-    @patch('suse_migration_services.units.migrate.update_env')
+    @patch('suse_migration_services.defaults.Defaults.log_env')
+    @patch('suse_migration_services.defaults.Defaults.update_env')
     @patch.object(MigrationConfig, 'get_migration_product')
     @patch('suse_migration_services.units.migrate.MigrationConfig')
     def test_main_zypper_migration_plugin_solver_case(
@@ -205,11 +207,11 @@ class TestMigration(object):
             ]
         )
 
-    @patch('suse_migration_services.units.migrate.is_single_rpmtrans_requested')
+    @patch('suse_migration_services.units.migrate.MigrateSystem.is_single_rpmtrans_requested')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.zypper.Zypper.run')
-    @patch('suse_migration_services.units.migrate.log_env')
-    @patch('suse_migration_services.units.migrate.update_env')
+    @patch('suse_migration_services.defaults.Defaults.log_env')
+    @patch('suse_migration_services.defaults.Defaults.update_env')
     @patch('suse_migration_services.units.migrate.MigrationConfig')
     def test_main_zypper_dup(
         self, mock_MigrationConfig, mock_update_env,
@@ -238,11 +240,11 @@ class TestMigration(object):
         )
         zypper_call.raise_if_failed.assert_called_once()
 
-    @patch('suse_migration_services.units.migrate.is_single_rpmtrans_requested')
+    @patch('suse_migration_services.units.migrate.MigrateSystem.is_single_rpmtrans_requested')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.zypper.Zypper.run')
-    @patch('suse_migration_services.units.migrate.log_env')
-    @patch('suse_migration_services.units.migrate.update_env')
+    @patch('suse_migration_services.defaults.Defaults.log_env')
+    @patch('suse_migration_services.defaults.Defaults.update_env')
     @patch('suse_migration_services.units.migrate.MigrationConfig')
     @patch('os.path.isdir')
     @patch('suse_migration_services.units.migrate.Command.run')
@@ -267,33 +269,35 @@ class TestMigration(object):
         )
 
     @patch('builtins.open', new_callable=MagicMock)
-    def test_is_single_rpmtrans_requested(self, mock_open):
+    @patch('suse_migration_services.logger.Logger.setup')
+    def test_is_single_rpmtrans_requested(self, mock_logger_setup, mock_open):
+        system = MigrateSystem()
         # Test case 1: migration.single_rpmtrans is not present
         mock_open.return_value.__enter__.return_value.read.return_value = \
             'BOOT_IMAGE=/boot/vmlinuz-5.3.18-150300.59.87-default root=/dev/sda2'
-        assert is_single_rpmtrans_requested() == '0'
+        assert system.is_single_rpmtrans_requested() == '0'
 
         # Test case 2: migration.single_rpmtrans=true
         mock_open.return_value.__enter__.return_value.read.return_value = \
             'BOOT_IMAGE=/boot/vmlinuz-5.3.18-150300.59.87-default migration.single_rpmtrans=true'
-        assert is_single_rpmtrans_requested() == '1'
+        assert system.is_single_rpmtrans_requested() == '1'
 
         # Test case 3: migration.single_rpmtrans=1
         mock_open.return_value.__enter__.return_value.read.return_value = \
             'BOOT_IMAGE=/boot/vmlinuz-5.3.18-150300.59.87-default migration.single_rpmtrans=1'
-        assert is_single_rpmtrans_requested() == '1'
+        assert system.is_single_rpmtrans_requested() == '1'
 
         # Test case 4: migration.single_rpmtrans=false
         mock_open.return_value.__enter__.return_value.read.return_value = \
             'BOOT_IMAGE=/boot/vmlinuz-5.3.18-150300.59.87-default migration.single_rpmtrans=false'
-        assert is_single_rpmtrans_requested() == '0'
+        assert system.is_single_rpmtrans_requested() == '0'
 
         # Test case 5: migration.single_rpmtrans=0
         mock_open.return_value.__enter__.return_value.read.return_value = \
             'BOOT_IMAGE=/boot/vmlinuz-5.3.18-150300.59.87-default migration.single_rpmtrans=0'
-        assert is_single_rpmtrans_requested() == '0'
+        assert system.is_single_rpmtrans_requested() == '0'
 
         # Test case 6: migration.single_rpmtrans with unexpected value
         mock_open.return_value.__enter__.return_value.read.return_value = \
             'BOOT_IMAGE=/boot/vmlinuz-5.3.18-150300.59.87-default migration.single_rpmtrans=unexpected'
-        assert is_single_rpmtrans_requested() == '0'
+        assert system.is_single_rpmtrans_requested() == '0'

--- a/test/unit/units/post_mount_system_test.py
+++ b/test/unit/units/post_mount_system_test.py
@@ -1,15 +1,12 @@
-import logging
-import os
-import yaml
-
 from pytest import fixture
 from unittest.mock import (
     patch, call
 )
 
 from suse_migration_services.units.post_mount_system import (
-    main, log_env, update_env
+    main, PostMountSystem
 )
+
 from suse_migration_services.defaults import Defaults
 
 
@@ -17,6 +14,14 @@ class TestPostMountSystem(object):
     @fixture(autouse=True)
     def inject_fixtures(self, caplog):
         self._caplog = caplog
+
+    @patch('suse_migration_services.logger.Logger.setup')
+    def setup(self, mock_Logger_setup):
+        self.post_mount_os = PostMountSystem()
+
+    @patch('suse_migration_services.logger.Logger.setup')
+    def setup_method(self, cls, mock_Logger_setup):
+        self.setup()
 
     @patch('os.remove')
     @patch('os.path.isfile')
@@ -62,22 +67,3 @@ class TestPostMountSystem(object):
             call(['sysctl', '--system'])
         ]
         mock_os_remove.assert_called_once()
-
-    @patch.dict(os.environ, {'foo': 'bar', 'a': 'b'}, clear=True)
-    def test_log_env(self):
-        log = logging.getLogger('foo')
-        with self._caplog.at_level(logging.INFO):
-            log_env(log)
-        assert ' Env variables' in self._caplog.text
-        assert ' a: b\nfoo: bar\n\n' in self._caplog.text
-
-    @patch.object(Defaults, 'get_proxy_path')
-    @patch('suse_migration_services.units.post_mount_system.os')
-    def test_update_env(self, mock_os, mock_proxy_path):
-        with open('../data/migration-config-proxy.yml', 'r') as config:
-            config_data = yaml.safe_load(config)
-        mock_os.linesep = '\n'
-        mock_proxy_path.return_value = '../data/etc/sysconfig/proxy'
-
-        update_env(config_data.get('preserve'))
-        mock_os.environ.update.assert_called_once_with({'http_foo': 'bar'})

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -12,8 +12,7 @@ from unittest.mock import (
 from pytest import raises
 
 from suse_migration_services.units.prepare import (
-    main, update_regionsrv_setup, get_regionsrv_client_file_location,
-    get_regionsrv_certs_path, report_if_regionsrv_certs_not_found
+    main, PrepareMigration
 )
 
 from suse_migration_services.suse_connect import SUSEConnect
@@ -23,12 +22,23 @@ from suse_migration_services.exceptions import (
 )
 
 
-@patch('suse_migration_services.units.prepare.update_regionsrv_setup')
-@patch('suse_migration_services.logger.Logger.setup')
-@patch('suse_migration_services.units.prepare.Fstab')
-@patch('suse_migration_services.command.Command.run')
-class TestSetupPrepare(object):
-    @patch('suse_migration_services.units.prepare.get_regionsrv_client_file_location')
+class TestSetupPrepare:
+    @patch('suse_migration_services.logger.Logger.setup')
+    def setup(self, mock_Logger_setup):
+        self.log = Mock(spec=['info'])
+        self.prepare = PrepareMigration()
+        self.prepare.root_path = '/foo'
+        self.prepare.log = self.log
+
+    @patch('suse_migration_services.logger.Logger.setup')
+    def setup_method(self, cls, mock_Logger_setup):
+        self.setup()
+
+    @patch('suse_migration_services.units.prepare.PrepareMigration.update_regionsrv_setup')
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.units.prepare.Fstab')
+    @patch('suse_migration_services.command.Command.run')
+    @patch('suse_migration_services.units.prepare.PrepareMigration.get_regionsrv_client_file_location')
     @patch('shutil.copy')
     @patch('os.listdir')
     @patch('builtins.open')
@@ -51,8 +61,12 @@ class TestSetupPrepare(object):
         with raises(DistMigrationZypperMetaDataException):
             main()
 
-    @patch('suse_migration_services.units.prepare.get_regionsrv_certs_path')
-    @patch('suse_migration_services.units.prepare.get_regionsrv_client_file_location')
+    @patch('suse_migration_services.units.prepare.PrepareMigration.update_regionsrv_setup')
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.units.prepare.Fstab')
+    @patch('suse_migration_services.command.Command.run')
+    @patch('suse_migration_services.units.prepare.PrepareMigration.get_regionsrv_certs_path')
+    @patch('suse_migration_services.units.prepare.PrepareMigration.get_regionsrv_client_file_location')
     @patch('shutil.copy')
     @patch('os.listdir')
     @patch('os.path.exists')
@@ -83,7 +97,11 @@ class TestSetupPrepare(object):
             with raises(DistMigrationZypperMetaDataException):
                 main()
 
-    @patch('suse_migration_services.units.prepare.get_regionsrv_client_file_location')
+    @patch('suse_migration_services.units.prepare.PrepareMigration.update_regionsrv_setup')
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.units.prepare.Fstab')
+    @patch('suse_migration_services.command.Command.run')
+    @patch('suse_migration_services.units.prepare.PrepareMigration.get_regionsrv_client_file_location')
     @patch('shutil.copy')
     @patch('os.listdir')
     def test_main_raises_on_regionsrv_client_file_exists(
@@ -106,7 +124,11 @@ class TestSetupPrepare(object):
             with raises(DistMigrationZypperMetaDataException):
                 main()
 
-    @patch('suse_migration_services.units.prepare.get_regionsrv_client_file_location')
+    @patch('suse_migration_services.units.prepare.PrepareMigration.update_regionsrv_setup')
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.units.prepare.Fstab')
+    @patch('suse_migration_services.command.Command.run')
+    @patch('suse_migration_services.units.prepare.PrepareMigration.get_regionsrv_client_file_location')
     @patch('shutil.copy')
     @patch('os.listdir')
     @patch('builtins.open')
@@ -136,7 +158,11 @@ class TestSetupPrepare(object):
                 call(['umount', '/system-root/dev'], raise_on_error=False)
             ]
 
-    @patch('suse_migration_services.units.prepare.get_regionsrv_certs_path')
+    @patch('suse_migration_services.units.prepare.PrepareMigration.update_regionsrv_setup')
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.units.prepare.Fstab')
+    @patch('suse_migration_services.command.Command.run')
+    @patch('suse_migration_services.units.prepare.PrepareMigration.get_regionsrv_certs_path')
     @patch('os.path.isfile')
     @patch.object(SUSEConnect, 'is_registered')
     @patch('suse_migration_services.units.prepare.MigrationConfig')
@@ -308,8 +334,12 @@ class TestSetupPrepare(object):
             ['cat', '/proc/net/bonding/bond*'], raise_on_error=False
         )
 
-    @patch('suse_migration_services.units.prepare.get_regionsrv_certs_path')
-    @patch('suse_migration_services.units.prepare.get_regionsrv_client_file_location')
+    @patch('suse_migration_services.units.prepare.PrepareMigration.update_regionsrv_setup')
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.units.prepare.Fstab')
+    @patch('suse_migration_services.command.Command.run')
+    @patch('suse_migration_services.units.prepare.PrepareMigration.get_regionsrv_certs_path')
+    @patch('suse_migration_services.units.prepare.PrepareMigration.get_regionsrv_client_file_location')
     @patch.object(SUSEConnect, 'is_registered')
     @patch('suse_migration_services.units.prepare.MigrationConfig')
     @patch('suse_migration_services.units.prepare.Path')
@@ -340,12 +370,14 @@ class TestSetupPrepare(object):
             with raises(DistMigrationZypperMetaDataException):
                 main()
 
-    @patch('suse_migration_services.units.prepare.get_regionsrv_client_file_location')
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.units.prepare.Fstab')
+    @patch('suse_migration_services.command.Command.run')
+    @patch('suse_migration_services.units.prepare.PrepareMigration.get_regionsrv_client_file_location')
     @patch('os.path.exists')
     def test_update_regionsrv_setup(
         self, mock_os_path_exists, mock_get_regionsrv_client_file_location,
-        mock_Command_run, mock_Fstab, mock_logger_setup,
-        mock_update_regionsrv_setup
+        mock_Command_run, mock_Fstab, mock_logger_setup
     ):
         # test with volume based block device returned from findmnt
         mock_command_return_values = [
@@ -362,9 +394,11 @@ class TestSetupPrepare(object):
         shutil.copy(
             '../data/regionserverclnt-azure.cfg', tmp_regionserverclnt.name
         )
-        update_regionsrv_setup(
-            '/system-root', tmp_regionserverclnt.name
-        )
+        self.prepare.root_path = '/system-root'
+        self.prepare.suse_cloud_regionsrv_setup = tmp_regionserverclnt.name
+
+        self.prepare.update_regionsrv_setup()
+
         assert mock_Command_run.call_args_list == [
             call(
                 [
@@ -382,8 +416,8 @@ class TestSetupPrepare(object):
         regionsrv_setup = ConfigParser()
         regionsrv_setup.read(tmp_regionserverclnt.name)
         assert regionsrv_setup.get('instance', 'dataProvider') == \
-            '/usr/bin/azuremetadata --api latest --subscriptionId --billingTag ' \
-            '--attestedData --signature --xml --device /dev/sda'
+            '/usr/bin/azuremetadata --api latest --subscriptionId ' \
+            '--billingTag --attestedData --signature --xml --device /dev/sda'
 
         # test with standard block device returned from findmnt
         mock_command_return_values = [
@@ -393,16 +427,18 @@ class TestSetupPrepare(object):
         shutil.copy(
             '../data/regionserverclnt-azure.cfg', tmp_regionserverclnt.name
         )
-        update_regionsrv_setup(
-            '/system-root', tmp_regionserverclnt.name
-        )
+        self.prepare.update_regionsrv_setup()
 
         regionsrv_setup = ConfigParser()
         regionsrv_setup.read(tmp_regionserverclnt.name)
         assert regionsrv_setup.get('instance', 'dataProvider') == \
-            '/usr/bin/azuremetadata --api latest --subscriptionId --billingTag ' \
-            '--attestedData --signature --xml --device /dev/sdb'
+            '/usr/bin/azuremetadata --api latest --subscriptionId ' \
+            '--billingTag --attestedData --signature --xml --device /dev/sdb'
 
+    @patch('suse_migration_services.units.prepare.PrepareMigration.update_regionsrv_setup')
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.units.prepare.Fstab')
+    @patch('suse_migration_services.command.Command.run')
     @patch('os.listdir')
     @patch('os.path.isdir')
     @patch('os.path.exists')
@@ -413,9 +449,13 @@ class TestSetupPrepare(object):
     ):
         mock_path_isdir.side_effect = [False, True]
         mock_os_listdir.return_value = ['fooSMT']
-        assert get_regionsrv_client_file_location('/foo') == \
+        assert self.prepare.get_regionsrv_client_file_location() == \
             '/foo/var/lib/cloudregister'
 
+    @patch('suse_migration_services.units.prepare.PrepareMigration.update_regionsrv_setup')
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.units.prepare.Fstab')
+    @patch('suse_migration_services.command.Command.run')
     @patch('os.path.isdir')
     @patch('os.path.exists')
     def test_get_regionsrv_client_file_location_raises(
@@ -425,8 +465,12 @@ class TestSetupPrepare(object):
     ):
         mock_path_isdir.side_effect = [False, False]
         with raises(DistMigrationZypperMetaDataException):
-            get_regionsrv_client_file_location('/foo')
+            self.prepare.get_regionsrv_client_file_location()
 
+    @patch('suse_migration_services.units.prepare.PrepareMigration.update_regionsrv_setup')
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.units.prepare.Fstab')
+    @patch('suse_migration_services.command.Command.run')
     def test_get_regionsrv_certs_path_certlocation(
         self,
         mock_Command_run,
@@ -434,19 +478,16 @@ class TestSetupPrepare(object):
         mock_logger_setup,
         mock_update_regionsrv_setup,
     ):
+        self.prepare.suse_cloud_regionsrv_setup = \
+            '/some/file/that/does/not/exist'
         tmp_regionserverclnt = NamedTemporaryFile()
 
         # assert fallback path returned if client config is missing
-        assert get_regionsrv_certs_path(
-            '/some/file/that/does/not/exist',
-            'foo'
-        ) == 'foo'
+        assert self.prepare.get_regionsrv_certs_path('foo') == 'foo'
 
         # assert fallback path returned if client config is empty
-        assert get_regionsrv_certs_path(
-            tmp_regionserverclnt.name,
-            'foo'
-        ) == 'foo'
+        self.prepare.suse_cloud_regionsrv_setup = tmp_regionserverclnt.name
+        assert self.prepare.get_regionsrv_certs_path('foo') == 'foo'
 
         # test we get the fallback certlocation when none specified in config
         shutil.copy(
@@ -454,10 +495,7 @@ class TestSetupPrepare(object):
             tmp_regionserverclnt.name
         )
 
-        assert get_regionsrv_certs_path(
-            tmp_regionserverclnt.name,
-            'foo'
-        ) == 'foo'
+        assert self.prepare.get_regionsrv_certs_path('foo') == 'foo'
 
         # test we get the standard certlocation from the config
         shutil.copy(
@@ -465,10 +503,8 @@ class TestSetupPrepare(object):
             tmp_regionserverclnt.name
         )
 
-        assert get_regionsrv_certs_path(
-            tmp_regionserverclnt.name,
-            'foo'
-        ) == '/usr/lib/regionService/certs'
+        assert self.prepare.get_regionsrv_certs_path('foo') == \
+            '/usr/lib/regionService/certs'
 
         # test we get the old certlocation from an old config
         shutil.copy(
@@ -476,11 +512,13 @@ class TestSetupPrepare(object):
             tmp_regionserverclnt.name
         )
 
-        assert get_regionsrv_certs_path(
-            tmp_regionserverclnt.name,
-            'foo'
-        ) == '/var/lib/regionService/certs'
+        assert self.prepare.get_regionsrv_certs_path('foo') == \
+            '/var/lib/regionService/certs'
 
+    @patch('suse_migration_services.units.prepare.PrepareMigration.update_regionsrv_setup')
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.units.prepare.Fstab')
+    @patch('suse_migration_services.command.Command.run')
     def test_report_if_regionsrv_certs_not_found(
         self,
         mock_Command_run,
@@ -490,20 +528,18 @@ class TestSetupPrepare(object):
     ):
         tmp_certs_dir = mkdtemp()
 
-        log = Mock(spec=['info'])
-
         # verify that log.info() is called when dir has no pem files
-        report_if_regionsrv_certs_not_found(tmp_certs_dir, log)
-        assert len(log.info.call_args_list) == 1
+        self.prepare.report_if_regionsrv_certs_not_found(tmp_certs_dir)
+        assert len(self.log.info.call_args_list) == 1
 
         # reset the log mock object
-        log.reset_mock()
+        self.log.reset_mock()
 
         # verify that log.info() is not called when dir has pem files
         tmp_pem_path = os.path.join(tmp_certs_dir, 'dummy_cert.pem')
         open(tmp_pem_path, 'w').close()
-        report_if_regionsrv_certs_not_found(tmp_certs_dir, log)
-        assert len(log.info.call_args_list) == 0
+        self.prepare.report_if_regionsrv_certs_not_found(tmp_certs_dir)
+        assert len(self.log.info.call_args_list) == 0
 
         # cleanup tmp_certs_dir
         shutil.rmtree(tmp_certs_dir, ignore_errors=True)

--- a/test/unit/units/regenerate_initrd_test.py
+++ b/test/unit/units/regenerate_initrd_test.py
@@ -9,28 +9,36 @@ from pytest import (
 )
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.units.regenerate_initrd import (
-    main, dracut_bind_mounts
+    main, RegenerateBootImage
 )
 from suse_migration_services.exceptions import (
     DistMigrationCommandException
 )
 
 
-@patch('suse_migration_services.logger.Logger.setup')
-@patch('os.path.exists')
-class TestRegenInitrd():
+class TestRegenInitrd:
     @fixture(autouse=True)
     def inject_fixtures(self, caplog):
         """Setup capture log"""
         self._caplog = caplog
 
+    @patch('suse_migration_services.logger.Logger.setup')
+    def setup(self, mock_Logger_setup):
+        self.dracut = RegenerateBootImage()
+        self.dracut.root_path = '/system-root'
+
+    @patch('suse_migration_services.logger.Logger.setup')
+    def setup_method(self, cls, mock_Logger_setup):
+        self.setup()
+
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('os.path.exists')
     @patch.object(Defaults, 'get_migration_config_file')
     @patch('suse_migration_services.command.Command.run')
-    def test_main_raises_on_regen_initrd(
+    def test_main_raises_on_regenerate_initrd(
         self, mock_Command_run, mock_get_migration_config_file,
         mock_os_path_exists, mock_logger_setup
     ):
-        """ Test exception raised when running regenerate_initrd"""
         mock_get_migration_config_file.return_value = \
             '../data/migration-config-initrd.yml'
         mock_Command_run.side_effect = [
@@ -42,53 +50,15 @@ class TestRegenInitrd():
         with self._caplog.at_level(logging.ERROR):
             with raises(DistMigrationCommandException):
                 main()
-        assert mock_Command_run.call_args_list == [
-            call(
-                [
-                    'mount',
-                    '--bind',
-                    '/dev',
-                    '/system-root/dev',
-                ]
-            ),
-            call(
-                [
-                    'mount',
-                    '--bind',
-                    '/proc',
-                    '/system-root/proc',
-                ]
-            ),
-            call(
-                [
-                    'mount',
-                    '--bind',
-                    '/sys',
-                    '/system-root/sys',
-                ]
-            ),
-            call(
-                [
-                    'chroot',
-                    '/system-root',
-                    'dracut',
-                    '--no-host-only',
-                    '--no-hostonly-cmdline',
-                    '--regenerate-all',
-                    '--logfile',
-                    '/tmp/host_independent_initrd.log',
-                    '-f'
-                ]
-            )
-        ]
 
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('os.path.exists')
     @patch.object(Defaults, 'get_migration_config_file')
     @patch('suse_migration_services.command.Command.run')
     def test_dracut_bind_mounts_raises_on_regen_initrd(
         self, mock_Command_run, mock_get_migration_config_file,
         mock_os_path_exists, mock_logger_setup
     ):
-        """ Test exception raised when running dracut_bind_mounts()"""
         mock_get_migration_config_file.return_value = \
             '../data/migration-config-initrd.yml'
         mock_Command_run.side_effect = [
@@ -98,15 +68,16 @@ class TestRegenInitrd():
         ]
         with self._caplog.at_level(logging.ERROR):
             with raises(DistMigrationCommandException):
-                dracut_bind_mounts('/system-root')
+                self.dracut._dracut_bind_mounts()
 
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('os.path.exists')
     @patch.object(Defaults, 'get_migration_config_file')
     @patch('suse_migration_services.command.Command.run')
     def test_main(
         self, mock_Command_run, mock_get_migration_config_file,
         mock_os_path_exists, mock_logger_setup
     ):
-        """ Test running regenerate_initrd"""
         mock_get_migration_config_file.return_value = \
             '../data/migration-config-initrd.yml'
         main()
@@ -137,32 +108,10 @@ class TestRegenInitrd():
             ),
             call(
                 [
-                    'chroot',
-                    '/system-root',
-                    'dracut',
-                    '--no-host-only',
-                    '--no-hostonly-cmdline',
-                    '--regenerate-all',
-                    '--logfile',
-                    '/tmp/host_independent_initrd.log',
-                    '-f'
-                ]
-            ),
-            call(
-                [
-                    'chroot',
-                    '/system-root',
-                    'cat',
-                    '/tmp/host_independent_initrd.log',
-                    '>> /var/log/distro_migration.log'
-                ]
-            ),
-            call(
-                [
-                    'chroot',
-                    '/system-root',
-                    'rm',
-                    '/tmp/host_independent_initrd.log'
+                    'bash', '-c', 'chroot /system-root '
+                    'dracut --force --verbose --no-host-only '
+                    '--no-hostonly-cmdline --regenerate-all &>> '
+                    '/var/log/distro_migration.log'
                 ]
             )
         ]

--- a/test/unit/units/setup_name_resolver_test.py
+++ b/test/unit/units/setup_name_resolver_test.py
@@ -5,15 +5,25 @@ from unittest.mock import (
 from pytest import raises
 
 from suse_migration_services.units.setup_name_resolver import (
-    main, has_host_resolv_setup
+    main, SetupNameResolver
 )
 from suse_migration_services.exceptions import (
     DistMigrationNameResolverException
 )
 
 
-class TestSetupNameResolver(object):
-    @patch('suse_migration_services.units.setup_name_resolver.has_host_resolv_setup')
+class TestSetupNameResolver:
+    @patch('suse_migration_services.logger.Logger.setup')
+    def setup(self, mock_Logger_setup):
+        self.name_resolver = SetupNameResolver()
+        self.name_resolver.root_path = '/system-root'
+        self.name_resolver.resolv_conf = '/system-root/etc/resolv.conf'
+
+    @patch('suse_migration_services.logger.Logger.setup')
+    def setup_method(self, cls, mock_Logger_setup):
+        self.setup()
+
+    @patch('suse_migration_services.units.setup_name_resolver.SetupNameResolver.has_host_resolv_setup')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.setup_name_resolver.Fstab')
@@ -30,7 +40,7 @@ class TestSetupNameResolver(object):
             main()
         assert not mock_shutil_copy.called
 
-    @patch('suse_migration_services.units.setup_name_resolver.has_host_resolv_setup')
+    @patch('suse_migration_services.units.setup_name_resolver.SetupNameResolver.has_host_resolv_setup')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.setup_name_resolver.Fstab')
@@ -63,7 +73,7 @@ class TestSetupNameResolver(object):
             return_value=io.StringIO('# foo\n# bar\nsearch domain'),
             create=True
         ):
-            assert has_host_resolv_setup('foo') is True
+            assert self.name_resolver.has_host_resolv_setup() is True
 
     def test_resolv_empty_without_info(self):
         with patch(
@@ -71,9 +81,9 @@ class TestSetupNameResolver(object):
             return_value=io.StringIO('#foo\n#bar\n'),
             create=True
         ):
-            assert has_host_resolv_setup('foo') is False
+            assert self.name_resolver.has_host_resolv_setup() is False
 
-    @patch('suse_migration_services.units.setup_name_resolver.has_host_resolv_setup')
+    @patch('suse_migration_services.units.setup_name_resolver.SetupNameResolver.has_host_resolv_setup')
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('suse_migration_services.units.setup_name_resolver.Fstab')

--- a/test/unit/units/update_bootloader_test.py
+++ b/test/unit/units/update_bootloader_test.py
@@ -5,12 +5,12 @@ from pytest import fixture
 from suse_migration_services.units.update_bootloader import main
 
 
-@patch('suse_migration_services.logger.Logger.setup')
 class TestUpdateBootloader:
     @fixture(autouse=True)
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
+    @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.zypper.Zypper.run')
     @patch('suse_migration_services.command.Command.run')
     def test_main(self, mock_Command_run, mock_Zypper_run, mock_logger_setup):


### PR DESCRIPTION
Implement DropComponents class to allow for removal of packages, files and directories. Every service class that has the need to perform this task needs to inherit from DropComponents. Along with the new class also all service units are turned into classes for consistency and to allow the inheritance model for eventually further extensions to the service units. This is related to Issue #421