### PR TITLE
fix: ensure NetworkManager is installed on the target system

### DIFF
--- a/suse_migration_services/units/wicked_migration.py
+++ b/suse_migration_services/units/wicked_migration.py
@@ -24,6 +24,7 @@ from suse_migration_services.command import Command
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.logger import Logger
 from suse_migration_services.drop_components import DropComponents
+from suse_migration_services.zypper import Zypper
 
 from suse_migration_services.exceptions import DistMigrationWickedMigrationException
 
@@ -56,6 +57,13 @@ class WickedToNetworkManager(DropComponents):
             self.log.info('wicked is not setup as network config engine, nothing to do')
             return
         try:
+            self.log.info('Ensuring NetworkManager is installed in migrated system')
+            Zypper.install(
+                'NetworkManager',
+                'NetworkManager-config-server',
+                system_root=self.root_path
+            )
+
             self.log.info('Enabling NetworkManager in migrated system')
             Command.run(
                 [

--- a/test/unit/units/wicked_migration_test.py
+++ b/test/unit/units/wicked_migration_test.py
@@ -12,6 +12,7 @@ class TestMigrationWicked:
     @patch.object(DropComponents, 'drop_perform')
     @patch.object(DropComponents, 'package_installed')
     @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.zypper.Zypper.install')
     @patch('suse_migration_services.command.Command.run')
     @patch('glob.iglob')
     @patch('os.path.exists')
@@ -22,6 +23,7 @@ class TestMigrationWicked:
         mock_os_path_exists,
         mock_iglob,
         mock_Command_run,
+        mock_Zypper_install,
         mock_logger_setup,
         mock_package_installed,
         mock_drop_perform,
@@ -33,6 +35,11 @@ class TestMigrationWicked:
         mock_package_installed.return_value = True
         mock_iglob.return_value = ['/etc/NetworkManager/system-connections/some.nmconnection']
         main()
+        mock_Zypper_install.assert_called_once_with(
+            'NetworkManager',
+            'NetworkManager-config-server',
+            system_root='/system-root'
+        )
         assert mock_Command_run.call_args_list == [
             call(
                 [


### PR DESCRIPTION
NetworkManager might not be automatically installed when some services are enabled on the migrated system (e.g. PackageHub), which will cause the migration from wicked to NM to fail. Install NetworkManager packages explicitly to fix this issue.

Ref bsc#1254388.