### PR TITLE
Backup drop_path data

### DIFF
--- a/suse_migration_services/defaults.py
+++ b/suse_migration_services/defaults.py
@@ -35,6 +35,10 @@ class Defaults:
         return '/var/log/zypper.solverTestCase'
 
     @staticmethod
+    def get_migration_backup_path():
+        return '/var/migration'
+
+    @staticmethod
     def get_migration_config_file():
         return '/etc/migration-config.yml'
 

--- a/test/unit/drop_components_test.py
+++ b/test/unit/drop_components_test.py
@@ -1,16 +1,22 @@
+import io
 from unittest.mock import (
-    patch, Mock
+    patch, Mock, MagicMock
 )
 
 from suse_migration_services.drop_components import DropComponents
 
 
 class TestDropComponents:
-    def setup(self):
+    @patch('suse_migration_services.drop_components.NamedTemporaryFile')
+    @patch('suse_migration_services.drop_components.datetime')
+    def setup_method(self, cls, mock_datetime, mock_NamedTemporaryFile):
+        date = Mock()
+        date.strftime.return_value = '2025-12-07'
+        mock_datetime.now.return_value = date
+        tmpfile = Mock()
+        tmpfile.name = 'tmpfile'
+        mock_NamedTemporaryFile.return_value = tmpfile
         self.drop = DropComponents()
-
-    def setup_method(self, cls):
-        self.setup()
 
     def test_drop_package(self):
         self.drop.drop_package('some')
@@ -26,7 +32,12 @@ class TestDropComponents:
         assert self.drop.package_installed('some_not_installed') is False
 
     def test_drop_path(self):
-        self.drop.drop_path('some')
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            self.drop.drop_path('some/')
+            mock_open.assert_called_once_with('tmpfile', 'a')
+            file_handle.write.assert_called_once_with('/system-root/some\n')
         assert self.drop.drop_files_and_directories == ['/system-root/some']
 
     @patch('suse_migration_services.drop_components.Zypper.run')
@@ -55,26 +66,62 @@ class TestDropComponents:
 
     @patch('os.path.isdir')
     @patch('shutil.rmtree')
+    @patch('suse_migration_services.drop_components.Command.run')
+    @patch('suse_migration_services.drop_components.Path.create')
     def test_drop_perform_directory(
-        self, mock_shutil_rmtree, mock_os_path_isdir,
+        self,
+        mock_Path_create,
+        mock_Command_run,
+        mock_shutil_rmtree,
+        mock_os_path_isdir,
     ):
         mock_os_path_isdir.return_value = True
-        self.drop.drop_path('some/directory')
+        with patch('builtins.open', create=True):
+            self.drop.drop_path('some/directory/')
         self.drop.drop_perform()
+        mock_Path_create.assert_called_once_with(
+            '/system-root/var/migration/2025-12-07'
+        )
+        mock_Command_run.assert_called_once_with(
+            [
+                'rsync', '-avr', '--ignore-missing-args',
+                '--files-from', 'tmpfile',
+                '/system-root',
+                '/system-root/var/migration/2025-12-07/'
+            ]
+        )
         mock_shutil_rmtree.assert_called_once_with(
             '/system-root/some/directory'
         )
 
     @patch('os.path.isdir')
     @patch('pathlib.Path')
+    @patch('suse_migration_services.drop_components.Command.run')
+    @patch('suse_migration_services.drop_components.Path.create')
     def test_drop_perform_file(
-        self, mock_pathlib_Path, mock_os_path_isdir
+        self,
+        mock_Path_create,
+        mock_Command_run,
+        mock_pathlib_Path,
+        mock_os_path_isdir
     ):
         path = Mock()
         mock_pathlib_Path.return_value = path
         mock_os_path_isdir.return_value = False
-        self.drop.drop_path('some/file')
+        with patch('builtins.open', create=True):
+            self.drop.drop_path('some/file')
         self.drop.drop_perform()
+        mock_Path_create.assert_called_once_with(
+            '/system-root/var/migration/2025-12-07'
+        )
+        mock_Command_run.assert_called_once_with(
+            [
+                'rsync', '-avr', '--ignore-missing-args',
+                '--files-from', 'tmpfile',
+                '/system-root',
+                '/system-root/var/migration/2025-12-07/'
+            ]
+        )
         mock_pathlib_Path.assert_called_once_with(
             '/system-root/some/file'
         )


### PR DESCRIPTION
All data that are subject to a drop_path call will be collected and rsync backuped prior deletion. The target path for the backup data is in /var/migration/ISO_DATE/... This is related to #426