### PR TITLE
Allow the migration packages to install on Leap 16

### DIFF
--- a/image/package/suse-migration-rpm.changes
+++ b/image/package/suse-migration-rpm.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Aug 14 17:34:04 UTC 2026 - Christian Hueller <chuller@suse.com>
+
+- Allow the migration packages to install on Leap 16
+
+  The SLES16-Migration package requires product(SLES), which causes
+  an installation on Leap to fail. This extends the product
+  requirement to Leap products.
+
+-------------------------------------------------------------------
 Tue Jun 16 16:19:40 UTC 2026 - Marcus Schäfer <marcus.schaefer@gmail.com>
 
 - Add handling for Staging builds

--- a/image/package/suse-migration-rpm/kiwi_post_run
+++ b/image/package/suse-migration-rpm/kiwi_post_run
@@ -31,7 +31,14 @@ ARCH="$(uname -m)"
 NAME=$(echo "$IMAGE" | cut -f1 -d.)
 VERSION=$(echo "$IMAGE" | cut -f3 -d-)
 RELEASE=$(echo "$IMAGE" | sed -e "s@-Staging@@" | sed -e "s@-Production@@" | cut -f4 -d- | sed -e "s@Build@@" | sed -e 's@.iso$@@')
-PRODUCT='product(SLES) >= %{MinSLEVersion}'
+case "$NAME" in
+    SLES16*)
+        PRODUCT='(product(SLES) >= %{MinSLEVersion} or product(Leap) >= 16.0)'
+        ;;
+    *)
+        PRODUCT='product(SLES) >= %{MinSLEVersion}'
+        ;;
+esac
 
 # SAP product check
 if echo "$NAME" | grep -q SAP_; then


### PR DESCRIPTION
The SLES16-Migration package requires product(SLES), which causes an installation on Leap to fail. This extends the product requirement to Leap products.