### PR TITLE
Fix backup processing

### DIFF
--- a/suse_migration_services/drop_components.py
+++ b/suse_migration_services/drop_components.py
@@ -78,7 +78,7 @@ class DropComponents:
                 os.sep.join([self.root_path, path])
             )
             with open(self.backup_data.name, 'a') as backup:
-                backup.write('{}{}'.format(target_path, os.linesep))
+                backup.write('{}{}'.format(path, os.linesep))
 
             self.drop_files_and_directories.append(target_path)
 

--- a/test/unit/drop_components_test.py
+++ b/test/unit/drop_components_test.py
@@ -37,7 +37,7 @@ class TestDropComponents:
             file_handle = mock_open.return_value.__enter__.return_value
             self.drop.drop_path('some/')
             mock_open.assert_called_once_with('tmpfile', 'a')
-            file_handle.write.assert_called_once_with('/system-root/some\n')
+            file_handle.write.assert_called_once_with('some/\n')
         assert self.drop.drop_files_and_directories == ['/system-root/some']
 
     @patch('suse_migration_services.drop_components.Zypper.run')


### PR DESCRIPTION
The rsync call is done relative to the system-root path. This means that all files added to the files-from file for the rsync call must not be prefixed with that system-root path