### PR TITLE
Fixed log message for already mounted system

### DIFF
--- a/suse_migration_services/units/mount_system.py
+++ b/suse_migration_services/units/mount_system.py
@@ -59,9 +59,11 @@ class MountSystem:
             # is considered to represent the system to upgrade and
             # not something else. Thus if already mounted, let's use
             # what is there.
+            self.log.info(
+                'Mount system service: {0} is already mounted, skipped'.format(self.root_path)
+            )
             return
 
-        self.log.info('Mount system service: {0} is mounted'.format(self.root_path))
         # Check if booted via loopback grub
         isoscan_loop_mount = '/run/initramfs/isoscan'
         if self.is_mounted(isoscan_loop_mount):


### PR DESCRIPTION
The log message was out of context and belongs to the block checking if the system was already mounted.
This Fixes #479