### PR TITLE
Update documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,15 @@ find them:
 General Information
 ===================
 
+Before starting the migration process it is required to update the current
+system to the latest available packages. Call the following command to perform
+this update:
+
+.. code:: bash
+
+    zypper refresh
+    zypper up
+
 The Distribution Migration System is a collection of several software packages
 and images. Together they form a non interactive migration procedure which
 runs in an isolated environment, either as a live system or as

--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -74,6 +74,17 @@ In case an error occurs prior to the start of the upgrade the system will
 be reverted to its original state.
 
 == Upgrade Prerequisites
+General requirements for using the distribution migration system::
+Before starting the migration process it is required to update the current
+system to the latest available packages. Call the following command to perform
+this update:
++
+[listing]
+----
+zypper refresh
+zypper up
+----
+
 Requirement for using the Zypper migration workflow::
 Systems that are to be upgraded need to be registered.
 "Pay as you go"-instances in the Public Cloud are automatically registered


### PR DESCRIPTION
Added information to the general requirements prior using the DMS. We stumbled over several hard to debug issues when the system to migrate is not up to date. Up to date in this regard means not patched with `zypper patch` but up to date in terms of content and repositories via `zypper dup`. There might also be a zypper plugin issue with regards to the public cloud infrastructure and the use of `zypper patch` which would be avoided by a properly up to date system