### PR TITLE
Add production/staging profiles for SLE16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ SLES16-Migration: clean check test
 	cp image/generic/sle16/config.kiwi dist/config.kiwi
 	cp image/generic/sle16/config.sh dist/config.sh
 	cp image/generic/sle16/SLES16-Migration.changes dist/SLES16-Migration.changes
+	cp image/generic/sle16/_multibuild dist/_multibuild
 
 SLES16-SAP_Migration: clean check test
 	mkdir -p dist
@@ -118,6 +119,7 @@ SLES16-SAP_Migration: clean check test
 	cp image/product/sle16/sles_sap/config.kiwi dist/config.kiwi
 	cp image/product/sle16/sles_sap/config.sh dist/config.sh
 	cp image/product/sle16/sles_sap/SLES16-SAP_Migration.changes dist/SLES16-SAP_Migration.changes
+	cp image/product/sle16/sles_sap/_multibuild dist/_multibuild
 
 SLES15-Migration: clean check test
 	mkdir -p dist

--- a/container/sle16/config.kiwi
+++ b/container/sle16/config.kiwi
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
 <image schemaversion="7.5" name="Migration">
     <description type="system">
@@ -8,6 +9,10 @@
             DMS system next generation, container based
         </specification>
     </description>
+    <profiles>
+        <profile name="Production" description="Production, released SLE16"/>
+        <profile name="Staging" description="Staging, current SLE16"/>
+    </profiles>
     <preferences>
         <version>2.1.34</version>
         <packagemanager>zypper</packagemanager>
@@ -22,8 +27,17 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md">
-        <source path="obsrepositories:/"/>
+    <repository type="rpm-md" profiles="Production">
+        <source path='obsrepositories:/'/>
+    </repository>
+    <repository type="rpm-md" profiles="Staging">
+        <source path="obs://devel:DMS/SLE_16.1"/>
+    </repository>
+    <repository type="rpm-md" profiles="Staging">
+        <source path="obs://SUSE:SLFO:Products:SLES:16.1/standard"/>
+    </repository>
+    <repository type="rpm-md" profiles="Staging">
+        <source path="obs://SUSE:SLFO:Main/standard"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
@@ -72,6 +86,7 @@
         <package name="glibc-locale-base"/>
         <package name="ca-certificates"/>
         <package name="ca-certificates-mozilla"/>
+        <package name="python3-base"/>
         <package name="shadow"/>
     </packages>
 </image>

--- a/image/generic/sle16/_multibuild
+++ b/image/generic/sle16/_multibuild
@@ -1,0 +1,3 @@
+<multibuild>
+  <flavor>Production</flavor>
+</multibuild>

--- a/image/generic/sle16/config.kiwi
+++ b/image/generic/sle16/config.kiwi
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- OBS-ExclusiveArch: aarch64 ppc64le x86_64 s390x -->
+<!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
 <image schemaversion="7.4" name="SLES16-Migration">
     <description type="system">
@@ -10,6 +11,10 @@
             SLES15-SP7+ instances to SLES16+
         </specification>
     </description>
+    <profiles>
+        <profile name="Production" description="Production, released SLE16"/>
+        <profile name="Staging" description="Staging, current SLE16"/>
+    </profiles>
     <preferences>
         <version>2.1.34</version>
         <packagemanager>zypper</packagemanager>
@@ -38,11 +43,17 @@
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/migration" name="migration" groups="users"/>
     </users>
-    <repository type="rpm-md" >
+    <repository type="rpm-md" profiles="Production">
         <source path='obsrepositories:/'/>
     </repository>
-    <repository type="rpm-md" >
+    <repository type="rpm-md" profiles="Staging">
+        <source path="obs://devel:DMS/SLE_16.1"/>
+    </repository>
+    <repository type="rpm-md" profiles="Staging">
         <source path="obs://SUSE:SLFO:Products:SLES:16.1/standard"/>
+    </repository>
+    <repository type="rpm-md" profiles="Staging">
+        <source path="obs://SUSE:SLFO:Main/standard"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/image/package/suse-migration-rpm.changes
+++ b/image/package/suse-migration-rpm.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jun 16 16:19:40 UTC 2026 - Marcus Schäfer <marcus.schaefer@gmail.com>
+
+- Add handling for Staging builds
+
+  Make sure the profile name does not interfere with the
+  built package name
+
+-------------------------------------------------------------------
 Tue Oct  7 16:04:17 UTC 2025 - Marcus Schäfer <marcus.schaefer@gmail.com>
 
 - Fix MinSLEVersion value depending on target

--- a/image/package/suse-migration-rpm/kiwi_post_run
+++ b/image/package/suse-migration-rpm/kiwi_post_run
@@ -30,7 +30,7 @@ IMAGE=${ISO##*/}
 ARCH="$(uname -m)"
 NAME=$(echo "$IMAGE" | cut -f1 -d.)
 VERSION=$(echo "$IMAGE" | cut -f3 -d-)
-RELEASE=$(echo "$IMAGE" | cut -f4 -d- | sed -e "s@Build@@" | sed -e 's@.iso$@@')
+RELEASE=$(echo "$IMAGE" | sed -e "s@-Staging@@" | sed -e "s@-Production@@" | cut -f4 -d- | sed -e "s@Build@@" | sed -e 's@.iso$@@')
 PRODUCT='product(SLES) >= %{MinSLEVersion}'
 
 # SAP product check

--- a/image/product/sle16/sles_sap/_multibuild
+++ b/image/product/sle16/sles_sap/_multibuild
@@ -1,0 +1,3 @@
+<multibuild>
+  <flavor>Production</flavor>
+</multibuild>

--- a/image/product/sle16/sles_sap/config.kiwi
+++ b/image/product/sle16/sles_sap/config.kiwi
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- OBS-ExclusiveArch: ppc64le x86_64 -->
+<!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
 <image schemaversion="7.4" name="SLES16-SAP_Migration">
     <description type="system">
@@ -10,6 +11,10 @@
             SLES15-SP7+ SAP instances to SLES16+
         </specification>
     </description>
+    <profiles>
+        <profile name="Production" description="Production, released SLE16"/>
+        <profile name="Staging" description="Staging, current SLE16"/>
+    </profiles>
     <preferences>
         <version>2.1.34</version>
         <packagemanager>zypper</packagemanager>
@@ -38,11 +43,17 @@
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/migration" name="migration" groups="users"/>
     </users>
-    <repository type="rpm-md" >
+    <repository type="rpm-md" profiles="Production">
         <source path='obsrepositories:/'/>
     </repository>
-    <repository type="rpm-md" >
+    <repository type="rpm-md" profiles="Staging">
+        <source path="obs://devel:DMS/SLE_16.1"/>
+    </repository>
+    <repository type="rpm-md" profiles="Staging">
         <source path="obs://SUSE:SLFO:Products:SLES:16.1/standard"/>
+    </repository>
+    <repository type="rpm-md" profiles="Staging">
+        <source path="obs://SUSE:SLFO:Main/standard"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>


### PR DESCRIPTION
In contrast to SLE15, SLE16 is still actively developed and not in maintenance mode. Therefore the rolling build for devel:DMS should use the latest version of SLE16 but should also allow for maintenance releases into production. For production the repository setup should come from the project as it is setup in the SUSE namespace. For the staging project we set the repositories as they fit the current development. This is SLE16.1 at the moment.