### PR TITLE
Avoid temporary file `test/unit/.coverage` in dist archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ version := $(shell \
 )
 
 tar: clean check test
+	# remove eventually existing test artifacts
+	rm -f test/unit/.coverage
 	# build the sdist source tarball
 	poetry build --format=sdist
 
@@ -146,8 +148,7 @@ test: setup
 		--cov=suse_migration_services \
 		--no-cov-on-fail \
 		--cov-report=term-missing \
-		--cov-fail-under=100 \
-		--cov-config .coveragerc'
+		--cov-fail-under=100'
 
 black: setup
 	poetry run black --skip-string-normalization --line-length 100 suse_migration_services test/unit/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ packages = [
 
 include = [
    { path = ".bumpversion.cfg", format = "sdist" },
-   { path = ".coverage*", format = "sdist" },
    { path = "setup.cfg", format = "sdist" },
    { path = "grub.d", format = "sdist" },
    { path = "systemd", format = "sdist" },
@@ -31,7 +30,8 @@ include = [
    { path = "package", format = "sdist" },
    { path = "setup.py", format = "sdist" },
    { path = "MANIFEST.in", format = "sdist" },
-   { path = "test", format = "sdist" },
+   { path = "test/unit/**/*.py", format = "sdist" },
+   { path = "test/data", format = "sdist" },
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ packages = [
 
 include = [
    { path = ".bumpversion.cfg", format = "sdist" },
-   { path = ".coverage*", format = "sdist" },
    { path = "setup.cfg", format = "sdist" },
    { path = "grub.d", format = "sdist" },
    { path = "systemd", format = "sdist" },


### PR DESCRIPTION
This temporary file(`test/unit/.coverage`), generated by pytest-cov, is created within each `make test` call containing different content, also if no source files has changed.


I didn't found any files which match `.coverage*` beside this temporary file. And for me, it makes no sense to distribute it.
