### PR TITLE
Fix loading SELinux policy of Salt Bundle with workaround

### DIFF
--- a/suse_migration_services/units/apparmor_migration.py
+++ b/suse_migration_services/units/apparmor_migration.py
@@ -62,6 +62,20 @@ class ApparmorToSelinux(DropComponents):
                 chroot=self.root_path,
             )
             zypper_call.log_if_failed(self.log)
+            if zypper_call.success and self.package_installed('venv-salt-minion'):
+                # Salt Bundle (venv-salt-minion) has its own SELinux policy
+                # which is loading in installing the package only if SELinux is available
+                # on the system. This workaround is used to enforce it to load the policy.
+                self.log.info(
+                    'Forcing reinstallation of venv-salt-minion to apply its SELinux policy'
+                )
+                zypper_call = Zypper.install(
+                    'venv-salt-minion',
+                    extra_args=['--force'],
+                    raise_on_error=False,
+                    chroot=self.root_path,
+                )
+                zypper_call.log_if_failed(self.log)
         except Exception as issue:
             message = 'Apparmor to SELinux migration failed with {0}'.format(issue)
             self.log.error(message)


### PR DESCRIPTION
Salt Bundle (`venv-salt-minion` package) is shipping its own SELinux policy with the single package.
It loads the SELinux policy only in case if SELinux is enabled, but with the migration process we have the situation when the packages are updating first and then the migration from AppArmor to SELinux is triggered what is causing the situation when Salt Bundle is installed, but the SELinux policy is not loaded.

This change is introducing a workaround with AppArmor migration and just triggering force reinstall of `venv-salt-minion` in case if it is installed on the system.

Tracks: https://github.com/SUSE/suse-migration-services/pull/487