### PR TITLE
Renew infrastructure registration prior migration

### DIFF
--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -72,6 +72,14 @@ class PrepareMigration:
         if os.path.exists(self.suse_connect_setup):
             shutil.copy(self.suse_connect_setup, '/etc/SUSEConnect')
         if os.path.exists(self.suse_cloud_regionsrv_setup):
+            # renew registration to make sure access to the repository
+            # server is working during migration
+            Command.run(
+                ['chroot', self.root_path, 'registercloudguest', '--force-new']
+            )
+            Command.run(
+                ['chroot', self.root_path, 'zypper', 'refresh']
+            )
             shutil.copy(self.suse_cloud_regionsrv_setup, self.migration_suse_cloud_regionsrv_setup)
             self.update_regionsrv_setup()
             self.cloud_register_certs_path = self.get_regionsrv_certs_path(

--- a/test/unit/units/prepare_test.py
+++ b/test/unit/units/prepare_test.py
@@ -224,6 +224,8 @@ class TestSetupPrepare:
         mock_Command_run.side_effect = [
             MagicMock(),
             MagicMock(),
+            MagicMock(),
+            MagicMock(),
             Exception('no zypper log'),
             MagicMock(),
             MagicMock(),
@@ -265,6 +267,8 @@ class TestSetupPrepare:
             call(['/etc/pki/trust/anchors']),
         ]
         assert mock_Command_run.call_args_list == [
+            call(['chroot', '/system-root', 'registercloudguest', '--force-new']),
+            call(['chroot', '/system-root', 'zypper', 'refresh']),
             call(['update-ca-certificates']),
             call(['update-ca-certificates']),
             call(['mount', '--bind', '/system-root/var/log/zypper.log', '/var/log/zypper.log']),


### PR DESCRIPTION
In case of a migration inside of the SUSE public cloud infrastructure make sure to renew the registration such that access to the repository server is working during migration