### PR TITLE
Fix python compatibility on latest zypper change

### DIFF
--- a/suse_migration_services/units/wicked_migration.py
+++ b/suse_migration_services/units/wicked_migration.py
@@ -59,9 +59,7 @@ class WickedToNetworkManager(DropComponents):
         try:
             self.log.info('Ensuring NetworkManager is installed in migrated system')
             Zypper.install(
-                'NetworkManager',
-                'NetworkManager-config-server',
-                system_root=self.root_path
+                'NetworkManager', 'NetworkManager-config-server', system_root=self.root_path
             )
 
             self.log.info('Enabling NetworkManager in migrated system')

--- a/suse_migration_services/zypper.py
+++ b/suse_migration_services/zypper.py
@@ -16,7 +16,6 @@
 # along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
 #
 import os
-from typing import List
 
 # project
 from suse_migration_services.command import Command
@@ -30,7 +29,7 @@ class Zypper:
     """
 
     @staticmethod
-    def run(args: List[str], raise_on_error=True, chroot=''):
+    def run(args, raise_on_error=True, chroot=''):
         """
         Invoke zypper and block the caller. The return value is a
         ZypperCall instance containing the result of invocation.
@@ -66,13 +65,7 @@ class Zypper:
         return ZypperCall(args, command_string, result)
 
     @staticmethod
-    def install(
-        *pkgs: str,
-        raise_on_error=True,
-        system_root: str | None = None,
-        chroot='',
-        extra_args: List[str] = []
-    ):
+    def install(*pkgs: str, raise_on_error=True, system_root=None, chroot='', extra_args=[]):
         zypper_args = [
             '--no-cd',
             '--non-interactive',
@@ -99,7 +92,7 @@ class Zypper:
 
 
 class ZypperCall:
-    def __init__(self, args: List[str], command, result):
+    def __init__(self, args, command, result):
         self.args = args
         self.command = command
         self.output = result.output

--- a/test/unit/units/wicked_migration_test.py
+++ b/test/unit/units/wicked_migration_test.py
@@ -36,9 +36,7 @@ class TestMigrationWicked:
         mock_iglob.return_value = ['/etc/NetworkManager/system-connections/some.nmconnection']
         main()
         mock_Zypper_install.assert_called_once_with(
-            'NetworkManager',
-            'NetworkManager-config-server',
-            system_root='/system-root'
+            'NetworkManager', 'NetworkManager-config-server', system_root='/system-root'
         )
         assert mock_Command_run.call_args_list == [
             call(


### PR DESCRIPTION
Unfortunately the code has to comply with the oldest distribution migration that we support. This includes compatibility with the python 3.6 interpreter (SLE15). The latest change on the Zypper class introduced a TypeError and broke the migration. This commit fixes it. It should be safe to move the DMS code base to python 3.11 as the oldest migration live image is based on SLE15-SP4 which is the first target that has a python 3.11 stack. However, I hesitate to add this change now as we already have enough other problems with regards to the migration. As such it shouldn't be a problem to stay python 3.6 compatible for the moment.