### PR TITLE
Add precheck for POWER architecture version on SLES16 migration

### DIFF
--- a/suse_migration_services/prechecks/cpu_arch.py
+++ b/suse_migration_services/prechecks/cpu_arch.py
@@ -19,21 +19,25 @@
 """Module for checking for CPU architecture support"""
 import logging
 import os
+import platform
+import re
 
 from suse_migration_services.defaults import Defaults
 from suse_migration_services.command import Command
 from suse_migration_services.migration_target import MigrationTarget
 
+log = logging.getLogger(Defaults.get_migration_log_name())
+
 
 def x86_64_version():
     """Function to check whether current CPU architecture is new enough to support SLE16"""
     target = MigrationTarget.get_migration_target()
+    version = target.get('version')
 
-    if target.get('version') != '16.0':
+    if not version or not version.startswith('16'):
         # This check is only necessary for migration to SLE16
         return
 
-    log = logging.getLogger(Defaults.get_migration_log_name())
     os.environ['ZYPP_READONLY_HACK'] = '1'
     zypper_call = Command.run(['zypper', 'system-architecture'])
     arch = zypper_call.output
@@ -43,6 +47,43 @@ def x86_64_version():
             'SLE16 requires x86_64_v2 at minimum. The architecture version '
             'of this system is too old.'
         )
+
+
+def power10_version():
+    """Function to check whether the system has at least POWER10 CPU for SLE16 migration"""
+    target = MigrationTarget.get_migration_target()
+    version = target.get('version')
+
+    if not version or not version.startswith('16'):
+        # This check is only necessary for migration to SLE16
+        return
+
+    machine = platform.machine()
+
+    if machine not in ['ppc64', 'ppc64le']:
+        return
+
+    try:
+        with open('/proc/cpuinfo', 'r') as cpuinfo_file:
+            cpuinfo_content = cpuinfo_file.read()
+
+            # Extract POWER generation number from cpuinfo
+            power_match = re.search(r'POWER(\d+)', cpuinfo_content)
+
+            if power_match:
+                power_generation = int(power_match.group(1))
+                if power_generation < 10:
+                    log.error(
+                        f'SLES 16 requires POWER10 or newer. This system is running '
+                        f'POWER{power_generation}, which is not supported for migration to SLES 16.'
+                    )
+            else:
+                log.warning(
+                    'Could not detect POWER generation from /proc/cpuinfo. '
+                    'Unable to verify POWER10 requirement for SLES 16 migration.'
+                )
+    except Exception as error:
+        log.warning(f'Could not read /proc/cpuinfo to check CPU model: {error}')
 
 
 def cpu_arch(migration_system=False):
@@ -57,3 +98,4 @@ def cpu_arch(migration_system=False):
         return
 
     x86_64_version()
+    power10_version()

--- a/test/unit/pre_checks_test.py
+++ b/test/unit/pre_checks_test.py
@@ -1150,3 +1150,110 @@ class TestPreChecks:
             mock_command_run.assert_not_called()
             # Should not log any warnings
             assert 'XFS v4 root filesystem detected' not in self._caplog.text
+
+    @patch(
+        'builtins.open',
+        new_callable=mock_open,
+        read_data='cpu\t\t: POWER10 (raw), altivec supported\n',
+    )
+    @patch('platform.machine')
+    @patch.object(MigrationTarget, 'get_migration_target')
+    def test_check_power10_sle16(
+        self, mock_get_migration_target, mock_platform_machine, mock_file, mock_os_geteuid, mock_log
+    ):
+        """Test that POWER10 is allowed for SLE16 migration"""
+        mock_get_migration_target.return_value = {'version': '16.0'}
+        mock_platform_machine.return_value = 'ppc64le'
+
+        with self._caplog.at_level(logging.ERROR):
+            check_cpu_arch.power10_version()
+            assert 'requires POWER10 or newer' not in self._caplog.text
+        mock_file.assert_called_once_with('/proc/cpuinfo', 'r')
+
+    @patch(
+        'builtins.open',
+        new_callable=mock_open,
+        read_data='cpu\t\t: POWER10 (raw), altivec supported\n',
+    )
+    @patch('platform.machine')
+    @patch.object(MigrationTarget, 'get_migration_target')
+    def test_check_power10_sle15(
+        self, mock_get_migration_target, mock_platform_machine, mock_file, mock_os_geteuid, mock_log
+    ):
+        """Test that POWER check is skipped for SLE15 migration"""
+        mock_get_migration_target.return_value = {'version': '15.7'}
+        mock_platform_machine.return_value = 'ppc64le'
+
+        with self._caplog.at_level(logging.ERROR):
+            check_cpu_arch.power10_version()
+            assert 'requires POWER10 or newer' not in self._caplog.text
+        mock_file.assert_not_called()
+
+    @patch(
+        'builtins.open',
+        new_callable=mock_open,
+        read_data='processor\t: 0\nvendor_id\t: GenuineIntel\n',
+    )
+    @patch('platform.machine')
+    @patch.object(MigrationTarget, 'get_migration_target')
+    def test_check_power10_non_power_arch(
+        self, mock_get_migration_target, mock_platform_machine, mock_file, mock_os_geteuid, mock_log
+    ):
+        """Test that POWER check is skipped for non-POWER architectures"""
+        mock_get_migration_target.return_value = {'version': '16.0'}
+        mock_platform_machine.return_value = 'x86_64'
+
+        with self._caplog.at_level(logging.ERROR):
+            check_cpu_arch.power10_version()
+            assert 'requires POWER10 or newer' not in self._caplog.text
+        mock_file.assert_not_called()
+
+    @patch(
+        'builtins.open',
+        new_callable=mock_open,
+        read_data='cpu\t\t: POWER9 (raw), altivec supported\n',
+    )
+    @patch('platform.machine')
+    @patch.object(MigrationTarget, 'get_migration_target')
+    def test_check_power9_sle16(
+        self, mock_get_migration_target, mock_platform_machine, mock_file, mock_os_geteuid, mock_log
+    ):
+        """Test that POWER9 is blocked for SLE16 migration"""
+        mock_get_migration_target.return_value = {'version': '16.0'}
+        mock_platform_machine.return_value = 'ppc64le'
+
+        with self._caplog.at_level(logging.ERROR):
+            check_cpu_arch.power10_version()
+            assert 'SLES 16 requires POWER10 or newer' in self._caplog.text
+            assert 'POWER9' in self._caplog.text
+        mock_file.assert_called_once_with('/proc/cpuinfo', 'r')
+
+    @patch('builtins.open', side_effect=FileNotFoundError('/proc/cpuinfo not found'))
+    @patch('platform.machine')
+    @patch.object(MigrationTarget, 'get_migration_target')
+    def test_check_power10_cpuinfo_read_error(
+        self, mock_get_migration_target, mock_platform_machine, mock_file, mock_os_geteuid, mock_log
+    ):
+        """Test that exception when reading cpuinfo is handled gracefully"""
+        mock_get_migration_target.return_value = {'version': '16.0'}
+        mock_platform_machine.return_value = 'ppc64le'
+
+        with self._caplog.at_level(logging.WARNING):
+            check_cpu_arch.power10_version()
+            assert 'Could not read /proc/cpuinfo' in self._caplog.text
+        mock_file.assert_called_once_with('/proc/cpuinfo', 'r')
+
+    @patch('builtins.open', new_callable=mock_open, read_data='cpu\t\t: Unknown CPU\n')
+    @patch('platform.machine')
+    @patch.object(MigrationTarget, 'get_migration_target')
+    def test_check_power_unparseable_cpuinfo(
+        self, mock_get_migration_target, mock_platform_machine, mock_file, mock_os_geteuid, mock_log
+    ):
+        """Test that unparseable cpuinfo generates a warning"""
+        mock_get_migration_target.return_value = {'version': '16.0'}
+        mock_platform_machine.return_value = 'ppc64le'
+
+        with self._caplog.at_level(logging.WARNING):
+            check_cpu_arch.power10_version()
+            assert 'Could not detect POWER generation' in self._caplog.text
+        mock_file.assert_called_once_with('/proc/cpuinfo', 'r')


### PR DESCRIPTION
SLES 16 only supports POWER10 (and probably above), so we need to add a precheck to notify user if they are trying to migrate on an older system. We don't need to block the migration as brutal as the x86_64_v1 check, as this does not cause a kernel panic (yet).