### PR TITLE
Drop and backup /etc/sysconfig/network

### DIFF
--- a/suse_migration_services/units/wicked_migration.py
+++ b/suse_migration_services/units/wicked_migration.py
@@ -79,6 +79,13 @@ class WickedToNetworkManager(DropComponents):
             self.drop_package('wicked-service')
             if self.package_installed('biosdevname'):
                 self.drop_package('biosdevname')
+            self.log.info('Drop /etc/sysconfig/network from migrated system')
+            self.log.info(
+                'Please find a backup of the data at {}'.format(
+                    Defaults.get_migration_backup_path()
+                )
+            )
+            self.drop_path('/etc/sysconfig/network/')
             self.drop_perform()
         except Exception as issue:
             message = 'wicked to NetworkManager migration failed with {}'.format(

--- a/test/unit/units/wicked_migration_test.py
+++ b/test/unit/units/wicked_migration_test.py
@@ -12,6 +12,7 @@ from suse_migration_services.exceptions import (
 
 class TestMigrationWicked:
     @patch.object(DropComponents, 'drop_package')
+    @patch.object(DropComponents, 'drop_path')
     @patch.object(DropComponents, 'drop_perform')
     @patch.object(DropComponents, 'package_installed')
     @patch('suse_migration_services.logger.Logger.setup')
@@ -24,6 +25,7 @@ class TestMigrationWicked:
         mock_logger_setup,
         mock_package_installed,
         mock_drop_perform,
+        mock_drop_path,
         mock_drop_package
     ):
         mock_package_installed.return_value = True
@@ -63,6 +65,7 @@ class TestMigrationWicked:
             call('wicked-service'),
             call('biosdevname'),
         ]
+        mock_drop_path.assert_called_once_with('/etc/sysconfig/network/')
         mock_drop_perform.assert_called_once_with()
 
     @patch('suse_migration_services.logger.Logger.setup')


### PR DESCRIPTION
On successful wicked to NetworkManager migration the data in /etc/sysconfig/network is no longer needed. There will be a backup of the data available in /var/migration