### PR TITLE
Be more explicit about kexec example

### DIFF
--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -174,8 +174,8 @@ The `run_migration` uses `kexec` to boot into the kernel delivered with the
 upgrade image delivered by the SLES15-Migration package. Once this system
 is live after the `kexec` the distribution migration process is automatically
 started. However, `kexec` is not supported and does not function in certain
-conditions. The `run_migration` utility does not work in Xen based
-environments.
+conditions. For example, the `run_migration` utility does not work in Xen
+based environments or when kernel keys change.
 +
 If kexec causes a kernel panic this can cause the system to hang and the
 distribution migration to fail. In that case refer to this TID:


### PR DESCRIPTION
Make it more explicit that Xen is only one example where kexec does not work. Hopefully this will make the previous sentence stand out more and people will process that kexec is not a supported upgrade path.