### PR TITLE
Fix SLES SAP migration 12 - 15 in public clouds

### DIFF
--- a/image/pubcloud/product/sles_sap/config.kiwi
+++ b/image/pubcloud/product/sles_sap/config.kiwi
@@ -29,22 +29,22 @@
         <source path='obsrepositories:/'/>
     </repository>
     <repository type="rpm-md">
-     <source path="obs://SUSE:SLE-15-SP4:Update/standard"/>
+        <source path="obs://SUSE:SLE-15-SP4:Update/standard"/>
     </repository>
     <repository type="rpm-md">
-     <source path="obs://SUSE:SLE-15-SP4:GA/standard"/>
+        <source path="obs://SUSE:SLE-15-SP4:GA/standard"/>
     </repository>
     <repository type="rpm-md">
-	 <source path="obs://SUSE:SLE-15-SP3:Update/standard"/>
+        <source path="obs://SUSE:SLE-15-SP3:Update/standard"/>
     </repository>
     <repository type="rpm-md">
-	 <source path="obs://SUSE:SLE-15-SP3:GA/standard"/>
+        <source path="obs://SUSE:SLE-15-SP3:GA/standard"/>
     </repository>
     <repository type="rpm-md">
-	 <source path="obs://SUSE:SLE-15-SP2:Update/standard"/>
+        <source path="obs://SUSE:SLE-15-SP2:Update/standard"/>
     </repository>
     <repository type="rpm-md">
-	 <source path="obs://SUSE:SLE-15-SP2:GA/standard"/>
+        <source path="obs://SUSE:SLE-15-SP2:GA/standard"/>
     </repository>
     <repository type="rpm-md">
         <source path="obs://SUSE:SLE-15-SP1:Update/standard"/>
@@ -93,6 +93,7 @@
         <package name="dialog"/>
         <package name="sudo"/>
         <package name="mdadm"/>
+        <package name="patch"/>
         <!-- support for migration of suse public cloud on demand images -->
         <package name="cloud-regionsrv-client"/>
         <package name="cloud-regionsrv-client-generic-config"/>

--- a/image/pubcloud/product/sles_sap/config.sh
+++ b/image/pubcloud/product/sles_sap/config.sh
@@ -12,6 +12,12 @@ test -f /.profile && . /.profile
 echo "Configure image: [$kiwi_iname]..."
 
 #======================================
+# Patch DMS to work with old zypper
+#--------------------------------------
+patch -p0 < /zypper.patch
+rm -f /zypper.patch
+
+#======================================
 # Setup baseproduct link
 #--------------------------------------
 suseSetupProduct

--- a/image/pubcloud/product/sles_sap/root/zypper.patch
+++ b/image/pubcloud/product/sles_sap/root/zypper.patch
@@ -1,0 +1,38 @@
+--- /usr/lib/python3.6/site-packages/suse_migration_services/units/migrate.py	2026-02-08 14:08:55.416996870 +0100
++++ /usr/lib/python3.6/site-packages/suse_migration_services/units/migrate.py	2026-02-08 14:09:27.269033991 +0100
+@@ -75,7 +75,6 @@
+                         verbose_migration,
+                         solver_case,
+                         '--non-interactive',
+-                        '--gpg-auto-import-keys',
+                         '--no-selfupdate',
+                         '--auto-agree-with-licenses',
+                         '--allow-vendor-change',
+@@ -92,7 +91,6 @@
+                     [
+                         '--no-cd',
+                         '--non-interactive',
+-                        '--gpg-auto-import-keys',
+                         '--root',
+                         self.root_path,
+                         'dup',
+--- /usr/lib/python3.6/site-packages/suse_migration_services/zypper.py	2026-02-08 14:08:47.368987489 +0100
++++ /usr/lib/python3.6/site-packages/suse_migration_services/zypper.py	2026-02-08 14:09:37.077045423 +0100
+@@ -69,7 +69,6 @@
+         zypper_args = [
+             '--no-cd',
+             '--non-interactive',
+-            '--gpg-auto-import-keys',
+         ]
+         if system_root:
+             zypper_args += ['--root', system_root]
+--- /usr/lib/python3.6/site-packages/suse_migration_services/drop_components.py	2026-02-08 14:09:02.981005685 +0100
++++ /usr/lib/python3.6/site-packages/suse_migration_services/drop_components.py	2026-02-08 14:09:14.453019062 +0100
+@@ -90,7 +90,6 @@
+                 [
+                     '--no-cd',
+                     '--non-interactive',
+-                    '--gpg-auto-import-keys',
+                     '--root',
+                     self.root_path,
+                     'remove',


### PR DESCRIPTION
Workaround an issue in the SLE15 SP4 based live migration system used for SAP migrations only. The zypper version on SLE15 SP4 is too old and does not support --gpg-auto-import-keys. This workaround patches the DMS code to not use this option. As soon as the SAP migration live image can switch to a newer SP, this workaround can hopefully be removed again.