### PR TITLE
Fixed spec file regarding wicked2nm

### DIFF
--- a/package/suse-migration-services-spec-template
+++ b/package/suse-migration-services-spec-template
@@ -93,8 +93,8 @@ Requires:         %{pythonpkgname} = %{version}-%{release}
 Requires:         %{pythons}-Cerberus
 Requires:         %{pythons}-PyYAML
 Requires:         %{pythons}-setuptools
-%if 0%{?suse_version} >= 1500
-Recommends:       wicked2nm
+%if %{sle_version} >= 150700 || %{suse_version} >= 1600
+Requires:         wicked2nm
 %endif
 Conflicts:        suse-migration-sle15-activation < 2.0.33
 Conflicts:        suse-migration-sle16-activation < 2.0.33


### PR DESCRIPTION
wicked2nm was set as a requirement to suse-migration-pre-checks beginning with SLE15 onward. wicked2nm is needed as pre-check tool on a SLE15 host as well as as migration tool inside of a SLE16 migration image/container. The package suse-migration-pre-checks is therefore installed into the live migration image/container and also set as a required package to the containment package that contains the live migration image blob. The problem is that wicked2nm only exists partially in SLE15, actually only on SLE15-SP7 for the x86_64 architecture. This is causing a problem for the SLE12-to-SLE15 migration images which builds migration live images for SLE15 for SP4(SAP target) and SP7(standard target) for x86_64 and aarch64. wicked2nm is a tool not really used or needed for this migration but the live migration image is based on SLE15 and of course other pre-checks are needed which means suse-migration-pre-checks has to be installed into those migration live image builds as well and that causes a problem when wicked2nm is a requirement not provided for this target. The solution proposed in this commit is to make wicked2nm a recommended package for suse-migration-pre-checks and to make sure that all SLE16 image builds explicitly installs wicked2nm which is already the case for all SLE16 based migration image descriptions in this git repo.