### PR TITLE
Explicitly request python3-base

### DIFF
--- a/image/generic/sle16/config.kiwi
+++ b/image/generic/sle16/config.kiwi
@@ -116,6 +116,7 @@
         <package name="glibc-locale-base"/>
         <package name="cracklib-dict-small"/>
         <package name="ca-certificates"/>
+        <package name="python3-base"/>
         <package name="SLES-release"/>
     </packages>
 </image>

--- a/image/product/sle16/sles_sap/config.kiwi
+++ b/image/product/sle16/sles_sap/config.kiwi
@@ -116,6 +116,7 @@
         <package name="glibc-locale-base"/>
         <package name="cracklib-dict-small"/>
         <package name="ca-certificates"/>
+        <package name="python3-base"/>
         <package name="SLES_SAP-release"/>
     </packages>
 </image>


### PR DESCRIPTION
Due to changes on the SUSE python packaging it's required to request python3-base such that symlinks like /usr/bin/python3 exists