### PR TITLE
Add use_cd_repos option for migration from offline media

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,25 @@ Upgrade Modes:
   .. code:: bash
 
       use_zypper_migration: false
-  
+
+Migration From an Installation Medium:
+  Every CD/DVD repository of the system to migrate is ignored by default,
+  which keeps the stale **cd:** repositories left behind by the original
+  installation out of the upgrade. Switching **use_cd_repos** on lets them
+  take part, which is what allows an installation medium such as a SLE Full
+  media to serve as the package source. Such a medium is not registered
+  against a repository server, so **dup** mode is required as well:
+
+  .. code:: bash
+
+      use_zypper_migration: false
+      use_cd_repos: true
+
+  The medium has to be added as a repository on the system to migrate before
+  the migration is started, and any other CD/DVD repository that is still
+  configured should be removed or disabled, as it takes part in the upgrade
+  as well.
+
 Migration Startup:
   There are three ways to perform the migration
 

--- a/doc/adoc/user_guide.adoc
+++ b/doc/adoc/user_guide.adoc
@@ -282,6 +282,26 @@ we use for the zypper migration/dup workflow and for eventual
 package installation after the migration. The default zypper options are
 not changed by this setting.
 
+Migrate From an Installation Medium::
+By default the upgrade process ignores every CD/DVD repository of the
+system to be migrated. Letting them take part is what allows an
+installation medium, such as a SLE Full media, to be used as the package
+source:
++
+[listing]
+----
+use_zypper_migration: false
+use_cd_repos: true
+----
++
+[NOTE]
+Since an installation medium is not registered against a repository
+server, `use_zypper_migration` has to be switched off as well. The medium
+must be added as a repository on the system to be migrated before the
+migration is started. Every other CD/DVD repository that is still
+configured takes part in the upgrade as well, so remove or disable the
+ones left over from the original installation.
+
 Specify Migration Product::
 The default migration target is dependent on the origin version and the
 product. This default target can be changed via the `migration_product`

--- a/suse_migration_services/drop_components.py
+++ b/suse_migration_services/drop_components.py
@@ -91,10 +91,8 @@ class DropComponents:
     def _uninstall_packages(self):
         if self.drop_packages and self.root_path:
             zypper_call = Zypper.run(
-                [
-                    '--no-cd',
-                    '--non-interactive',
-                    '--gpg-auto-import-keys',
+                Zypper.global_args()
+                + [
                     '--root',
                     self.root_path,
                     'remove',

--- a/suse_migration_services/migration_config.py
+++ b/suse_migration_services/migration_config.py
@@ -179,6 +179,17 @@ class MigrationConfig:
     def is_zypper_migration_plugin_requested(self):
         return self.config_data.get('use_zypper_migration', True)
 
+    def are_cd_repos_requested(self):
+        """
+        Return whether CD/DVD repositories may take part in the migration
+
+        By default they are ignored, which keeps the stale cd: repositories
+        left behind by the original installation out of the upgrade.
+        Switching this on is what allows an installation medium to serve
+        as the package source.
+        """
+        return self.config_data.get('use_cd_repos', False)
+
     def is_soft_reboot_requested(self):
         return self.config_data.get('soft_reboot', False)
 

--- a/suse_migration_services/schema.py
+++ b/suse_migration_services/schema.py
@@ -12,6 +12,7 @@ schema = {
     },
     'soft_reboot': {'required': False, 'type': 'boolean'},
     'use_zypper_migration': {'required': False, 'type': 'boolean'},
+    'use_cd_repos': {'required': False, 'type': 'boolean'},
     'verbose_migration': {'required': False, 'type': 'boolean'},
     'build_host_independent_initrd': {'required': False, 'type': 'boolean'},
     'pre_checks_fix': {'required': False, 'type': 'boolean'},

--- a/suse_migration_services/units/migrate.py
+++ b/suse_migration_services/units/migrate.py
@@ -96,10 +96,8 @@ class MigrateSystem:
                     )
             else:
                 zypper_call = Zypper.run(
-                    [
-                        '--no-cd',
-                        '--non-interactive',
-                        '--gpg-auto-import-keys',
+                    Zypper.global_args()
+                    + [
                         '--root',
                         self.root_path,
                         'dup',

--- a/suse_migration_services/zypper.py
+++ b/suse_migration_services/zypper.py
@@ -69,12 +69,19 @@ class Zypper:
         return ZypperCall(args, command_string, result)
 
     @staticmethod
-    def install(*pkgs: str, raise_on_error=True, system_root=None, chroot='', extra_args=[]):
-        zypper_args = [
+    def global_args():
+        """
+        Global zypper options shared by all migration zypper calls
+        """
+        return [
             '--no-cd',
             '--non-interactive',
             '--gpg-auto-import-keys',
         ]
+
+    @staticmethod
+    def install(*pkgs: str, raise_on_error=True, system_root=None, chroot='', extra_args=[]):
+        zypper_args = Zypper.global_args()
         if system_root:
             zypper_args += ['--root', system_root]
         zypper_args += (

--- a/suse_migration_services/zypper.py
+++ b/suse_migration_services/zypper.py
@@ -21,6 +21,7 @@ import os
 # project
 from suse_migration_services.command import Command
 from suse_migration_services.defaults import Defaults
+from suse_migration_services.migration_config import MigrationConfig
 from suse_migration_services.exceptions import DistMigrationZypperException
 
 
@@ -72,12 +73,22 @@ class Zypper:
     def global_args():
         """
         Global zypper options shared by all migration zypper calls
+
+        The options that depend on the migration configuration are
+        resolved here rather than by the caller. Every unit runs as its
+        own process against the same configuration file, so a caller
+        could only repeat that lookup, and settings affecting all
+        zypper calls stay in one place as they get added.
         """
-        return [
-            '--no-cd',
+        migration_config = MigrationConfig()
+        zypper_args = []
+        if not migration_config.are_cd_repos_requested():
+            zypper_args.append('--no-cd')
+        zypper_args += [
             '--non-interactive',
             '--gpg-auto-import-keys',
         ]
+        return zypper_args
 
     @staticmethod
     def install(*pkgs: str, raise_on_error=True, system_root=None, chroot='', extra_args=[]):

--- a/test/unit/drop_components_test.py
+++ b/test/unit/drop_components_test.py
@@ -43,9 +43,11 @@ class TestDropComponents:
             file_handle.write.assert_called_once_with('some/\n')
         assert self.drop.drop_files_and_directories == ['/system-root/some']
 
+    @patch('suse_migration_services.zypper.MigrationConfig')
     @patch('suse_migration_services.drop_components.Zypper.run')
     @patch('suse_migration_services.drop_components.Command.run')
-    def test_drop_perform_package(self, mock_Command_run, mock_Zypper_run):
+    def test_drop_perform_package(self, mock_Command_run, mock_Zypper_run, mock_MigrationConfig):
+        mock_MigrationConfig.return_value.are_cd_repos_requested.return_value = False
         package_call = Mock()
         package_call.returncode = 0
         mock_Command_run.return_value = package_call
@@ -63,6 +65,31 @@ class TestDropComponents:
                 '--clean-deps',
                 'some',
                 'some_other',
+            ],
+            raise_on_error=False,
+        )
+
+    @patch('suse_migration_services.zypper.MigrationConfig')
+    @patch('suse_migration_services.drop_components.Zypper.run')
+    @patch('suse_migration_services.drop_components.Command.run')
+    def test_drop_perform_package_with_cd_repos(
+        self, mock_Command_run, mock_Zypper_run, mock_MigrationConfig
+    ):
+        mock_MigrationConfig.return_value.are_cd_repos_requested.return_value = True
+        package_call = Mock()
+        package_call.returncode = 0
+        mock_Command_run.return_value = package_call
+        self.drop.drop_package('some')
+        self.drop.drop_perform()
+        mock_Zypper_run.assert_called_once_with(
+            [
+                '--non-interactive',
+                '--gpg-auto-import-keys',
+                '--root',
+                '/system-root',
+                'remove',
+                '--clean-deps',
+                'some',
             ],
             raise_on_error=False,
         )

--- a/test/unit/migration_config_test.py
+++ b/test/unit/migration_config_test.py
@@ -144,6 +144,11 @@ class TestMigrationConfig(object):
     def test_is_zypper_migration_plugin_requested(self):
         assert self.config.is_zypper_migration_plugin_requested() is True
 
+    def test_are_cd_repos_requested(self):
+        assert self.config.are_cd_repos_requested() is False
+        self.config.config_data['use_cd_repos'] = True
+        assert self.config.are_cd_repos_requested() is True
+
     def test_is_debug_requested(self):
         assert self.config.is_debug_requested() is False
 

--- a/test/unit/units/migrate_test.py
+++ b/test/unit/units/migrate_test.py
@@ -324,8 +324,10 @@ class TestMigration(object):
     @patch('suse_migration_services.defaults.Defaults.log_env')
     @patch('suse_migration_services.defaults.Defaults.update_env')
     @patch('suse_migration_services.units.migrate.MigrationConfig')
+    @patch('suse_migration_services.zypper.MigrationConfig')
     def test_main_zypper_dup(
         self,
+        mock_zypper_MigrationConfig,
         mock_MigrationConfig,
         mock_update_env,
         mock_log_env,
@@ -333,6 +335,7 @@ class TestMigration(object):
         mock_logger_setup,
         mock_is_single_rpmtrans_requested,
     ):
+        mock_zypper_MigrationConfig.return_value.are_cd_repos_requested.return_value = False
         mock_MigrationConfig.return_value = self.migration_config_dup
         zypper_call = Mock()
         mock_Zypper_run.return_value = zypper_call
@@ -364,12 +367,56 @@ class TestMigration(object):
     @patch('suse_migration_services.defaults.Defaults.log_env')
     @patch('suse_migration_services.defaults.Defaults.update_env')
     @patch('suse_migration_services.units.migrate.MigrationConfig')
+    @patch('suse_migration_services.zypper.MigrationConfig')
+    def test_main_zypper_dup_with_cd_repos(
+        self,
+        mock_zypper_MigrationConfig,
+        mock_MigrationConfig,
+        mock_update_env,
+        mock_log_env,
+        mock_Zypper_run,
+        mock_logger_setup,
+        mock_is_single_rpmtrans_requested,
+    ):
+        mock_zypper_MigrationConfig.return_value.are_cd_repos_requested.return_value = True
+        mock_MigrationConfig.return_value = self.migration_config_dup
+        zypper_call = Mock()
+        mock_Zypper_run.return_value = zypper_call
+        mock_is_single_rpmtrans_requested.return_value = '0'
+        with patch('builtins.open', create=True):
+            main()
+        mock_Zypper_run.assert_called_once_with(
+            [
+                '--non-interactive',
+                '--gpg-auto-import-keys',
+                '--root',
+                '/system-root',
+                'dup',
+                '--auto-agree-with-licenses',
+                '--allow-vendor-change',
+                '--download',
+                'in-advance',
+                '--replacefiles',
+                '--allow-downgrade',
+            ],
+            raise_on_error=False,
+        )
+        zypper_call.raise_if_failed.assert_called_once()
+
+    @patch('suse_migration_services.units.migrate.MigrateSystem.is_single_rpmtrans_requested')
+    @patch('suse_migration_services.logger.Logger.setup')
+    @patch('suse_migration_services.zypper.Zypper.run')
+    @patch('suse_migration_services.defaults.Defaults.log_env')
+    @patch('suse_migration_services.defaults.Defaults.update_env')
+    @patch('suse_migration_services.units.migrate.MigrationConfig')
+    @patch('suse_migration_services.zypper.MigrationConfig')
     @patch('os.path.isdir')
     @patch('suse_migration_services.units.migrate.Command.run')
     def test_main_zypper_dup_with_solver_test_case(
         self,
         mock_Command_run,
         mock_os_path_isdir,
+        mock_zypper_MigrationConfig,
         mock_MigrationConfig,
         mock_update_env,
         mock_log_env,

--- a/test/unit/zypper_test.py
+++ b/test/unit/zypper_test.py
@@ -9,8 +9,10 @@ from suse_migration_services.exceptions import DistMigrationZypperException
 
 @patch('suse_migration_services.command.Command.run')
 class TestCommand(object):
+    @patch('suse_migration_services.zypper.MigrationConfig')
     @patch('suse_migration_services.zypper.Zypper.run')
-    def test_zypper_install(self, mock_Zypper_run, mock_Command_run):
+    def test_zypper_install(self, mock_Zypper_run, mock_MigrationConfig, mock_Command_run):
+        mock_MigrationConfig.return_value.are_cd_repos_requested.return_value = False
         Zypper.install(
             'package_a',
             'package_b',
@@ -39,12 +41,42 @@ class TestCommand(object):
             chroot='root',
         )
 
+    @patch('suse_migration_services.zypper.MigrationConfig')
     @patch('suse_migration_services.zypper.Zypper.run')
-    def test_zypper_install_system_root(self, mock_Zypper_run, mock_Command_run):
+    def test_zypper_install_system_root(
+        self, mock_Zypper_run, mock_MigrationConfig, mock_Command_run
+    ):
+        mock_MigrationConfig.return_value.are_cd_repos_requested.return_value = False
         Zypper.install('package', system_root='/root')
         mock_Zypper_run.assert_called_once_with(
             [
                 '--no-cd',
+                '--non-interactive',
+                '--gpg-auto-import-keys',
+                '--root',
+                '/root',
+                'install',
+                '--auto-agree-with-licenses',
+                '--allow-vendor-change',
+                '--download',
+                'in-advance',
+                '--replacefiles',
+                '--allow-downgrade',
+                'package',
+            ],
+            raise_on_error=True,
+            chroot='',
+        )
+
+    @patch('suse_migration_services.zypper.MigrationConfig')
+    @patch('suse_migration_services.zypper.Zypper.run')
+    def test_zypper_install_use_cd_repos(
+        self, mock_Zypper_run, mock_MigrationConfig, mock_Command_run
+    ):
+        mock_MigrationConfig.return_value.are_cd_repos_requested.return_value = True
+        Zypper.install('package', system_root='/root')
+        mock_Zypper_run.assert_called_once_with(
+            [
                 '--non-interactive',
                 '--gpg-auto-import-keys',
                 '--root',


### PR DESCRIPTION
**DRAFT: Still reviewing AI changes, don't merge yet**

Migration from offline media requires us to setup a cd based repository; this currently does not work due to the `--no-cd` option we pass to zypper. This PR adds a configuration flag to allow turning off this option, so migration from offline media can be possible.