### PR TITLE
Fix consistency of regionserverclnt.cfg

### DIFF
--- a/suse_migration_services/units/prepare.py
+++ b/suse_migration_services/units/prepare.py
@@ -72,8 +72,8 @@ class PrepareMigration:
         if os.path.exists(self.suse_connect_setup):
             shutil.copy(self.suse_connect_setup, '/etc/SUSEConnect')
         if os.path.exists(self.suse_cloud_regionsrv_setup):
-            shutil.copy(self.suse_cloud_regionsrv_setup, self.migration_suse_cloud_regionsrv_setup)
             self.update_regionsrv_setup()
+            shutil.copy(self.suse_cloud_regionsrv_setup, self.migration_suse_cloud_regionsrv_setup)
             self.cloud_register_certs_path = self.get_regionsrv_certs_path(
                 self.cloud_register_certs_path_fallback
             )


### PR DESCRIPTION
The DMS copies the contents of system-root/etc/regionserverclnt.cfg into the live migration system /etc/regionserverclnt.cfg. However, after the copy the update_regionsrv_setup() function modifies the contents of system-root/etc/regionserverclnt.cfg if the dataProvider is azuremetadata. This leads to different content of the file in system-root and the file in /. Whether or not this is causing a problem for the migration is unclear, but in any case having the file twice with different content during the DMS runtime is a bug. This is related to bsc#1258710