### PR TITLE
wicked2nm: explicitly remove sysconfig-netconfig (bsc#1258112)

### DIFF
--- a/suse_migration_services/units/wicked_migration.py
+++ b/suse_migration_services/units/wicked_migration.py
@@ -90,6 +90,7 @@ class WickedToNetworkManager(DropComponents):
             self.drop_package('wicked-service')
             if self.package_installed('biosdevname'):
                 self.drop_package('biosdevname')
+            self.drop_package('sysconfig-netconfig')
             self.log.info('Drop /etc/sysconfig/network from migrated system')
             self.log.info(
                 'Please find a backup of the data at {}'.format(

--- a/test/unit/units/wicked_migration_test.py
+++ b/test/unit/units/wicked_migration_test.py
@@ -63,6 +63,7 @@ class TestMigrationWicked:
             call('wicked'),
             call('wicked-service'),
             call('biosdevname'),
+            call('sysconfig-netconfig'),
         ]
         mock_drop_path.assert_called_once_with('/etc/sysconfig/network/')
         mock_drop_perform.assert_called_once_with()


### PR DESCRIPTION
If sysconfig-netconfig is not removed, when dropping wicked, NetworkManager still use `netconfig`.
But `netconfig` doesn't find its `/etc/sysconfig/network/scripts/netconfig.function` file, which lead to an error like:
```
NetworkManager[926]: /usr/sbin/netconfig: line 574: log: command not found
```