### PR TITLE
Fixed migration live image package requires

### DIFF
--- a/image/package/suse-migration-rpm/image.spec.in
+++ b/image/package/suse-migration-rpm/image.spec.in
@@ -12,6 +12,7 @@ License:        SUSE-EULA
 Source0:        __SOURCE__
 Requires:       __PRODUCT__
 Requires:       suse-migration-pre-checks
+Requires:       suse-migration-scripts
 Provides:       Migration = __VERSION__
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 


### PR DESCRIPTION
When the containment rpm package, packages the live migration ISO image into an rpm package it also adds the run_migration tool to the package. The latest changes to run_migration code however also requires the new suse-migration-scripts package which was not yet required. This commit fixes it