### PR TITLE
Run wicked_migration only if wicked is the active online network target

### DIFF
--- a/suse_migration_services/units/wicked_migration.py
+++ b/suse_migration_services/units/wicked_migration.py
@@ -41,8 +41,18 @@ class WickedToNetworkManager(DropComponents):
         super().__init__()
 
     def perform(self):
-        try:
+        self.log.info('Checking if wicked is setup for network management')
+        wicked_service_path = os.path.join(
+            self.root_path,
+            '/etc/systemd/system/network-online.target.wants/wicked.service'
+        )
+        if os.path.exists(wicked_service_path):
             self.log.info('Running wicked to NetworkManager migration')
+        else:
+            self.log.info('wicked is not setup as network config engine, '
+                          'nothing to do')
+            return
+        try:
             self.log.info('Enabling NetworkManager in migrated system')
             Command.run(
                 [

--- a/test/unit/units/wicked_migration_test.py
+++ b/test/unit/units/wicked_migration_test.py
@@ -17,8 +17,10 @@ class TestMigrationWicked:
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
     @patch('glob.iglob')
+    @patch('os.path.exists')
     def test_main(
         self,
+        mock_os_path_exists,
         mock_iglob,
         mock_Command_run,
         mock_logger_setup,
@@ -26,6 +28,7 @@ class TestMigrationWicked:
         mock_drop_perform,
         mock_drop_package
     ):
+        mock_os_path_exists.return_value = True
         mock_package_installed.return_value = True
         mock_iglob.return_value = [
             '/etc/NetworkManager/system-connections/some.nmconnection'
@@ -67,9 +70,21 @@ class TestMigrationWicked:
 
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('suse_migration_services.command.Command.run')
+    @patch('os.path.exists')
     def test_main_raises(
-        self, mock_Command_run, mock_logger_setup
+        self, mock_os_path_exists, mock_Command_run, mock_logger_setup
     ):
+        mock_os_path_exists.return_value = True
         mock_Command_run.side_effect = Exception
         with raises(DistMigrationWickedMigrationException):
             main()
+
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.command.Command.run')
+    @patch('os.path.exists')
+    def test_main_skip(
+            self, mock_os_path_exists, mock_Command_run, mock_logger_setup
+    ):
+        mock_os_path_exists.return_value = False
+        main()
+        assert not mock_Command_run.called


### PR DESCRIPTION
While wicked was the default network configuration code in SLE 15 NetworkManager was also available either via the Desktop Module or PackageHub. As such it is conceivable that a user does not have wicked on the system to be migrated. Check if wicked is installed before adding it to the list of packages to be remove. An error condition would be triggered when an attempt is made to remove a package that is is not installed.