### PR TITLE
Fix install of NetworkManager

### DIFF
--- a/suse_migration_services/units/wicked_migration.py
+++ b/suse_migration_services/units/wicked_migration.py
@@ -59,9 +59,14 @@ class WickedToNetworkManager(DropComponents):
             return
         try:
             self.log.info('Ensuring NetworkManager is installed in migrated system')
-            Zypper.install(
-                'NetworkManager', 'NetworkManager-config-server', system_root=self.root_path
-            )
+            if not self.package_installed('NetworkManager'):
+                Zypper.install(
+                    'NetworkManager',
+                    'NetworkManager-config-server',
+                    extra_args=['--no-recommends'],
+                    raise_on_error=True,
+                    chroot=self.root_path,
+                )
 
             self.log.info('Enabling NetworkManager in migrated system')
             Command.run(

--- a/test/unit/units/wicked_migration_test.py
+++ b/test/unit/units/wicked_migration_test.py
@@ -34,14 +34,23 @@ class TestMigrationWicked:
         mock_drop_package,
         mock_resolv_conf_setup_target_root,
     ):
+        def package_installed(name):
+            if name.startswith('NetworkManager'):
+                return False
+            return True
+
         mock_os_path_islink.return_value = True
         mock_os_path_exists.return_value = True
         mock_os_path_lexists.side_effect = [True, False, True]
-        mock_package_installed.return_value = True
+        mock_package_installed.side_effect = package_installed
         mock_iglob.return_value = ['/etc/NetworkManager/system-connections/some.nmconnection']
         main()
         mock_Zypper_install.assert_called_once_with(
-            'NetworkManager', 'NetworkManager-config-server', system_root='/system-root'
+            'NetworkManager',
+            'NetworkManager-config-server',
+            extra_args=['--no-recommends'],
+            raise_on_error=True,
+            chroot='/system-root',
         )
         assert mock_Command_run.call_args_list == [
             call(


### PR DESCRIPTION
Check if NetworkManager is installed already and only install it when needed. In addition run the installation of packages inside of the upgraded system as a chroot operation. We identified zypper metadata read issues when driving a package install from the outside (live migration system) into the target and we also want this operation to be as close as possible to a standard package installation on the target system.