### PR TITLE
precheck: XFSv4

### DIFF
--- a/suse_migration_services/prechecks/pre_checks.py
+++ b/suse_migration_services/prechecks/pre_checks.py
@@ -33,6 +33,7 @@ import suse_migration_services.prechecks.scc as check_scc
 import suse_migration_services.prechecks.wicked2nm as check_wicked2nm
 import suse_migration_services.prechecks.cpu_arch as check_cpu_arch
 import suse_migration_services.prechecks.sshd as check_sshd
+import suse_migration_services.prechecks.xfs as check_xfs
 
 
 def main():
@@ -100,6 +101,10 @@ def main():
 
     log.info('--> Checking for encrypted rootfs...')
     check_fs.encryption(migration_system=migration_system_mode)
+    log.info('Done')
+
+    log.info('--> Checking for XFS v4 filesystems...')
+    check_xfs.xfs_v4(migration_system=migration_system_mode)
     log.info('Done')
 
     log.info('--> Checking for latest kernel in multiversion kernel system...')

--- a/suse_migration_services/prechecks/xfs.py
+++ b/suse_migration_services/prechecks/xfs.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 SUSE Linux LLC.  All rights reserved.
+#
+# This file is part of suse-migration-services.
+#
+# suse-migration-services is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# suse-migration-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with suse-migration-services. If not, see <http://www.gnu.org/licenses/>
+#
+"""Module for checking XFS filesystem version"""
+import logging
+import re
+
+from suse_migration_services.command import Command
+from suse_migration_services.defaults import Defaults
+
+
+def xfs_v4(migration_system=False):
+    """Check for XFS v4 root filesystem and warn about potential issues"""
+    if migration_system:
+        # This check must not be called inside of the
+        # migration system live iso or container image.
+        # It will only be useful on the system to migrate
+        # at install time of the Migration package or on
+        # manual user invocation of suse-migration-pre-checks
+        # prior the actual migration.
+        return
+
+    log = logging.getLogger(Defaults.get_migration_log_name())
+
+    stat_result = Command.run(['stat', '-f', '-c', '%T', '/'])
+    if stat_result:
+        target_fs = stat_result.output.strip()
+        if target_fs != 'xfs':
+            return
+
+    xfs_info_result = Command.run(['xfs_info', '/'])
+
+    # Check for v4 filesystem (absence of crc=1 indicates v4)
+    # v5 filesystems have: crc=1, finobt=1, sparse=1, rmapbt=0, reflink=1
+    # v4 filesystems typically show: crc=0 or no crc field
+    output = xfs_info_result.output
+    if re.search(r'crc=0\b', output) or 'crc=' not in output:
+        log.warning(
+            'XFS v4 root filesystem detected. XFS v4 is deprecated and support '
+            'will be dropped after September 2030. See the XFS formats chapter '
+            'in Storage Administration Guide for details on this issue.'
+        )

--- a/test/unit/logger_test.py
+++ b/test/unit/logger_test.py
@@ -1,11 +1,14 @@
 import io
+import logging
 from unittest.mock import patch, MagicMock
 
 from suse_migration_services.logger import Logger
+from suse_migration_services.defaults import Defaults
 
 
 @patch('suse_migration_services.logger.Path.create')
 class TestLogger:
+    @patch.object(logging.getLogger(Defaults.get_migration_log_name()), 'handlers', [])
     def test_setup(self, mock_Path_create):
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)
@@ -16,6 +19,7 @@ class TestLogger:
                 '/system-root/var/log/distro_migration.log', 'a', encoding='locale', errors=None
             )
 
+    @patch.object(logging.getLogger(Defaults.get_migration_log_name()), 'handlers', [])
     def test_setup_no_system_root(self, mock_Path_create):
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)

--- a/test/unit/pre_checks_test.py
+++ b/test/unit/pre_checks_test.py
@@ -17,6 +17,7 @@ import suse_migration_services.prechecks.ha as check_ha
 import suse_migration_services.prechecks.wicked2nm as check_wicked2nm
 import suse_migration_services.prechecks.cpu_arch as check_cpu_arch
 import suse_migration_services.prechecks.sshd as check_sshd
+import suse_migration_services.prechecks.xfs as check_xfs
 import suse_migration_services.prechecks.pre_checks as check_pre_checks
 from suse_migration_services.exceptions import DistMigrationCommandException
 from suse_migration_services.defaults import Defaults
@@ -34,6 +35,7 @@ class TestPreChecks:
 
     @patch('suse_migration_services.prechecks.repos.remote_repos')
     @patch('suse_migration_services.prechecks.fs.encryption')
+    @patch('suse_migration_services.prechecks.xfs.xfs_v4')
     @patch('suse_migration_services.prechecks.kernels.multiversion_and_multiple_kernels')
     @patch('suse_migration_services.prechecks.cpu_arch.cpu_arch')
     @patch('suse_migration_services.prechecks.sshd.root_login')
@@ -45,6 +47,7 @@ class TestPreChecks:
         mock_sshd_root_login,
         mock_cpu_arch,
         mock_kernels,
+        mock_xfs,
         mock_fs,
         mock_repos,
         mock_os_geteuid,
@@ -57,6 +60,7 @@ class TestPreChecks:
 
     @patch('suse_migration_services.prechecks.repos.remote_repos')
     @patch('suse_migration_services.prechecks.fs.encryption')
+    @patch('suse_migration_services.prechecks.xfs.xfs_v4')
     @patch('suse_migration_services.prechecks.kernels.multiversion_and_multiple_kernels')
     @patch('suse_migration_services.prechecks.cpu_arch.cpu_arch')
     @patch('suse_migration_services.prechecks.sshd.root_login')
@@ -70,6 +74,7 @@ class TestPreChecks:
         mock_sshd_root_login,
         mock_cpu_arch,
         mock_kernels,
+        mock_xfs,
         mock_fs,
         mock_repos,
         mock_os_geteuid,
@@ -517,6 +522,7 @@ class TestPreChecks:
     @patch('suse_migration_services.prechecks.scc.migration')
     @patch('suse_migration_services.prechecks.repos.remote_repos')
     @patch('suse_migration_services.prechecks.fs.encryption')
+    @patch('suse_migration_services.prechecks.xfs.xfs_v4')
     @patch('suse_migration_services.prechecks.kernels.multiversion_and_multiple_kernels')
     @patch('suse_migration_services.prechecks.cpu_arch.cpu_arch')
     @patch('suse_migration_services.prechecks.sshd.root_login')
@@ -530,6 +536,7 @@ class TestPreChecks:
         mock_sshd_root_login,
         mock_cpu_arch,
         mock_kernels,
+        mock_xfs,
         mock_fs,
         mock_repos,
         mock_scc_migration,
@@ -1071,3 +1078,75 @@ class TestPreChecks:
         mock_get_migration_target.return_value = {'version': '15.7'}
         check_sshd.root_login(migration_system=False)
         mock_Command_run.assert_not_called()
+
+    @patch('suse_migration_services.command.Command.run')
+    def test_check_xfs_v4_detected(self, mock_command_run, mock_os_geteuid, mock_log):
+        """Test detection of XFS v4 root filesystem"""
+
+        def command_side_effect(cmd):
+            result = Mock()
+            if cmd[0] == 'stat':
+                result.output = 'xfs\n'
+            elif cmd[0] == 'xfs_info':
+                result.output = (
+                    'meta-data=/dev/sda1              isize=256    agcount=4, agsize=6553600 blks\n'
+                    '         =                       sectsz=512   attr=2, projid32bit=0\n'
+                    '         =                       crc=0        finobt=0, sparse=0, rmapbt=0\n'
+                    '         =                       reflink=0\n'
+                    'data     =                       bsize=4096   blocks=26214400, imaxpct=25\n'
+                )
+            return result
+
+        mock_command_run.side_effect = command_side_effect
+
+        with self._caplog.at_level(logging.WARNING):
+            check_xfs.xfs_v4()
+            assert 'XFS v4 root filesystem detected' in self._caplog.text
+            assert 'deprecated' in self._caplog.text
+
+    @patch('suse_migration_services.command.Command.run')
+    def test_check_xfs_v5_no_warning(self, mock_command_run, mock_os_geteuid, mock_log):
+        """Test that XFS v5 root filesystem does not trigger warning"""
+
+        def command_side_effect(cmd):
+            result = Mock()
+            if cmd[0] == 'stat':
+                result.output = 'xfs\n'
+            elif cmd[0] == 'xfs_info':
+                result.output = (
+                    'meta-data=/dev/sda1              isize=512    agcount=4, agsize=6553600 blks\n'
+                    '         =                       sectsz=512   attr=2, projid32bit=1\n'
+                    '         =                       crc=1        finobt=1, sparse=1, rmapbt=0\n'
+                    '         =                       reflink=1\n'
+                    'data     =                       bsize=4096   blocks=26214400, imaxpct=25\n'
+                )
+            return result
+
+        mock_command_run.side_effect = command_side_effect
+
+        with self._caplog.at_level(logging.WARNING):
+            check_xfs.xfs_v4()
+            assert 'XFS v4 root filesystem detected' not in self._caplog.text
+
+    @patch('suse_migration_services.command.Command.run')
+    def test_check_xfs_non_xfs_filesystem(self, mock_command_run, mock_os_geteuid, mock_log):
+        """Test that non-XFS root filesystems are ignored"""
+        stat_result = Mock()
+        stat_result.output = 'ext4\n'
+        mock_command_run.return_value = stat_result
+
+        with self._caplog.at_level(logging.WARNING):
+            check_xfs.xfs_v4()
+            assert 'XFS v4 root filesystem detected' not in self._caplog.text
+            # Should only call stat, not xfs_info
+            mock_command_run.assert_called_once_with(['stat', '-f', '-c', '%T', '/'])
+
+    @patch('suse_migration_services.command.Command.run')
+    def test_check_xfs_with_migration_system(self, mock_command_run, mock_os_geteuid, mock_log):
+        """Test XFS v4 check returns early in migration system mode"""
+        with self._caplog.at_level(logging.WARNING):
+            check_xfs.xfs_v4(migration_system=True)
+            # Should not run any commands in migration system mode
+            mock_command_run.assert_not_called()
+            # Should not log any warnings
+            assert 'XFS v4 root filesystem detected' not in self._caplog.text


### PR DESCRIPTION
XFSv4 is no longer supported in SLES. Add a precheck to find XFSv4 filesystems and issue a warning for this.