### PR TITLE
Fixed get_migration_target return behavior

### DIFF
--- a/suse_migration_services/migration_target.py
+++ b/suse_migration_services/migration_target.py
@@ -45,9 +45,7 @@ class MigrationTarget:
                 'arch': product[2]
             }
         migration_iso = glob('/migration-image/*-*Migration.*.iso')
-        if not migration_iso:
-            return {}
-        migration_iso = migration_iso[0]
+        migration_iso = migration_iso[0] if migration_iso else ''
 
         if fnmatch(migration_iso, '*SLES16*-*Migration*.iso'):
             # return default migration target

--- a/test/unit/migration_target_test.py
+++ b/test/unit/migration_target_test.py
@@ -6,11 +6,24 @@ from suse_migration_services.migration_target import MigrationTarget
 
 
 class TestMigrationTarget(object):
+    @patch('suse_migration_services.migration_target.MigrationConfig')
+    def test_get_migration_target_configured(self, mock_MigrationConfig):
+        migration_config = Mock()
+        migration_config.config_data = {
+            'migration_product': 'SLES/15.4/x86_64'
+        }
+        mock_MigrationConfig.return_value = migration_config
+        assert MigrationTarget.get_migration_target() == {
+            'identifier': 'SLES',
+            'version': '15.4',
+            'arch': 'x86_64'
+        }
+
     @patch('platform.machine')
     @patch('os.path.isfile')
     @patch('suse_migration_services.migration_target.glob')
     @patch('suse_migration_services.migration_target.MigrationConfig')
-    def test_get_migration_target_empty(
+    def test_get_migration_target_no_migration_image_found(
         self, mock_MigrationConfig, mock_glob, mock_os_path_isfile,
         mock_platform_machine
     ):
@@ -20,15 +33,6 @@ class TestMigrationTarget(object):
         mock_platform_machine.return_value = 'x86_64'
         mock_glob.return_value = []
         mock_os_path_isfile.return_value = False
-        assert MigrationTarget.get_migration_target() == {}
-
-    @patch('suse_migration_services.migration_target.MigrationConfig')
-    def test_get_migration_target_configured(self, mock_MigrationConfig):
-        migration_config = Mock()
-        migration_config.config_data = {
-            'migration_product': 'SLES/15.4/x86_64'
-        }
-        mock_MigrationConfig.return_value = migration_config
         assert MigrationTarget.get_migration_target() == {
             'identifier': 'SLES',
             'version': '15.4',


### PR DESCRIPTION
Instances of MigrationTarget are used across the entire code base and it is expected that get_migration_target() always provides a proper migration target record. If it is not possible to determine the migration target it should always report the default migration target. However, there was one code path which returned an empty record wich is then causing e.g. suse-migration-pre-checks to fail with a stack trace because some code evaluates a target record when there is none. The above situation can be reproduced if a user for some reason just installs the suse-migration-pre-checks package but nothing else from the DMS. The code logic obviosly can now not detect the migration target but should not return with an empty record. This commit fixes the behavior.