### PR TITLE
Fix validation of zypper migration result

### DIFF
--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -69,7 +69,7 @@ class MigrateSystem:
             os.environ['ZYPP_NO_USRMERGE_PROTECT'] = self.is_single_rpmtrans_requested()
 
             if migration_config.is_zypper_migration_plugin_requested():
-                Zypper.run(
+                zypper_call = Zypper.run(
                     [
                         'migration',
                         verbose_migration,
@@ -87,6 +87,10 @@ class MigrateSystem:
                         self.root_path,
                     ]
                 )
+                if 'No migration available' in zypper_call.output:
+                    raise DistMigrationZypperException(
+                        'The package management system did not receive any upgrade target information from the repository server'
+                    )
             else:
                 zypper_call = Zypper.run(
                     [
@@ -123,8 +127,8 @@ class MigrateSystem:
             # report failed(1) return code
             with open(self.exit_code_file, 'w') as exit_code:
                 exit_code.write('1{}'.format(os.linesep))
-            self.log.error('migrate service failed with {0}'.format(issue))
-            raise DistMigrationZypperException('Migration failed with {0}'.format(issue))
+            self.log.error('Migration failed with: {0}'.format(issue))
+            raise DistMigrationZypperException('Migration failed with: {0}'.format(issue))
         finally:
             self.duplicate_solver_test_case_data()
 

--- a/suse_migration_services/zypper.py
+++ b/suse_migration_services/zypper.py
@@ -45,7 +45,9 @@ class Zypper:
             run zypper chrooted against the given path
         """
         log_file = Defaults.get_migration_log_file(system_root=False if chroot else True)
-        command_string = ' '.join(['zypper'] + list(args) + ['&>>', log_file])
+        command_string = ' '.join(
+            ['set -o pipefail; zypper'] + list(args) + ['|& tee -a', log_file]
+        )
         command = []
         if chroot:
             # Calling zypper in a new system root should be done in
@@ -96,7 +98,6 @@ class ZypperCall:
         self.args = args
         self.command = command
         self.output = result.output
-        self.error = result.error
         self.returncode = result.returncode
 
     @property
@@ -140,7 +141,7 @@ class ZypperCall:
             return
 
         raise DistMigrationZypperException(
-            '{0}: failed with: {1}: {2}'.format(self.command, self.output, self.error)
+            '{0}: failed with: {1}'.format(self.command, self.output)
         )
 
     def log_if_failed(self, log):
@@ -148,4 +149,4 @@ class ZypperCall:
         log output and error when failed
         """
         if not self.success:
-            log.error('{0}: failed with: {1}: {2}'.format(self.command, self.output, self.error))
+            log.error('{0}: failed with: {1}'.format(self.command, self.output))

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -66,6 +66,14 @@ class TestMigration(object):
                 ),
                 call('1\n'),
             ]
+        mock_Zypper_run.reset_mock()
+        mock_Zypper_run.side_effect = None
+        zypper_call = Mock()
+        zypper_call.output = 'No migration available'
+        mock_Zypper_run.return_value = zypper_call
+        with patch('builtins.open', create=True) as mock_open:
+            with raises(DistMigrationZypperException):
+                main()
 
     @patch('suse_migration_services.units.migrate.MigrateSystem.is_single_rpmtrans_requested')
     @patch('suse_migration_services.logger.Logger.setup')

--- a/test/unit/zypper_test.py
+++ b/test/unit/zypper_test.py
@@ -70,8 +70,8 @@ class TestCommand(object):
             [
                 'bash',
                 '-c',
-                'zypper in test --root /system-root '
-                '&>> /system-root/var/log/distro_migration.log',
+                'set -o pipefail; zypper in test --root /system-root '
+                '|& tee -a /system-root/var/log/distro_migration.log',
             ],
             raise_on_error=True,
         )
@@ -86,7 +86,8 @@ class TestCommand(object):
                 'root',
                 'bash',
                 '-c',
-                'zypper in test --root /system-root ' '&>> /var/log/distro_migration.log',
+                'set -o pipefail; zypper in test --root /system-root '
+                '|& tee -a /var/log/distro_migration.log',
             ],
             raise_on_error=True,
         )
@@ -104,8 +105,8 @@ class TestCommand(object):
             [
                 'bash',
                 '-c',
-                'zypper in test --root /system-root '
-                '&>> /system-root/var/log/distro_migration.log',
+                'set -o pipefail; zypper in test --root /system-root '
+                '|& tee -a /system-root/var/log/distro_migration.log',
             ],
             raise_on_error=False,
         )
@@ -117,14 +118,14 @@ class TestCommand(object):
     def test_zypper_log_if_failed(self, mock_Command_run):
         command_run_result = namedtuple('command', ['output', 'error', 'returncode'])
         mock_Command_run.return_value = command_run_result(
-            output='some_output', error='some_error', returncode=1
+            output='some_output', error='', returncode=1
         )
         zypper_call = Zypper.run(['args'], raise_on_error=False)
         log = Mock()
         zypper_call.log_if_failed(log)
         log.error.assert_called_once_with(
-            'zypper args &>> /system-root/var/log/distro_migration.log: '
-            'failed with: some_output: some_error'
+            'set -o pipefail; zypper args |& tee -a /system-root/var/log/distro_migration.log: '
+            'failed with: some_output'
         )
 
     def test_zypper_call_failed(self, mock_Command_run):


### PR DESCRIPTION
Up to now the assumption was that any situation in which zypper migration cannot migrate the system returns with an error, meaning exit code != 0. However, this assumption is wrong. There are condition in which zypper migration only indicates a problem with a message saying 'No migration available' and the call return with a successful error code = 0. This causes big trouble for the DMS in a way that it continues running its services which all assumes the migration to the next major release was performed. It misleads readers of the log file into the wrong direction and the worst it causes modifications to the host system when it was not migrated. This commit makes sure that the migration stops and treats the above message as an error condition.