### PR TITLE
Handle multipath root

### DIFF
--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -29,8 +29,10 @@ if [[ ${image_fs_type} =~ ^ext[[:digit:]] ]] ; then
    image_fs_type="ext2"
 fi
 
-if type -p multipath; then
-    migration_rootfs_device=$(lsblk -p -n -r -o NAME,MOUNTPOINTS | grep -E "/$" | uniq | cut -f1 -d" ")
+if type -p multipath &>/dev/null; then
+    migration_rootfs_device=$(
+        lsblk -p -n -r -o NAME,MOUNTPOINTS | grep -E "/$" | uniq | cut -f1 -d" "
+    )
     for wwn in $(multipath -l -v1 2>/dev/null); do
         if [[ "${migration_rootfs_device}" == *"${wwn}"* ]];then
             migration_rootfs_wwn="${wwn}"

--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -32,9 +32,9 @@ fi
 if [ -e /sbin/multipath ]; then
     migration_rootfs_device=$(lsblk -p -n -r -o NAME,MOUNTPOINTS | grep -E "/$" | uniq | cut -f1 -d" ")
     for wwn in $(/sbin/multipath -l -v1 2>/dev/null); do
-	if [[ "${migration_rootfs_device}" == *"${wwn}"* ]];then
-	    migration_rootfs_wwn="${wwn}"
-	fi
+        if [[ "${migration_rootfs_device}" == *"${wwn}"* ]];then
+            migration_rootfs_wwn="${wwn}"
+        fi
     done
 fi
 

--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -29,9 +29,9 @@ if [[ ${image_fs_type} =~ ^ext[[:digit:]] ]] ; then
    image_fs_type="ext2"
 fi
 
-if [ -e /sbin/multipath ]; then
+if type -p multipath; then
     migration_rootfs_device=$(lsblk -p -n -r -o NAME,MOUNTPOINTS | grep -E "/$" | uniq | cut -f1 -d" ")
-    for wwn in $(/sbin/multipath -l -v1 2>/dev/null); do
+    for wwn in $(multipath -l -v1 2>/dev/null); do
         if [[ "${migration_rootfs_device}" == *"${wwn}"* ]];then
             migration_rootfs_wwn="${wwn}"
         fi

--- a/grub.d/99_migration
+++ b/grub.d/99_migration
@@ -29,6 +29,15 @@ if [[ ${image_fs_type} =~ ^ext[[:digit:]] ]] ; then
    image_fs_type="ext2"
 fi
 
+if [ -e /sbin/multipath ]; then
+    migration_rootfs_device=$(lsblk -p -n -r -o NAME,MOUNTPOINTS | grep -E "/$" | uniq | cut -f1 -d" ")
+    for wwn in $(/sbin/multipath -l -v1 2>/dev/null); do
+	if [[ "${migration_rootfs_device}" == *"${wwn}"* ]];then
+	    migration_rootfs_wwn="${wwn}"
+	fi
+    done
+fi
+
 # init boot options needed for live boot
 boot_options="rd.live.image root=live:CDLABEL=CDROM"
 
@@ -38,6 +47,11 @@ boot_options="${boot_options} migration_target=${migration_rootfs_uuid}"
 # add auto activation of devices in soft raid mode
 if [ -n "$(mdadm --detail --scan 2>/dev/null | cut -f2 -d' ')" ];then
     boot_options="${boot_options} rd.auto"
+fi
+
+# add multipath wwn of migration target device on multipath systems
+if [ -n "${migration_rootfs_wwn}" ];then
+    boot_options="${boot_options} multipath_wwn=${migration_rootfs_wwn}"
 fi
 
 # add relevant boot options used on the host to migrate

--- a/suse_migration_services/units/mount_system.py
+++ b/suse_migration_services/units/mount_system.py
@@ -135,7 +135,7 @@ class MountSystem:
                             device = block_record[0]
                             uuid = self.get_uuid(device)
                             if uuid == migration_rootfs_uuid:
-                                if is_multipath and not migration_rootfs_wwn in device:
+                                if is_multipath and migration_rootfs_wwn not in device:
                                     self.log.info('Skipping {0} since it is not the multipath root device'.format(device))
                                 else:
                                     return device

--- a/suse_migration_services/units/mount_system.py
+++ b/suse_migration_services/units/mount_system.py
@@ -136,7 +136,11 @@ class MountSystem:
                             uuid = self.get_uuid(device)
                             if uuid == migration_rootfs_uuid:
                                 if is_multipath and migration_rootfs_wwn not in device:
-                                    self.log.info('Skipping {0} since it is not the multipath root device'.format(device))
+                                    self.log.info(
+                                        'Skipping {0} since it is not the multipath root device'.format(
+                                            device
+                                        )
+                                    )
                                 else:
                                     return device
             # nothing was found

--- a/suse_migration_services/units/mount_system.py
+++ b/suse_migration_services/units/mount_system.py
@@ -117,8 +117,14 @@ class MountSystem:
             with open('/proc/cmdline') as cmdline_fd:
                 cmdline = cmdline_fd.read()
             match = re.search(r'migration_target=([\w-]+)', cmdline)
+            match_wwn = re.search(r'multipath_wwn=([\w-]+)', cmdline)
+
             if match:
                 migration_rootfs_uuid = match.group(1)
+                is_multipath = False
+                if match_wwn:
+                    migration_rootfs_wwn = match_wwn.group(1)
+                    is_multipath = True
                 lsblk_call = Command.run(['lsblk', '-p', '-n', '-r', '-o', 'NAME,TYPE'])
                 considered_block_types = ['part', 'raid', 'lvm']
                 for entry in lsblk_call.output.split(os.linesep):
@@ -129,7 +135,10 @@ class MountSystem:
                             device = block_record[0]
                             uuid = self.get_uuid(device)
                             if uuid == migration_rootfs_uuid:
-                                return device
+                                if is_multipath and not migration_rootfs_wwn in device:
+                                    self.log.info('Skipping {0} since it is not the multipath root device'.format(device))
+                                else:
+                                    return device
             # nothing was found
             raise DistMigrationSystemMountException('no match for migration_target= in cmdline')
         except Exception as issue:

--- a/test/unit/units/mount_system_test.py
+++ b/test/unit/units/mount_system_test.py
@@ -110,7 +110,9 @@ class TestMountSystem:
     def test_get_target_root_match_no_multipath_root(self, mock_get_uuid, mock_Command_run):
         mock_get_uuid.return_value = 'UUID'
         command_run = namedtuple('command', ['output', 'error', 'returncode'])
-        mock_Command_run.return_value = command_run(output='/dev/sda4 lvm\n/dev/mapper/WWN-part2 part', error='', returncode=0)
+        mock_Command_run.return_value = command_run(
+            output='/dev/sda4 lvm\n/dev/mapper/WWN-part2 part', error='', returncode=0
+        )
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)
             file_handle = mock_open.return_value.__enter__.return_value
@@ -122,7 +124,9 @@ class TestMountSystem:
     def test_get_target_root_match_multipath_root(self, mock_get_uuid, mock_Command_run):
         mock_get_uuid.return_value = 'UUID'
         command_run = namedtuple('command', ['output', 'error', 'returncode'])
-        mock_Command_run.return_value = command_run(output='/dev/sda4 lvm\n/dev/mapper/WWN-part2 part', error='', returncode=0)
+        mock_Command_run.return_value = command_run(
+            output='/dev/sda4 lvm\n/dev/mapper/WWN-part2 part', error='', returncode=0
+        )
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)
             file_handle = mock_open.return_value.__enter__.return_value

--- a/test/unit/units/mount_system_test.py
+++ b/test/unit/units/mount_system_test.py
@@ -105,6 +105,30 @@ class TestMountSystem:
             file_handle.read.return_value = 'migration_target=UUID'
             assert self.mount_os.get_target_root() == '/dev/sda4'
 
+    @patch('suse_migration_services.command.Command.run')
+    @patch('suse_migration_services.units.mount_system.MountSystem.get_uuid')
+    def test_get_target_root_match_no_multipath_root(self, mock_get_uuid, mock_Command_run):
+        mock_get_uuid.return_value = 'UUID'
+        command_run = namedtuple('command', ['output', 'error', 'returncode'])
+        mock_Command_run.return_value = command_run(output='/dev/sda4 lvm\n/dev/mapper/WWN-part2 part', error='', returncode=0)
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            file_handle.read.return_value = 'migration_target=UUID'
+            assert self.mount_os.get_target_root() == '/dev/sda4'
+
+    @patch('suse_migration_services.command.Command.run')
+    @patch('suse_migration_services.units.mount_system.MountSystem.get_uuid')
+    def test_get_target_root_match_multipath_root(self, mock_get_uuid, mock_Command_run):
+        mock_get_uuid.return_value = 'UUID'
+        command_run = namedtuple('command', ['output', 'error', 'returncode'])
+        mock_Command_run.return_value = command_run(output='/dev/sda4 lvm\n/dev/mapper/WWN-part2 part', error='', returncode=0)
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            file_handle.read.return_value = 'migration_target=UUID multipath_wwn=WWN'
+            assert self.mount_os.get_target_root() == '/dev/mapper/WWN-part2'
+
     @patch('suse_migration_services.logger.Logger.setup')
     @patch('os.path.ismount')
     def test_is_mounted(self, mock_os_path_ismount, mock_Logger_setup):

--- a/tools/run_migration
+++ b/tools/run_migration
@@ -52,6 +52,16 @@ function get_system_root_device {
     lsblk -p -n -r -o NAME,MOUNTPOINTS | grep -E "/$" | uniq | cut -f1 -d" "
 }
 
+function get_multipath_wwn {
+    if [ -e /sbin/multipath ]; then
+        for wwn in $(/sbin/multipath -l -v1 2>/dev/null); do
+            if [[ "$(get_system_root_device)" == *"${wwn}"* ]]; then
+                echo "${wwn}"
+            fi
+        done
+    fi
+}
+
 function get_boot_options {
     # """
     # Create boot options list for kexec
@@ -61,7 +71,10 @@ function get_boot_options {
     local migration_iso=$1
     local is_sles16_migration=$2
     local migration_rootfs_uuid
+    local migration_rootfs_wwn
     migration_rootfs_uuid=$(findmnt --noheadings --output UUID /)
+    # get multipath wnn if availiable
+    migration_rootfs_wwn="$(get_multipath_wwn)"
     # init boot options needed for live boot
     boot_options="rd.live.image root=live:CDLABEL=CDROM"
     # add live image reference filename for iso-scan module
@@ -71,6 +84,9 @@ function get_boot_options {
     # add auto activation of devices in soft raid mode
     if mdadm --detail "$(get_system_root_device)" &>/dev/null; then
         boot_options="${boot_options} rd.auto"
+    fi
+    if [ -n "${migration_rootfs_wwn}" ]; then
+	boot_options="${boot_options} multipath_wwn=${migration_rootfs_wwn}"
     fi
     for host_boot_option in $(xargs -n1 < /proc/cmdline);do
         case "${host_boot_option}" in

--- a/tools/run_migration
+++ b/tools/run_migration
@@ -53,7 +53,10 @@ function get_system_root_device {
 }
 
 function get_multipath_wwn {
-    if type -p multipath; then
+    # """
+    # Check if root device node is mapped in a multipath setup
+    # """
+    if type -p multipath &>/dev/null; then
         for wwn in $(multipath -l -v1 2>/dev/null); do
             if [[ "$(get_system_root_device)" == *"${wwn}"* ]]; then
                 echo "${wwn}"

--- a/tools/run_migration
+++ b/tools/run_migration
@@ -86,7 +86,7 @@ function get_boot_options {
         boot_options="${boot_options} rd.auto"
     fi
     if [ -n "${migration_rootfs_wwn}" ]; then
-	boot_options="${boot_options} multipath_wwn=${migration_rootfs_wwn}"
+        boot_options="${boot_options} multipath_wwn=${migration_rootfs_wwn}"
     fi
     for host_boot_option in $(xargs -n1 < /proc/cmdline);do
         case "${host_boot_option}" in

--- a/tools/run_migration
+++ b/tools/run_migration
@@ -53,8 +53,8 @@ function get_system_root_device {
 }
 
 function get_multipath_wwn {
-    if [ -e /sbin/multipath ]; then
-        for wwn in $(/sbin/multipath -l -v1 2>/dev/null); do
+    if type -p multipath; then
+        for wwn in $(multipath -l -v1 2>/dev/null); do
             if [[ "$(get_system_root_device)" == *"${wwn}"* ]]; then
                 echo "${wwn}"
             fi

--- a/tools/run_migration
+++ b/tools/run_migration
@@ -49,7 +49,7 @@ function get_system_root_device {
     # """
     # Looking for running system root device
     # """
-    lsblk -p -n -r -o NAME,MOUNTPOINT | grep -E "/$" | uniq | cut -f1 -d" "
+    lsblk -p -n -r -o NAME,MOUNTPOINTS | grep -E "/$" | uniq | cut -f1 -d" "
 }
 
 function get_boot_options {


### PR DESCRIPTION
This PR adds handling multipath systems by determining the multipath wwn of the migration target and passing it as kernel command line parameter:

- In the host system to be maigrated, check if a the multipath wwn is used for the root device.
- Pass the miltipath wnn as multipath_wwn kernel parameter
-  In the migration system pick up the multipath_wwn
- Use the device name containing the multipath wwn instead of the block device with the same uuid