### PR TITLE
Switch reboot default

### DIFF
--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -171,20 +171,24 @@ tux > sudo zypper in SLES15-Migration
 ----
 +
 The `run_migration` uses `kexec` to boot into the kernel delivered with the
-upgrade image delivered by the SLES15-Migration package. Once this system
-is live after the `kexec` the distribution migration process is automatically
-started. However, `kexec` is not supported and does not function in certain
-conditions. For example, the `run_migration` utility does not work in Xen
-based environments or when kernel keys change.
+upgrade image delivered by the SLES{$VERSION}-Migration package.
 +
-If kexec causes a kernel panic this can cause the system to hang and the
-distribution migration to fail. In that case refer to this TID:
-https://www.suse.com/support/kb/doc/?id=000019733
-And set the "soft_reboot" customization option:
+On the s390x architecture this is the only package available and the
+the `run_migration` method is the only option to start the migration process.
+The migration process starts automatically once the `run_migration` command
+is issued.
++
+On all other architectures the `kexec`, i.e. use of `run_migration` is not
+supported. This path does not work in certain conditions, for example
+on Xen based environments or when kernel keys change.
++
+By default this method is disabled. Enabling soft reboot behavior via kexec
+requires an explicit configuration change on all architectures except s390x
+by setting the "soft_reboot" customization option:
 +
 [listing]
 ----
-echo "soft_reboot: false" >> /etc/sle-migration-service.yml
+echo "soft_reboot: true" >> /etc/sle-migration-service.yml
 ----
 
 Option 2 - Trigger via reboot::
@@ -303,9 +307,10 @@ debug: true|false
 ----
 
 Configure Reboot Method::
-By default, the migration system uses `kexec` to boot back into the host
-system once migration is complete.  If this is in any way problematic,
-a regular `reboot` can be requested by setting `soft_reboot: false`.
+By default, the migration system uses a full reboot to boot back into the
+host system once migration is complete. It is possible to configure the
+migration system to use `kexec`, i.e. use a soft reboot by setting
+`soft_reboot: true` in the configuration. A soft reboot may trigger issues.
 +
 [listing]
 ----

--- a/suse_migration_services/migration_config.py
+++ b/suse_migration_services/migration_config.py
@@ -180,7 +180,7 @@ class MigrationConfig:
         return self.config_data.get('use_zypper_migration', True)
 
     def is_soft_reboot_requested(self):
-        return self.config_data.get('soft_reboot', True)
+        return self.config_data.get('soft_reboot', False)
 
     def is_host_independent_initd_requested(self):
         return self.config_data.get('build_host_independent_initrd', False)

--- a/test/data/migration-config-soft-reboot.yml
+++ b/test/data/migration-config-soft-reboot.yml
@@ -1,0 +1,1 @@
+soft_reboot: true

--- a/test/unit/units/kernel_load_test.py
+++ b/test/unit/units/kernel_load_test.py
@@ -108,7 +108,7 @@ class TestKernelLoad(object):
             + 'splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw'
         )
         mock_get_cmdline.return_value = cmd_line
-        mock_get_migration_config_file.return_value = '../data/migration-config.yml'
+        mock_get_migration_config_file.return_value = '../data/migration-config-soft-reboot.yml'
         mock_Command_run.side_effect = [None, Exception('error')]
         with self._caplog.at_level(logging.ERROR):
             with raises(DistMigrationKernelRebootException):
@@ -147,7 +147,7 @@ class TestKernelLoad(object):
             + 'splash root=UUID=ec7aaf92-30ea-4c07-991a-4700177ce1b8 rw'
         )
         mock_get_cmdline.return_value = cmd_line
-        mock_get_migration_config_file.return_value = '../data/migration-config.yml'
+        mock_get_migration_config_file.return_value = '../data/migration-config-soft-reboot.yml'
         main()
         assert mock_Command_run.call_args_list == [
             call(['mkdir', '-p', '/var/tmp/kexec']),

--- a/test/unit/units/reboot_test.py
+++ b/test/unit/units/reboot_test.py
@@ -58,7 +58,7 @@ class TestKernelReboot(object):
         fstab_mock.get_devices.return_value = fstab.get_devices()
         mock_Fstab.return_value = fstab_mock
         mock_get_migration_config_file.return_value = '../data/migration-config.yml'
-        mock_get_system_migration_custom_config_file.return_value = '../data/migration-config.yml'
+        mock_get_system_migration_custom_config_file.return_value = '../data/migration-config-soft-reboot.yml'
         main()
         assert mock_Command_run.call_args_list == [
             call(['systemctl', 'stop', 'suse-migration-console-log'], raise_on_error=False),


### PR DESCRIPTION
In light of recent issues reported with soft reboot we are chaning the reboot method to a full reboot. This is intended to reduce the number of requests we receive to investigate boot issues.