### PR TITLE
Add package_installed method

### DIFF
--- a/suse_migration_services/drop_components.py
+++ b/suse_migration_services/drop_components.py
@@ -48,18 +48,16 @@ class DropComponents:
         self.root_path = Defaults.get_system_root_path()
 
     def drop_package(self, name):
+        self.drop_packages.append(name)
+
+    def package_installed(self, name):
         package_call = Command.run(
             ['chroot', self.root_path, 'rpm', '-q', name],
             raise_on_error=False
         )
         if package_call.returncode == 0:
-            self.drop_packages.append(name)
-        else:
-            log.warning(
-                'Package {} not added to drop list: not installed'.format(
-                    name
-                )
-            )
+            return True
+        return False
 
     def drop_path(self, path):
         if self.root_path:

--- a/test/unit/drop_components_test.py
+++ b/test/unit/drop_components_test.py
@@ -12,16 +12,18 @@ class TestDropComponents:
     def setup_method(self, cls):
         self.setup()
 
+    def test_drop_package(self):
+        self.drop.drop_package('some')
+        assert self.drop.drop_packages == ['some']
+
     @patch('suse_migration_services.drop_components.Command.run')
-    def test_drop_package(self, mock_Command_run):
+    def test_package_installed(self, mock_Command_run):
         package_call = Mock()
         package_call.returncode = 0
         mock_Command_run.return_value = package_call
-        self.drop.drop_package('some')
-        assert self.drop.drop_packages == ['some']
+        assert self.drop.package_installed('some') is True
         package_call.returncode = 1
-        self.drop.drop_package('some_not_installed')
-        assert self.drop.drop_packages == ['some']
+        assert self.drop.package_installed('some_not_installed') is False
 
     def test_drop_path(self):
         self.drop.drop_path('some')


### PR DESCRIPTION
This allows service units to individually check if a package exists prior adding it to the drop list. The drop_package method will no longer perform this sanity check.