### PR TITLE
Fix mount_system unit

### DIFF
--- a/suse_migration_services/units/mount_system.py
+++ b/suse_migration_services/units/mount_system.py
@@ -230,26 +230,31 @@ class MountSystem:
                     self.root_path
                 )
             )
-            os.makedirs(
-                os.sep.join([self.root_path, 'run', 'NetworkManager']),
-                exist_ok=True
+            run_network_manager = '/run/NetworkManager'
+            run_netconfig = '/run/netconfig'
+            root_run_network_manager = os.path.normpath(
+                os.sep.join([self.root_path, run_network_manager])
             )
-            Command.run(
-                [
-                    'mount', '-o', 'bind', '/run/NetworkManager',
-                    os.sep.join([self.root_path, 'run', 'NetworkManager'])
-                ]
+            root_run_netconfig = os.path.normpath(
+                os.sep.join([self.root_path, run_netconfig])
             )
-            os.makedirs(
-                os.sep.join([self.root_path, 'run', 'netconfig']),
-                exist_ok=True
-            )
-            Command.run(
-                [
-                    'mount', '-o', 'bind', '/run/netconfig',
-                    os.sep.join([self.root_path, 'run', 'netconfig'])
-                ]
-            )
+            if os.path.exists(run_network_manager):
+                os.makedirs(root_run_network_manager, exist_ok=True)
+                Command.run(
+                    [
+                        'mount', '-o', 'bind',
+                        run_network_manager, root_run_network_manager
+                    ]
+                )
+
+            if os.path.exists(run_netconfig):
+                os.makedirs(root_run_netconfig, exist_ok=True)
+                Command.run(
+                    [
+                        'mount', '-o', 'bind',
+                        run_netconfig, root_run_netconfig
+                    ]
+                )
         except Exception as issue:
             self.log.error(
                 'Mounting system for upgrade failed with {0}'.format(issue)


### PR DESCRIPTION
The mount_system unit unconditionally bind mounts /run locations into the system to migrate. If the migration system doesn't provide these mountpoints e.g /run/NetworkManager on a SLE12-to-15 migration the mount_system unit fails and the entire migration fails because of this mandatory unit to fail. We really have to be more careful when writing DMS code.